### PR TITLE
Add support to generate argspec from DOCUMENTATION string

### DIFF
--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -737,7 +737,7 @@ def convert_doc_to_ansible_module_kwargs(doc):
     argspec = {}
     spec = {}
     extract_argspec(doc_obj, argspec)
-    spec.update({"argument_spec": doc_obj})
+    spec.update({"argument_spec": argspec})
     for item in doc_obj:
         if item in VALID_ANSIBLEMODULE_ARGS:
             spec.update({item: doc_obj[item]})

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -86,6 +86,10 @@ OPTION_METADATA = (
     "elements",
     "fallback",
     "no_log",
+    "apply_defaults",
+    "deprecated_aliases",
+    "removed_in_version",
+
 )
 OPTION_CONDITIONALS = (
     "mutually_exclusive",

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -89,7 +89,6 @@ OPTION_METADATA = (
     "apply_defaults",
     "deprecated_aliases",
     "removed_in_version",
-
 )
 OPTION_CONDITIONALS = (
     "mutually_exclusive",


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Add support to genereate the argument_spec dictionary
   at module runtime by reading the DOCUMENTATION string
* TODO item is to support extends_documentation_fragment
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
/module_utils/network/common/utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
