### PR TITLE
To fix empty config issue where states with empty config should error out

### DIFF
--- a/plugins/module_utils/network/common/resource_module.py
+++ b/plugins/module_utils/network/common/resource_module.py
@@ -40,6 +40,7 @@ class ResourceModule(object):  # pylint: disable=R0902
         self.changed = False
         self.commands = []
         self.warnings = []
+
         self.have = deepcopy(self.before)
         self.want = remove_empties(self._module.params).get(
             "config", self._empty_fact_val

--- a/plugins/module_utils/network/common/resource_module.py
+++ b/plugins/module_utils/network/common/resource_module.py
@@ -27,8 +27,8 @@ class ResourceModule(object):  # pylint: disable=R0902
         self.state = self._module.params["state"]
         # Error out if empty config is passed for following states
         if (
-                self.state in ("overridden", "merged", "replaced", "rendered")
-                and not self.want
+            self.state in ("overridden", "merged", "replaced", "rendered")
+            and not self.want
         ):
             self._module.fail_json(
                 msg="value of config parameter must not be empty for state {0}".format(

--- a/plugins/module_utils/network/common/resource_module.py
+++ b/plugins/module_utils/network/common/resource_module.py
@@ -34,6 +34,16 @@ class ResourceModule(object):  # pylint: disable=R0902
         self.want = remove_empties(self._module.params).get(
             "config", self._empty_fact_val
         )
+        # Error out if empty config is passed for following states
+        if (
+            self.state in ("overridden", "merged", "replaced", "rendered")
+            and not self.want
+        ):
+            self._module.fail_json(
+                msg="value of config parameter must not be empty for state {0}".format(
+                    self.state
+                )
+            )
 
         self._get_connection()
 

--- a/plugins/module_utils/network/common/resource_module.py
+++ b/plugins/module_utils/network/common/resource_module.py
@@ -25,25 +25,25 @@ class ResourceModule(object):  # pylint: disable=R0902
 
         self._connection = None
         self.state = self._module.params["state"]
-        self.before = self.gather_current()
-        self.changed = False
-        self.commands = []
-        self.warnings = []
-
-        self.have = deepcopy(self.before)
-        self.want = remove_empties(self._module.params).get(
-            "config", self._empty_fact_val
-        )
         # Error out if empty config is passed for following states
         if (
-            self.state in ("overridden", "merged", "replaced", "rendered")
-            and not self.want
+                self.state in ("overridden", "merged", "replaced", "rendered")
+                and not self.want
         ):
             self._module.fail_json(
                 msg="value of config parameter must not be empty for state {0}".format(
                     self.state
                 )
             )
+
+        self.before = self.gather_current()
+        self.changed = False
+        self.commands = []
+        self.warnings = []
+        self.have = deepcopy(self.before)
+        self.want = remove_empties(self._module.params).get(
+            "config", self._empty_fact_val
+        )
 
         self._get_connection()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix empty config issue where states with empty config should error out, changes updated in newer rm prototype resource_module base class.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
resource_module.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
