### PR TITLE
Support reserved IPv4 translate to 6to4

### DIFF
--- a/plugins/filter/ipaddr.py
+++ b/plugins/filter/ipaddr.py
@@ -71,7 +71,7 @@ def _6to4_query(v, vtype, value):
             else:
                 ipconv = False
 
-        if ipaddr(ipconv, "public"):
+        if ipaddr(ipconv, "public") or ipaddr(ipconv, "private"):
             numbers = list(map(int, ipconv.split(".")))
 
         try:


### PR DESCRIPTION
##### SUMMARY

Both the private and the public IPv4 addresses should be converted to 6to4 address. But currently we can only convert the public IPv4 address. 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

filter plugin:  `ipaddr`

##### ADDITIONAL INFORMATION

https://github.com/ansible/ansible/issues/68810#issue-597175929
