### PR TITLE
dict_merge() should not modify base dict

### DIFF
--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -34,6 +34,7 @@ import operator
 import socket
 import json
 
+from copy import deepcopy
 from itertools import chain
 
 from ansible.module_utils._text import to_text, to_bytes
@@ -341,7 +342,7 @@ def dict_merge(base, other):
 
     combined = dict()
 
-    for key, value in iteritems(base):
+    for key, value in iteritems(deepcopy(base)):
         if isinstance(value, dict):
             if key in other:
                 item = other.get(key)

--- a/tests/unit/module_utils/network/common/test_utils.py
+++ b/tests/unit/module_utils/network/common/test_utils.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import pytest
+from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     to_list,
@@ -188,6 +189,28 @@ def test_dict_merge():
     assert "b2" in result
     assert result["b3"]
     assert result["b4"]
+
+
+def test_dict_merge_src_unchanged():
+    base = {
+        "flist": [
+            {"dir": "out", "rmap": "rmap_1"},
+            {"dir": "in", "rmap": "rmap_2"},
+        ]
+    }
+    basecp = deepcopy(base)
+    other = {
+        "flist": [
+            {"dir": "out", "rmap": "rmap_12"},
+            {"dir": "in", "rmap": "rmap_2"},
+        ]
+    }
+    othercp = deepcopy(other)
+
+    dict_merge(base, other)
+    # dict_merge() should not modify the source dicts
+    assert base == basecp
+    assert other == othercp
 
 
 def test_conditional():


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
 - Looks like dict_merge() was actually modifying the `base` dict that contains values which are unhashable in nature.
- Here's a quick example - https://gist.github.com/NilashishC/b43eaaba6f032af4afab7d6a272ed3c4
- The logic to handle unhashables now does a deepcopy() of the list and then works on the copied list.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
plugins/module_utils/network/common/utils.py 

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/435