### PR TITLE
Revert Introduce context manager for temporary templar context changes

### DIFF
--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -184,7 +184,7 @@ class ActionModule(_ActionModule):
                         searchpath.append(role._role_path)
         searchpath.append(os.path.dirname(source))
         self._templar.environment.loader.searchpath = searchpath
-        self._task.args['src'] = self._templar.template(template_data)
+        self._task.args["src"] = self._templar.template(template_data)
 
     def _get_network_os(self, task_vars):
         if "network_os" in self._task.args and self._task.args["network_os"]:

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -183,10 +183,8 @@ class ActionModule(_ActionModule):
                     for role in dep_chain:
                         searchpath.append(role._role_path)
         searchpath.append(os.path.dirname(source))
-        with self._templar.set_temporary_context(searchpath=searchpath):
-            self._task.args["src"] = self._templar.template(
-                template_data, convert_data=convert_data
-            )
+        self._templar.environment.loader.searchpath = searchpath
+        self._task.args['src'] = self._templar.template(template_data)
 
     def _get_network_os(self, task_vars):
         if "network_os" in self._task.args and self._task.args["network_os"]:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR https://github.com/ansible/ansible/pull/60513 is applicable for 2.10 and was introduced as precautionary
to prevent issues with future use of `Templar` and since the feature
won't be backported to stable-2.9 reverting the changes
in network.py action, the plugin to ensure backward compatibility
for 2.9.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/action/network.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
