### PR TITLE
Add support for libssh connection type

### DIFF
--- a/changelogs/fragments/30-add-libssh-connection-support.yaml
+++ b/changelogs/fragments/30-add-libssh-connection-support.yaml
@@ -1,0 +1,3 @@
+---
+major_changes:
+  - Add libssh connection plugin and refactor network_cli (https://github.com/ansible-collections/ansible.netcommon/pull/30)

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -1,0 +1,501 @@
+# (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+    author: Ansible Team
+    connection: libssh
+    short_description: Run tasks via libssh (python extension)
+    description:
+        - Use the pylibssh python bindings to connect to targets
+        - The python bindings use libssh C library (https://www.libssh.org/) to connect to targets
+        - This plugin borrows a lot of settings from the ssh plugin as they both cover the same protocol.
+    version_added: "2.10"
+    options:
+      remote_addr:
+        description:
+            - Address of the remote target
+        default: inventory_hostname
+        vars:
+            - name: ansible_host
+            - name: ansible_ssh_host
+            - name: ansible_libssh_host
+      remote_user:
+        description:
+            - User to login/authenticate as
+            - Can be set from the CLI via the C(--user) or C(-u) options.
+        vars:
+            - name: ansible_user
+            - name: ansible_ssh_user
+            - name: ansible_libssh_user
+        env:
+            - name: ANSIBLE_REMOTE_USER
+            - name: ANSIBLE_LIBSSH_REMOTE_USER
+        ini:
+            - section: defaults
+              key: remote_user
+            - section: libssh_connection
+              key: remote_user
+      password:
+        description:
+          - Secret used to either login the ssh server or as a passphrase for ssh keys that require it
+          - Can be set from the CLI via the C(--ask-pass) option.
+        vars:
+            - name: ansible_password
+            - name: ansible_ssh_pass
+            - name: ansible_ssh_password
+            - name: ansible_libssh_pass
+            - name: ansible_libssh_password
+      host_key_auto_add:
+        description: 'TODO: write it'
+        env: [{name: ANSIBLE_LIBSSH_HOST_KEY_AUTO_ADD}]
+        ini:
+          - {key: host_key_auto_add, section: libssh_connection}
+        type: boolean
+      look_for_keys:
+        default: True
+        description: 'TODO: write it'
+        env: [{name: ANSIBLE_LIBSSH_LOOK_FOR_KEYS}]
+        ini:
+        - {key: look_for_keys, section: libssh_connection}
+        type: boolean
+      proxy_command:
+        default: ''
+        description:
+            - Proxy information for running the connection via a jumphost
+            - Also this plugin will scan 'ssh_args', 'ssh_extra_args' and 'ssh_common_args' from the 'ssh' plugin settings for proxy information if set.
+        env: [{name: ANSIBLE_LIBSSH_PROXY_COMMAND}]
+        ini:
+          - {key: proxy_command, section: libssh_connection}
+      pty:
+        default: True
+        description: 'TODO: write it'
+        env:
+          - name: ANSIBLE_LIBSSH_PTY
+        ini:
+          - section: libssh_connection
+            key: pty
+        type: boolean
+      host_key_checking:
+        description: 'Set this to "False" if you want to avoid host key checking by the underlying tools Ansible uses to connect to the host'
+        type: boolean
+        default: True
+        env:
+          - name: ANSIBLE_HOST_KEY_CHECKING
+          - name: ANSIBLE_SSH_HOST_KEY_CHECKING
+          - name: ANSIBLE_LIBSSH_HOST_KEY_CHECKING
+        ini:
+          - section: defaults
+            key: host_key_checking
+          - section: libssh_connection
+            key: host_key_checking
+        vars:
+          - name: ansible_host_key_checking
+          - name: ansible_ssh_host_key_checking
+          - name: ansible_libssh_host_key_checking
+      use_persistent_connections:
+        description: 'Toggles the use of persistence for connections'
+        type: boolean
+        default: False
+        env:
+          - name: ANSIBLE_USE_PERSISTENT_CONNECTIONS
+        ini:
+          - section: defaults
+            key: use_persistent_connections
+# TODO:
+#timeout=self._play_context.timeout,
+"""
+import os
+import socket
+import re
+import sys
+
+from termios import tcflush, TCIFLUSH
+
+from ansible.errors import (
+    AnsibleConnectionFailure,
+    AnsibleError,
+    AnsibleFileNotFound,
+)
+from ansible.module_utils.six.moves import input
+from ansible.plugins.connection import ConnectionBase
+from ansible.utils.display import Display
+from ansible.module_utils._text import to_bytes, to_native, to_text
+import logging
+
+display = Display()
+
+try:
+    from pylibsshext.session import Session
+    from pylibsshext.channel import Channel
+    from pylibsshext.errors import LibsshSessionException
+
+    HAS_PYLIBSSH = True
+except ImportError:
+    HAS_PYLIBSSH = False
+
+
+AUTHENTICITY_MSG = """
+libssh: The authenticity of host '%s' can't be established due to '%s'.
+The %s key fingerprint is %s.
+Are you sure you want to continue connecting (yes/no)?
+"""
+
+# SSH Options Regex
+SETTINGS_REGEX = re.compile(r'(\w+)(?:\s*=\s*|\s+)(.+)')
+
+
+class MyAddPolicy(object):
+    """
+    Based on AutoAddPolicy in paramiko so we can determine when keys are added
+
+    and also prompt for input.
+
+    Policy for automatically adding the hostname and new host key to the
+    local L{HostKeys} object, and saving it.  This is used by L{SSHClient}.
+    """
+
+    def __init__(self, new_stdin, connection):
+        self._new_stdin = new_stdin
+        self.connection = connection
+        self._options = connection._options
+
+    def missing_host_key(self, session, hostname, username, key_type, fingerprint, message):
+
+        if all((self._options['host_key_checking'], not self._options['host_key_auto_add'])):
+
+            if self.connection.get_option('use_persistent_connections') or self.connection.force_persistence:
+                # don't print the prompt string since the user cannot respond
+                # to the question anyway
+                raise AnsibleError(AUTHENTICITY_MSG[1:92] % (hostname, key_type, fingerprint))
+
+            self.connection.connection_lock()
+            old_stdin = sys.stdin
+            sys.stdin = self._new_stdin
+
+            # clear out any premature input on sys.stdin
+            tcflush(sys.stdin, TCIFLUSH)
+
+            inp = input(AUTHENTICITY_MSG % (hostname, message, key_type, fingerprint))
+            sys.stdin = old_stdin
+
+            self.connection.connection_unlock()
+            if inp not in ['yes', 'y', '']:
+                raise AnsibleError("host connection rejected by user")
+
+        session.hostkey_auto_add(username)
+
+        # host keys are actually saved in close() function below
+        # in order to control ordering.
+
+# keep connection objects on a per host basis to avoid repeated attempts to reconnect
+SSH_CONNECTION_CACHE = {}
+SFTP_CONNECTION_CACHE = {}
+
+
+class Connection(ConnectionBase):
+    """ SSH based connections with Paramiko """
+
+    transport = "ansible.netcommon.libssh"
+    _log_channel = None
+
+    def _cache_key(self):
+        return "%s__%s__" % (
+            self._play_context.remote_addr,
+            self._play_context.remote_user,
+        )
+
+    def _connect(self):
+        cache_key = self._cache_key()
+        if cache_key in SSH_CONNECTION_CACHE:
+            self.ssh = SSH_CONNECTION_CACHE[cache_key]
+        else:
+            self.ssh = SSH_CONNECTION_CACHE[
+                cache_key
+            ] = self._connect_uncached()
+        return self
+
+    def _set_log_channel(self, name):
+        self._log_channel = name
+
+    def _get_proxy_command(self, port=22):
+        proxy_command = None
+        # Parse ansible_ssh_common_args, specifically looking for ProxyCommand
+        ssh_args = [
+            getattr(self._play_context, "ssh_extra_args", "") or "",
+            getattr(self._play_context, "ssh_common_args", "") or "",
+            getattr(self._play_context, "ssh_args", "") or "",
+        ]
+
+        if ssh_args is not None:
+            args = self._split_ssh_args(" ".join(ssh_args))
+            for i, arg in enumerate(args):
+                if arg.lower() == "proxycommand":
+                    # _split_ssh_args split ProxyCommand from the command itself
+                    proxy_command = args[i + 1]
+                else:
+                    # ProxyCommand and the command itself are a single string
+                    match = SETTINGS_REGEX.match(arg)
+                    if match:
+                        if match.group(1).lower() == "proxycommand":
+                            proxy_command = match.group(2)
+
+                if proxy_command:
+                    break
+
+        proxy_command = proxy_command or self.get_option("proxy_command")
+
+        if proxy_command:
+            replacers = {
+                "%h": self._play_context.remote_addr,
+                "%p": port,
+                "%r": self._play_context.remote_user,
+            }
+            for find, replace in replacers.items():
+                proxy_command = proxy_command.replace(find, str(replace))
+
+        return proxy_command
+
+    def _connect_uncached(self):
+        """ activates the connection object """
+
+        if not HAS_PYLIBSSH:
+            raise AnsibleError("ansible-pylibssh is not installed")
+
+        ssh_connect_kwargs = {}
+
+        port = self._play_context.port or 22
+        display.vvv(
+            "ESTABLISH LIBSSH CONNECTION FOR USER: %s on PORT %s TO %s"
+            % (
+                self._play_context.remote_user,
+                port,
+                self._play_context.remote_addr,
+            ),
+            host=self._play_context.remote_addr,
+        )
+
+        self.ssh = Session()
+
+        if self._play_context.verbosity > 3:
+            self.ssh.set_log_level(logging.INFO)
+
+        self.keyfile = os.path.expanduser("~/.ssh/known_hosts")
+
+        proxy_command = self._get_proxy_command(port)
+
+        try:
+            if proxy_command:
+                ssh_connect_kwargs["proxycommand"] = proxy_command
+
+            self.ssh.set_missing_host_key_policy(MyAddPolicy(self._new_stdin, self))
+
+            self.ssh.connect(
+                host=self._play_context.remote_addr.lower(),
+                user=self._play_context.remote_user,
+                look_for_keys=self.get_option("look_for_keys"),
+                host_key_checking=self.get_option("host_key_checking"),
+                password=self._play_context.password,
+                timeout=self._play_context.timeout,
+                port=port,
+                **ssh_connect_kwargs
+            )
+        except LibsshSessionException as e:
+            msg = "ssh connection failed: " + to_text(e)
+            raise AnsibleConnectionFailure(msg)
+        except Exception as e:
+            raise AnsibleConnectionFailure(to_text(e))
+
+        display.vvv("ssh connection is OK: " + str(self.ssh))
+        return self.ssh
+
+    def exec_command(self, cmd, in_data=None, sudoable=True):
+        """ run a command on the remote host """
+
+        super(Connection, self).exec_command(
+            cmd, in_data=in_data, sudoable=sudoable
+        )
+
+        if in_data:
+            raise AnsibleError(
+                "Internal Error: this module does not support optimized module pipelining"
+            )
+
+        bufsize = 4096
+
+        try:
+            chan = self.ssh.new_channel()
+        except Exception as e:
+            text_e = to_text(e)
+            msg = u"Failed to open session"
+            if text_e:
+                msg += u": %s" % text_e
+            raise AnsibleConnectionFailure(to_native(msg))
+
+        # sudo usually requires a PTY (cf. requiretty option), therefore
+        # we give it one by default (pty=True in ansible.cfg), and we try
+        # to initialise from the calling environment when sudoable is enabled
+        if self.get_option("pty") and sudoable:
+            chan.request_shell()
+
+        display.vvv("EXEC %s" % cmd, host=self._play_context.remote_addr)
+
+        cmd = to_bytes(cmd, errors="surrogate_or_strict")
+
+        result = None
+        no_prompt_out = b""
+        no_prompt_err = b""
+        become_output = b""
+        out = b""
+        err = b""
+
+        try:
+            if self.become and self.become.expect_prompt():
+                passprompt = False
+                become_sucess = False
+                chan.sendall(cmd)
+
+                while not (become_sucess or passprompt):
+                    display.debug("Waiting for Privilege Escalation input")
+                    chan.poll(timeout=self._play_context.timeout)
+                    chunk = chan.recv(bufsize)
+                    display.debug("chunk is: %s" % chunk)
+
+                    if not chunk:
+                        if b"unknown user" in become_output:
+                            n_become_user = to_native(
+                                self.become.get_option(
+                                    "become_user",
+                                    playcontext=self._play_context,
+                                )
+                            )
+                            raise AnsibleError(
+                                "user %s does not exist" % n_become_user
+                            )
+                        else:
+                            break
+                            # raise AnsibleError('ssh connection closed waiting for password prompt')
+                    become_output += chunk
+                    # need to check every line because we might get lectured
+                    # and we might get the middle of a line in a chunk
+                    for l in become_output.splitlines(True):
+                        if self.become.check_success(l):
+                            become_sucess = True
+                            break
+                        elif self.become.check_password_prompt(l):
+                            passprompt = True
+                            break
+                if passprompt:
+                    if self.become:
+                        become_pass = self.become.get_option(
+                            "become_pass", playcontext=self._play_context
+                        )
+                        chan.sendall(
+                            to_bytes(become_pass, errors="surrogate_or_strict")
+                            + b"\n"
+                        )
+                    else:
+                        raise AnsibleError(
+                            "A password is required but none was supplied"
+                        )
+                else:
+                    no_prompt_out += become_output
+                    no_prompt_err += become_output
+            else:
+                result = chan.exec_command(
+                    to_text(cmd, errors="surrogate_or_strict")
+                )
+        except socket.timeout:
+            raise AnsibleError(
+                "ssh timed out waiting for privilege escalation.\n"
+                + become_output
+            )
+
+        if result:
+            rc = result.returncode
+            out = result.stdout
+            err = result.stderr
+        else:
+            rc = chan.get_channel_exit_status()
+        return rc, out, err
+
+    def put_file(self, in_path, out_path):
+        """ transfer a file from local to remote """
+
+        super(Connection, self).put_file(in_path, out_path)
+
+        display.vvv(
+            "PUT %s TO %s" % (in_path, out_path),
+            host=self._play_context.remote_addr,
+        )
+
+        if not os.path.exists(to_bytes(in_path, errors="surrogate_or_strict")):
+            raise AnsibleFileNotFound(
+                "file or module does not exist: %s" % in_path
+            )
+
+        try:
+            self.sftp = self.ssh.sftp()
+        except Exception as e:
+            raise AnsibleError("failed to open a SFTP connection (%s)" % e)
+
+        try:
+            self.sftp.put(
+                to_bytes(in_path, errors="surrogate_or_strict"),
+                to_bytes(out_path, errors="surrogate_or_strict"),
+            )
+        except IOError:
+            raise AnsibleError("failed to transfer file to %s" % out_path)
+
+    def _connect_sftp(self):
+        cache_key = "%s__%s__" % (
+            self._play_context.remote_addr,
+            self._play_context.remote_user,
+        )
+        if cache_key in SFTP_CONNECTION_CACHE:
+            return SFTP_CONNECTION_CACHE[cache_key]
+        else:
+            result = SFTP_CONNECTION_CACHE[
+                cache_key
+            ] = self._connect().ssh.sftp()
+            return result
+
+    def fetch_file(self, in_path, out_path):
+        """ save a remote file to the specified path """
+
+        super(Connection, self).fetch_file(in_path, out_path)
+
+        display.vvv(
+            "FETCH %s TO %s" % (in_path, out_path),
+            host=self._play_context.remote_addr,
+        )
+
+        try:
+            self.sftp = self._connect_sftp()
+        except Exception as e:
+            raise AnsibleError("failed to open a SFTP connection (%s)" % to_native(e))
+
+        try:
+            self.sftp.get(to_bytes(in_path, errors='surrogate_or_strict'), to_bytes(out_path, errors='surrogate_or_strict'))
+        except IOError:
+            raise AnsibleError("failed to transfer file from %s" % in_path)
+
+    def reset(self):
+        self.close()
+        self._connect()
+
+    def close(self):
+        """ terminate the connection """
+
+        cache_key = self._cache_key()
+        SSH_CONNECTION_CACHE.pop(cache_key, None)
+        SFTP_CONNECTION_CACHE.pop(cache_key, None)
+
+        if hasattr(self, "sftp"):
+            if self.sftp is not None:
+                self.sftp.close()
+
+        self.ssh.close()
+        self._connected = False

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -129,7 +129,6 @@ display = Display()
 
 try:
     from pylibsshext.session import Session
-    from pylibsshext.channel import Channel
     from pylibsshext.errors import LibsshSessionException
 
     HAS_PYLIBSSH = True
@@ -397,11 +396,11 @@ class Connection(ConnectionBase):
                     become_output += chunk
                     # need to check every line because we might get lectured
                     # and we might get the middle of a line in a chunk
-                    for l in become_output.splitlines(True):
-                        if self.become.check_success(l):
+                    for line in become_output.splitlines(True):
+                        if self.become.check_success(line):
                             become_sucess = True
                             break
-                        elif self.become.check_password_prompt(l):
+                        elif self.become.check_password_prompt(line):
                             passprompt = True
                             break
                 if passprompt:

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -144,7 +144,7 @@ Are you sure you want to continue connecting (yes/no)?
 """
 
 # SSH Options Regex
-SETTINGS_REGEX = re.compile(r'(\w+)(?:\s*=\s*|\s+)(.+)')
+SETTINGS_REGEX = re.compile(r"(\w+)(?:\s*=\s*|\s+)(.+)")
 
 
 class MyAddPolicy(object):
@@ -162,14 +162,26 @@ class MyAddPolicy(object):
         self.connection = connection
         self._options = connection._options
 
-    def missing_host_key(self, session, hostname, username, key_type, fingerprint, message):
+    def missing_host_key(
+        self, session, hostname, username, key_type, fingerprint, message
+    ):
 
-        if all((self._options['host_key_checking'], not self._options['host_key_auto_add'])):
+        if all(
+            (
+                self._options["host_key_checking"],
+                not self._options["host_key_auto_add"],
+            )
+        ):
 
-            if self.connection.get_option('use_persistent_connections') or self.connection.force_persistence:
+            if (
+                self.connection.get_option("use_persistent_connections")
+                or self.connection.force_persistence
+            ):
                 # don't print the prompt string since the user cannot respond
                 # to the question anyway
-                raise AnsibleError(AUTHENTICITY_MSG[1:92] % (hostname, key_type, fingerprint))
+                raise AnsibleError(
+                    AUTHENTICITY_MSG[1:92] % (hostname, key_type, fingerprint)
+                )
 
             self.connection.connection_lock()
             old_stdin = sys.stdin
@@ -178,17 +190,20 @@ class MyAddPolicy(object):
             # clear out any premature input on sys.stdin
             tcflush(sys.stdin, TCIFLUSH)
 
-            inp = input(AUTHENTICITY_MSG % (hostname, message, key_type, fingerprint))
+            inp = input(
+                AUTHENTICITY_MSG % (hostname, message, key_type, fingerprint)
+            )
             sys.stdin = old_stdin
 
             self.connection.connection_unlock()
-            if inp not in ['yes', 'y', '']:
+            if inp not in ["yes", "y", ""]:
                 raise AnsibleError("host connection rejected by user")
 
         session.hostkey_auto_add(username)
 
         # host keys are actually saved in close() function below
         # in order to control ordering.
+
 
 # keep connection objects on a per host basis to avoid repeated attempts to reconnect
 SSH_CONNECTION_CACHE = {}
@@ -290,7 +305,9 @@ class Connection(ConnectionBase):
             if proxy_command:
                 ssh_connect_kwargs["proxycommand"] = proxy_command
 
-            self.ssh.set_missing_host_key_policy(MyAddPolicy(self._new_stdin, self))
+            self.ssh.set_missing_host_key_policy(
+                MyAddPolicy(self._new_stdin, self)
+            )
 
             self.ssh.connect(
                 host=self._play_context.remote_addr.lower(),
@@ -475,10 +492,15 @@ class Connection(ConnectionBase):
         try:
             self.sftp = self._connect_sftp()
         except Exception as e:
-            raise AnsibleError("failed to open a SFTP connection (%s)" % to_native(e))
+            raise AnsibleError(
+                "failed to open a SFTP connection (%s)" % to_native(e)
+            )
 
         try:
-            self.sftp.get(to_bytes(in_path, errors='surrogate_or_strict'), to_bytes(out_path, errors='surrogate_or_strict'))
+            self.sftp.get(
+                to_bytes(in_path, errors="surrogate_or_strict"),
+                to_bytes(out_path, errors="surrogate_or_strict"),
+            )
         except IOError:
             raise AnsibleError("failed to transfer file from %s" % in_path)
 

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -379,7 +379,9 @@ class Connection(NetworkConnectionBase):
                 "manually configure ansible_network_os value for this host"
             )
         self.queue_message("log", "network_os is set to %s" % self._network_os)
-        self.queue_message("vvvv", "ssh_type is set to: %s" % self.get_option("ssh_type"))
+        self.queue_message(
+            "vvvv", "ssh_type is set to: %s" % self.get_option("ssh_type")
+        )
 
     @property
     def ssh_type_conn(self):
@@ -408,7 +410,7 @@ class Connection(NetworkConnectionBase):
                 }
             )
             self.queue_message(
-            "vvvv", "ssh type is set to %s" % self.get_option("ssh_type")
+                "vvvv", "ssh type is set to %s" % self.get_option("ssh_type")
             )
         return self._ssh_type_conn
 

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -379,6 +379,7 @@ class Connection(NetworkConnectionBase):
                 "manually configure ansible_network_os value for this host"
             )
         self.queue_message("log", "network_os is set to %s" % self._network_os)
+        self.queue_message("vvvv", "ssh_type is set to: %s" % self.get_option("ssh_type"))
 
     @property
     def ssh_type_conn(self):
@@ -506,10 +507,6 @@ class Connection(NetworkConnectionBase):
 
         self.queue_message(
             "vvvv", "invoked shell using ssh_type: %s" % self._ssh_type
-        )
-        self.queue_message(
-            "vvvv",
-            "loaded terminal plugin for network_os %s" % self._network_os,
         )
 
         if not self.connected:
@@ -859,9 +856,6 @@ class Connection(NetworkConnectionBase):
         """
         Sends the command to the device in the opened shell
         """
-        self.queue_message(
-            "vvvv", "invoked shell using ssh_type: %s" % self._ssh_type
-        )
         if check_all:
             prompt_len = len(to_list(prompt))
             answer_len = len(to_list(answer))

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -623,9 +623,9 @@ class Connection(NetworkConnectionBase):
                 )
         super(Connection, self).close()
 
-    def _read_post_command_prompt_match(self, size=256):
+    def _read_post_command_prompt_match(self):
         time.sleep(self.get_option("persistent_buffer_read_timeout"))
-        data = self._ssh_shell.read_bulk_response(size=size)
+        data = self._ssh_shell.read_bulk_response()
         return data if data else None
 
     def receive_paramiko(

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -529,7 +529,7 @@ class Connection(NetworkConnectionBase):
                 try:
                     ssh = self.ssh_type_conn._connect()
                     break
-                except AnsibleError as e:
+                except AnsibleError:
                     raise
                 except Exception as e:
                     pause = 2 ** (attempt + 1)
@@ -736,6 +736,8 @@ class Connection(NetworkConnectionBase):
     ):
         self._command_response = resp = b""
         command_prompt_matched = False
+        handled = False
+
         while True:
 
             if command_prompt_matched:

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -261,7 +261,7 @@ options:
     description:
       - The type of the transport used by C(network_cli) connection plugin to connection to remote host.
         Valid value is either I(paramiko) or I(libssh)
-    default: libssh
+    default: paramiko
     env:
         - name: ANSIBLE_NETWORK_CLI_SSH_TYPE
     ini:

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -617,7 +617,7 @@ class Connection(NetworkConnectionBase):
                 self.queue_message("debug", "cli session is now closed")
 
                 self.ssh_type_conn.close()
-                self.ssh_type_conn = None
+                self._ssh_type_conn = None
                 self.queue_message(
                     "debug", "ssh connection has been closed successfully"
                 )

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -379,9 +379,7 @@ class Connection(NetworkConnectionBase):
                 "manually configure ansible_network_os value for this host"
             )
         self.queue_message("log", "network_os is set to %s" % self._network_os)
-        self.queue_message(
-            "vvvv", "ssh_type is set to: %s" % self.get_option("ssh_type")
-        )
+
 
     @property
     def ssh_type_conn(self):

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -261,7 +261,7 @@ options:
     description:
       - The type of the transport used by C(network_cli) connection plugin to connection to remote host.
         Valid value is either I(paramiko) or I(libssh)
-    default: paramiko
+    default: libssh
     env:
         - name: ANSIBLE_NETWORK_CLI_SSH_TYPE
     ini:

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -267,7 +267,8 @@ options:
     ini:
         - section: persistent_connection
           key: ssh_type
-    version_added: "2.10"
+    vars:
+    - name: ansible_network_cli_ssh_type
 """
 
 from functools import wraps

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -749,6 +749,8 @@ class Connection(NetworkConnectionBase):
             else:
                 data = self._ssh_shell.read_bulk_response()
 
+            if not data:
+                continue
             self._last_recv_window = self._strip(data)
             resp += self._last_recv_window
             self._window_count += 1

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -257,6 +257,17 @@ options:
       key: network_cli_retries
     vars:
     - name: ansible_network_cli_retries
+  ssh_type:
+    description:
+      - The type of the transport used by C(network_cli) connection plugin to connection to remote host.
+        Valid value is either I(paramiko) or I(libssh)
+    default: libssh
+    env:
+        - name: ANSIBLE_NETWORK_CLI_SSH_TYPE
+    ini:
+        - section: persistent_connection
+          key: ssh_type
+    version_added: "2.10"
 """
 
 from functools import wraps
@@ -271,7 +282,7 @@ import time
 import traceback
 from io import BytesIO
 
-from ansible.errors import AnsibleConnectionFailure
+from ansible.errors import AnsibleConnectionFailure, AnsibleError
 from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import cPickle
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
@@ -324,14 +335,13 @@ class Connection(NetworkConnectionBase):
 
         self._terminal = None
         self.cliconf = None
-        self._paramiko_conn = None
 
         # Managing prompt context
         self._check_prompt = False
-        self._task_uuid = to_text(kwargs.get("task_uuid", ""))
 
-        if self._play_context.verbosity > 3:
-            logging.getLogger("paramiko").setLevel(logging.DEBUG)
+        self._task_uuid = to_text(kwargs.get("task_uuid", ""))
+        self._ssh_type_conn = None
+        self._ssh_type = None
 
         if self._network_os:
             self._terminal = terminal_loader.get(self._network_os, self)
@@ -370,12 +380,24 @@ class Connection(NetworkConnectionBase):
         self.queue_message("log", "network_os is set to %s" % self._network_os)
 
     @property
-    def paramiko_conn(self):
-        if self._paramiko_conn is None:
-            self._paramiko_conn = connection_loader.get(
-                "paramiko", self._play_context, "/dev/null"
+    def ssh_type_conn(self):
+        ssh_type = self._ssh_type
+        if self._ssh_type_conn is None:
+            if ssh_type not in ["paramiko", "libssh"]:
+                raise AnsibleConnectionFailure(
+                    "Invalid value '%s' set for ssh_type option."
+                    " Excpected value is either 'libssh' or 'paramiko'"
+                    % ssh_type
+                )
+
+            # TODO: Remove this check if/when libssh connection plugin is moved to ansible-base
+            if ssh_type == "libssh":
+                ssh_type = "ansible.netcommon.libssh"
+
+            self._ssh_type_conn = connection_loader.get(
+                ssh_type, self._play_context, "/dev/null"
             )
-            self._paramiko_conn.set_options(
+            self._ssh_type_conn.set_options(
                 direct={
                     "look_for_keys": not bool(
                         self._play_context.password
@@ -383,11 +405,19 @@ class Connection(NetworkConnectionBase):
                     )
                 }
             )
-        return self._paramiko_conn
+            self.queue_message(
+            "vvvv", "ssh type is set to %s" % self.get_option("ssh_type")
+            )
+        return self._ssh_type_conn
+
+    # To maintain backward compatibility
+    @property
+    def paramiko_conn(self):
+        return self.ssh_type_conn
 
     def _get_log_channel(self):
         name = "p=%s u=%s | " % (os.getpid(), getpass.getuser())
-        name += "paramiko [%s]" % self._play_context.remote_addr
+        name += "%s [%s]" % (self._ssh_type, self._play_context.remote_addr)
         return name
 
     @ensure_connect
@@ -469,9 +499,21 @@ class Connection(NetworkConnectionBase):
         """
         Connects to the remote device and starts the terminal
         """
+        self._ssh_type = self.get_option("ssh_type")
+        if self._play_context.verbosity > 3:
+            logging.getLogger(self._ssh_type).setLevel(logging.DEBUG)
+
+        self.queue_message(
+            "vvvv", "invoked shell using ssh_type: %s" % self._ssh_type
+        )
+        self.queue_message(
+            "vvvv",
+            "loaded terminal plugin for network_os %s" % self._network_os,
+        )
+
         if not self.connected:
-            self.paramiko_conn._set_log_channel(self._get_log_channel())
-            self.paramiko_conn.force_persistence = self.force_persistence
+            self.ssh_type_conn._set_log_channel(self._get_log_channel())
+            self.ssh_type_conn.force_persistence = self.force_persistence
 
             command_timeout = self.get_option("persistent_command_timeout")
             max_pause = min(
@@ -485,8 +527,10 @@ class Connection(NetworkConnectionBase):
 
             for attempt in range(retries + 1):
                 try:
-                    ssh = self.paramiko_conn._connect()
+                    ssh = self.ssh_type_conn._connect()
                     break
+                except AnsibleError as e:
+                    raise
                 except Exception as e:
                     pause = 2 ** (attempt + 1)
                     if attempt == retries or total_pause >= max_pause:
@@ -513,7 +557,8 @@ class Connection(NetworkConnectionBase):
             self._connected = True
 
             self._ssh_shell = ssh.ssh.invoke_shell()
-            self._ssh_shell.settimeout(command_timeout)
+            if self._ssh_type == "paramiko":
+                self._ssh_shell.settimeout(command_timeout)
 
             self.queue_message(
                 "vvvv",
@@ -571,14 +616,19 @@ class Connection(NetworkConnectionBase):
                 self._ssh_shell = None
                 self.queue_message("debug", "cli session is now closed")
 
-                self.paramiko_conn.close()
-                self._paramiko_conn = None
+                self.ssh_type_conn.close()
+                self.ssh_type_conn = None
                 self.queue_message(
                     "debug", "ssh connection has been closed successfully"
                 )
         super(Connection, self).close()
 
-    def receive(
+    def _read_post_command_prompt_match(self, size=256):
+        time.sleep(self.get_option("persistent_buffer_read_timeout"))
+        data = self._ssh_shell.read_bulk_response(size=size)
+        return data if data else None
+
+    def receive_paramiko(
         self,
         command=None,
         prompts=None,
@@ -587,49 +637,25 @@ class Connection(NetworkConnectionBase):
         prompt_retry_check=False,
         check_all=False,
     ):
-        """
-        Handles receiving of output from command
-        """
-        self._matched_prompt = None
-        self._matched_cmd_prompt = None
+
         recv = BytesIO()
-        handled = False
-        command_prompt_matched = False
-        matched_prompt_window = window_count = 0
-
-        # set terminal regex values for command prompt and errors in response
-        self._terminal_stderr_re = self._get_terminal_std_re(
-            "terminal_stderr_re"
-        )
-        self._terminal_stdout_re = self._get_terminal_std_re(
-            "terminal_stdout_re"
-        )
-
         cache_socket_timeout = self._ssh_shell.gettimeout()
-        command_timeout = self.get_option("persistent_command_timeout")
-        self._validate_timeout_value(
-            command_timeout, "persistent_command_timeout"
-        )
-        if cache_socket_timeout != command_timeout:
-            self._ssh_shell.settimeout(command_timeout)
+        command_prompt_matched = False
+        handled = False
 
-        buffer_read_timeout = self.get_option("persistent_buffer_read_timeout")
-        self._validate_timeout_value(
-            buffer_read_timeout, "persistent_buffer_read_timeout"
-        )
-
-        self._log_messages("command: %s" % command)
         while True:
             if command_prompt_matched:
                 try:
                     signal.signal(
                         signal.SIGALRM, self._handle_buffer_read_timeout
                     )
-                    signal.setitimer(signal.ITIMER_REAL, buffer_read_timeout)
+                    signal.setitimer(
+                        signal.ITIMER_REAL, self._buffer_read_timeout
+                    )
                     data = self._ssh_shell.recv(256)
                     signal.alarm(0)
                     self._log_messages(
-                        "response-%s: %s" % (window_count + 1, data)
+                        "response-%s: %s" % (self._window_count + 1, data)
                     )
                     # if data is still received on channel it indicates the prompt string
                     # is wrongly matched in between response chunks, continue to read
@@ -638,7 +664,7 @@ class Connection(NetworkConnectionBase):
 
                     # restart command_timeout timer
                     signal.signal(signal.SIGALRM, self._handle_command_timeout)
-                    signal.alarm(command_timeout)
+                    signal.alarm(self._command_timeout)
 
                 except AnsibleCmdRespRecv:
                     # reset socket timeout to global timeout
@@ -647,7 +673,7 @@ class Connection(NetworkConnectionBase):
             else:
                 data = self._ssh_shell.recv(256)
                 self._log_messages(
-                    "response-%s: %s" % (window_count + 1, data)
+                    "response-%s: %s" % (self._window_count + 1, data)
                 )
             # when a channel stream is closed, received data will be empty
             if not data:
@@ -659,18 +685,18 @@ class Connection(NetworkConnectionBase):
 
             window = self._strip(recv.read())
             self._last_recv_window = window
-            window_count += 1
+            self._window_count += 1
 
             if prompts and not handled:
                 handled = self._handle_prompt(
                     window, prompts, answer, newline, False, check_all
                 )
-                matched_prompt_window = window_count
+                self._matched_prompt_window = self._window_count
             elif (
                 prompts
                 and handled
                 and prompt_retry_check
-                and matched_prompt_window + 1 == window_count
+                and self._matched_prompt_window + 1 == self._window_count
             ):
                 # check again even when handled, if same prompt repeats in next window
                 # (like in the case of a wrong enable password, etc) indicates
@@ -692,12 +718,131 @@ class Connection(NetworkConnectionBase):
                 self._last_response = recv.getvalue()
                 resp = self._strip(self._last_response)
                 self._command_response = self._sanitize(resp, command)
-                if buffer_read_timeout == 0.0:
+                if self._buffer_read_timeout == 0.0:
                     # reset socket timeout to global timeout
                     self._ssh_shell.settimeout(cache_socket_timeout)
                     return self._command_response
                 else:
                     command_prompt_matched = True
+
+    def receive_libssh(
+        self,
+        command=None,
+        prompts=None,
+        answer=None,
+        newline=True,
+        prompt_retry_check=False,
+        check_all=False,
+    ):
+        self._command_response = resp = b""
+        command_prompt_matched = False
+        while True:
+
+            if command_prompt_matched:
+                data = self._read_post_command_prompt_match()
+                if data:
+                    command_prompt_matched = False
+                else:
+                    return self._command_response
+            else:
+                data = self._ssh_shell.read_bulk_response()
+
+            self._last_recv_window = self._strip(data)
+            resp += self._last_recv_window
+            self._window_count += 1
+
+            self._log_messages("response-%s: %s" % (self._window_count, data))
+
+            if prompts and not handled:
+                handled = self._handle_prompt(
+                    resp, prompts, answer, newline, False, check_all
+                )
+                self._matched_prompt_window = self._window_count
+            elif (
+                prompts
+                and handled
+                and prompt_retry_check
+                and self._matched_prompt_window + 1 == self._window_count
+            ):
+                # check again even when handled, if same prompt repeats in next window
+                # (like in the case of a wrong enable password, etc) indicates
+                # value of answer is wrong, report this as error.
+                if self._handle_prompt(
+                    resp,
+                    prompts,
+                    answer,
+                    newline,
+                    prompt_retry_check,
+                    check_all,
+                ):
+                    raise AnsibleConnectionFailure(
+                        "For matched prompt '%s', answer is not valid"
+                        % self._matched_cmd_prompt
+                    )
+
+            if self._find_prompt(resp):
+                self._last_response = data
+                self._command_response += self._sanitize(resp, command)
+                command_prompt_matched = True
+
+    def receive(
+        self,
+        command=None,
+        prompts=None,
+        answer=None,
+        newline=True,
+        prompt_retry_check=False,
+        check_all=False,
+    ):
+        """
+        Handles receiving of output from command
+        """
+        self._matched_prompt = None
+        self._matched_cmd_prompt = None
+        self._matched_prompt_window = 0
+        self._window_count = 0
+
+        # set terminal regex values for command prompt and errors in response
+        self._terminal_stderr_re = self._get_terminal_std_re(
+            "terminal_stderr_re"
+        )
+        self._terminal_stdout_re = self._get_terminal_std_re(
+            "terminal_stdout_re"
+        )
+
+        self._command_timeout = self.get_option("persistent_command_timeout")
+        self._validate_timeout_value(
+            self._command_timeout, "persistent_command_timeout"
+        )
+
+        self._buffer_read_timeout = self.get_option(
+            "persistent_buffer_read_timeout"
+        )
+        self._validate_timeout_value(
+            self._buffer_read_timeout, "persistent_buffer_read_timeout"
+        )
+
+        self._log_messages("command: %s" % command)
+        if self._ssh_type == "libssh":
+            response = self.receive_libssh(
+                command,
+                prompts,
+                answer,
+                newline,
+                prompt_retry_check,
+                check_all,
+            )
+        else:
+            response = self.receive_paramiko(
+                command,
+                prompts,
+                answer,
+                newline,
+                prompt_retry_check,
+                check_all,
+            )
+
+        return response
 
     @ensure_connect
     def send(
@@ -713,6 +858,9 @@ class Connection(NetworkConnectionBase):
         """
         Sends the command to the device in the opened shell
         """
+        self.queue_message(
+            "vvvv", "invoked shell using ssh_type: %s" % self._ssh_type
+        )
         if check_all:
             prompt_len = len(to_list(prompt))
             answer_len = len(to_list(answer))

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -380,7 +380,6 @@ class Connection(NetworkConnectionBase):
             )
         self.queue_message("log", "network_os is set to %s" % self._network_os)
 
-
     @property
     def ssh_type_conn(self):
         ssh_type = self._ssh_type

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
---extra-index-url https://ansible.github.io/pylibssh/simple/
 ansible
 jxmlease
 ncclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ ansible
 jxmlease
 ncclient
 paramiko
-ansible-pylibssh==0.0.1a2.dev0
+ansible-pylibssh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--extra-index-url https://ansible.github.io/pylibssh/simple/
 ansible
 jxmlease
 ncclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ansible
 jxmlease
 ncclient
 paramiko
+ansible-pylibssh==0.0.1a2.dev0

--- a/tests/unit/plugins/connection/test_libssh.py
+++ b/tests/unit/plugins/connection/test_libssh.py
@@ -6,21 +6,14 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import re
-import json
-
 from ansible_collections.ansible.netcommon.tests.unit.compat import unittest
 from ansible_collections.ansible.netcommon.tests.unit.compat.mock import (
     patch,
     MagicMock,
 )
 
-from ansible.module_utils._text import to_text, to_bytes
-from ansible.errors import (
-    AnsibleConnectionFailure,
-    AnsibleError,
-    AnsibleFileNotFound,
-)
+from ansible.module_utils._text import to_bytes
+from ansible.errors import AnsibleError, AnsibleFileNotFound
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
 

--- a/tests/unit/plugins/connection/test_libssh.py
+++ b/tests/unit/plugins/connection/test_libssh.py
@@ -12,11 +12,15 @@ import json
 from ansible_collections.ansible.netcommon.tests.unit.compat import unittest
 from ansible_collections.ansible.netcommon.tests.unit.compat.mock import (
     patch,
-    MagicMock
+    MagicMock,
 )
 
 from ansible.module_utils._text import to_text, to_bytes
-from ansible.errors import AnsibleConnectionFailure, AnsibleError, AnsibleFileNotFound
+from ansible.errors import (
+    AnsibleConnectionFailure,
+    AnsibleError,
+    AnsibleFileNotFound,
+)
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
 
@@ -32,19 +36,29 @@ class TestConnectionClass(unittest.TestCase):
         pc.timeout = 60
         pc.remote_user = "user1"
 
-        conn = connection_loader.get("ansible.netcommon.libssh", pc, "/dev/null")
+        conn = connection_loader.get(
+            "ansible.netcommon.libssh", pc, "/dev/null"
+        )
 
         conn.ssh = mock_session
         mock_connect = MagicMock()
         conn.ssh.connect = mock_connect
         conn._connect()
-        conn.ssh.connect.assert_called_with(host="localhost", host_key_checking=False, look_for_keys=True,
-                                            password="test", port=8080, timeout=60, user="user1"
-                                            )
+        conn.ssh.connect.assert_called_with(
+            host="localhost",
+            host_key_checking=False,
+            look_for_keys=True,
+            password="test",
+            port=8080,
+            timeout=60,
+            user="user1",
+        )
 
     def test_libssh_close(self):
         pc = PlayContext()
-        conn = connection_loader.get("ansible.netcommon.libssh", pc, "/dev/null")
+        conn = connection_loader.get(
+            "ansible.netcommon.libssh", pc, "/dev/null"
+        )
         conn.ssh = MagicMock()
         conn.sftp = MagicMock()
         conn.chan = MagicMock()
@@ -58,56 +72,70 @@ class TestConnectionClass(unittest.TestCase):
     @patch("ansible.plugins.connection.ConnectionBase.exec_command")
     def test_libssh_exec_command(self, mocked_super):
         pc = PlayContext()
-        conn = connection_loader.get("ansible.netcommon.libssh", pc, "/dev/null")
+        conn = connection_loader.get(
+            "ansible.netcommon.libssh", pc, "/dev/null"
+        )
         with self.assertRaises(AnsibleError):
             conn.exec_command(cmd="ls", in_data=True)
 
         mock_chan = MagicMock()
         mock_chan.request_shell = MagicMock()
         mock_chan.exec_command = MagicMock()
-        mock_chan.exec_command.return_value = MagicMock(returncode=0, stdout='echo hello', stderr='')
+        mock_chan.exec_command.return_value = MagicMock(
+            returncode=0, stdout="echo hello", stderr=""
+        )
 
-        attr = {'new_channel.return_value': mock_chan}
+        attr = {"new_channel.return_value": mock_chan}
         mock_ssh = MagicMock(**attr)
         conn.ssh = mock_ssh
 
-        rc, out, err = conn.exec_command(cmd='echo hello')
+        rc, out, err = conn.exec_command(cmd="echo hello")
 
-        self.assertEqual((rc, out, err), (0, 'echo hello', ''))
+        self.assertEqual((rc, out, err), (0, "echo hello", ""))
 
     @patch("ansible.plugins.connection.ConnectionBase.put_file")
     def test_libssh_put_file_not_exist(self, mocked_super):
         pc = PlayContext()
-        conn = connection_loader.get("ansible.netcommon.libssh", pc, "/dev/null")
+        conn = connection_loader.get(
+            "ansible.netcommon.libssh", pc, "/dev/null"
+        )
         with self.assertRaises(AnsibleFileNotFound):
             conn.put_file(in_path="", out_path="")
 
-    @patch('os.path.exists')
+    @patch("os.path.exists")
     @patch("ansible.plugins.connection.ConnectionBase.put_file")
     def test_libssh_put_file(self, mocked_super, mock_exists):
         pc = PlayContext()
-        conn = connection_loader.get("ansible.netcommon.libssh", pc, "/dev/null")
+        conn = connection_loader.get(
+            "ansible.netcommon.libssh", pc, "/dev/null"
+        )
 
         mock_sftp = MagicMock()
-        attr = {'sftp.return_value': mock_sftp}
+        attr = {"sftp.return_value": mock_sftp}
         mock_ssh = MagicMock(**attr)
         conn.ssh = mock_ssh
 
-        file_path = 'test_libssh.py'
+        file_path = "test_libssh.py"
         conn.put_file(in_path=file_path, out_path=file_path)
-        mock_sftp.put.assert_called_with(to_bytes(file_path), to_bytes(file_path))
+        mock_sftp.put.assert_called_with(
+            to_bytes(file_path), to_bytes(file_path)
+        )
 
     @patch("pylibsshext.session.Session")
     @patch("ansible.plugins.connection.ConnectionBase.fetch_file")
     def test_libssh_fetch_file(self, mocked_super, mock_session):
         pc = PlayContext()
         pc.remote_addr = "localhost"
-        conn = connection_loader.get("ansible.netcommon.libssh", pc, "/dev/null")
+        conn = connection_loader.get(
+            "ansible.netcommon.libssh", pc, "/dev/null"
+        )
 
         conn.ssh = mock_session
         mock_connect = MagicMock()
         conn.ssh.connect = mock_connect
 
-        file_path = 'test_libssh.py'
+        file_path = "test_libssh.py"
         conn.fetch_file(in_path=file_path, out_path=file_path)
-        conn.sftp.get.assert_called_with(to_bytes(file_path), to_bytes(file_path))
+        conn.sftp.get.assert_called_with(
+            to_bytes(file_path), to_bytes(file_path)
+        )

--- a/tests/unit/plugins/connection/test_libssh.py
+++ b/tests/unit/plugins/connection/test_libssh.py
@@ -1,0 +1,113 @@
+# (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import re
+import json
+
+from ansible_collections.ansible.netcommon.tests.unit.compat import unittest
+from ansible_collections.ansible.netcommon.tests.unit.compat.mock import (
+    patch,
+    MagicMock
+)
+
+from ansible.module_utils._text import to_text, to_bytes
+from ansible.errors import AnsibleConnectionFailure, AnsibleError, AnsibleFileNotFound
+from ansible.playbook.play_context import PlayContext
+from ansible.plugins.loader import connection_loader
+
+
+class TestConnectionClass(unittest.TestCase):
+    @patch("pylibsshext.session.Session")
+    @patch("ansible.plugins.connection.ConnectionBase._connect")
+    def test_libssh_connect(self, mocked_super, mock_session):
+        pc = PlayContext()
+        pc.remote_addr = "localhost"
+        pc.password = "test"
+        pc.port = 8080
+        pc.timeout = 60
+        pc.remote_user = "user1"
+
+        conn = connection_loader.get("ansible.netcommon.libssh", pc, "/dev/null")
+
+        conn.ssh = mock_session
+        mock_connect = MagicMock()
+        conn.ssh.connect = mock_connect
+        conn._connect()
+        conn.ssh.connect.assert_called_with(host="localhost", host_key_checking=False, look_for_keys=True,
+                                            password="test", port=8080, timeout=60, user="user1"
+                                            )
+
+    def test_libssh_close(self):
+        pc = PlayContext()
+        conn = connection_loader.get("ansible.netcommon.libssh", pc, "/dev/null")
+        conn.ssh = MagicMock()
+        conn.sftp = MagicMock()
+        conn.chan = MagicMock()
+
+        conn.close()
+
+        conn.sftp.close.assert_called()
+        conn.chan.close.assert_called()
+        conn.sftp.close.assert_called()
+
+    @patch("ansible.plugins.connection.ConnectionBase.exec_command")
+    def test_libssh_exec_command(self, mocked_super):
+        pc = PlayContext()
+        conn = connection_loader.get("ansible.netcommon.libssh", pc, "/dev/null")
+        with self.assertRaises(AnsibleError):
+            conn.exec_command(cmd="ls", in_data=True)
+
+        mock_chan = MagicMock()
+        mock_chan.request_shell = MagicMock()
+        mock_chan.exec_command = MagicMock()
+        mock_chan.exec_command.return_value = MagicMock(returncode=0, stdout='echo hello', stderr='')
+
+        attr = {'new_channel.return_value': mock_chan}
+        mock_ssh = MagicMock(**attr)
+        conn.ssh = mock_ssh
+
+        rc, out, err = conn.exec_command(cmd='echo hello')
+
+        self.assertEqual((rc, out, err), (0, 'echo hello', ''))
+
+    @patch("ansible.plugins.connection.ConnectionBase.put_file")
+    def test_libssh_put_file_not_exist(self, mocked_super):
+        pc = PlayContext()
+        conn = connection_loader.get("ansible.netcommon.libssh", pc, "/dev/null")
+        with self.assertRaises(AnsibleFileNotFound):
+            conn.put_file(in_path="", out_path="")
+
+    @patch('os.path.exists')
+    @patch("ansible.plugins.connection.ConnectionBase.put_file")
+    def test_libssh_put_file(self, mocked_super, mock_exists):
+        pc = PlayContext()
+        conn = connection_loader.get("ansible.netcommon.libssh", pc, "/dev/null")
+
+        mock_sftp = MagicMock()
+        attr = {'sftp.return_value': mock_sftp}
+        mock_ssh = MagicMock(**attr)
+        conn.ssh = mock_ssh
+
+        file_path = 'test_libssh.py'
+        conn.put_file(in_path=file_path, out_path=file_path)
+        mock_sftp.put.assert_called_with(to_bytes(file_path), to_bytes(file_path))
+
+    @patch("pylibsshext.session.Session")
+    @patch("ansible.plugins.connection.ConnectionBase.fetch_file")
+    def test_libssh_fetch_file(self, mocked_super, mock_session):
+        pc = PlayContext()
+        pc.remote_addr = "localhost"
+        conn = connection_loader.get("ansible.netcommon.libssh", pc, "/dev/null")
+
+        conn.ssh = mock_session
+        mock_connect = MagicMock()
+        conn.ssh.connect = mock_connect
+
+        file_path = 'test_libssh.py'
+        conn.fetch_file(in_path=file_path, out_path=file_path)
+        conn.sftp.get.assert_called_with(to_bytes(file_path), to_bytes(file_path))

--- a/tests/unit/plugins/connection/test_network_cli.py
+++ b/tests/unit/plugins/connection/test_network_cli.py
@@ -65,7 +65,9 @@ class TestConnectionClass(unittest.TestCase):
         "ansible_collections.ansible.netcommon.plugins.connection.network_cli.terminal_loader"
     )
     @patch("ansible.plugins.connection.paramiko_ssh.Connection._connect")
-    def test_network_cli__connect_paramiko(self, mocked_super, mocked_terminal_loader):
+    def test_network_cli__connect_paramiko(
+        self, mocked_super, mocked_terminal_loader
+    ):
         pc = PlayContext()
         pc.network_os = "ios"
         conn = connection_loader.get("network_cli", pc, "/dev/null")
@@ -73,7 +75,7 @@ class TestConnectionClass(unittest.TestCase):
         conn.ssh = MagicMock()
         conn.receive = MagicMock()
         conn._terminal = MagicMock()
-        conn.set_options(direct={'ssh_type': 'paramiko'})
+        conn.set_options(direct={"ssh_type": "paramiko"})
         conn._connect()
         self.assertTrue(conn._terminal.on_open_shell.called)
         self.assertFalse(conn._terminal.on_become.called)
@@ -92,7 +94,9 @@ class TestConnectionClass(unittest.TestCase):
     @patch(
         "ansible_collections.ansible.netcommon.plugins.connection.libssh.Connection._connect"
     )
-    def test_network_cli__connect_libssh(self, mocked_super, mocked_terminal_loader):
+    def test_network_cli__connect_libssh(
+        self, mocked_super, mocked_terminal_loader
+    ):
         pc = PlayContext()
         pc.network_os = "ios"
         conn = connection_loader.get("network_cli", pc, "/dev/null")
@@ -100,7 +104,7 @@ class TestConnectionClass(unittest.TestCase):
         conn.ssh = MagicMock()
         conn.receive = MagicMock()
         conn._terminal = MagicMock()
-        conn.set_options(direct={'ssh_type': 'libssh'})
+        conn.set_options(direct={"ssh_type": "libssh"})
         conn._connect()
         self.assertTrue(conn._terminal.on_open_shell.called)
         self.assertFalse(conn._terminal.on_become.called)
@@ -118,7 +122,7 @@ class TestConnectionClass(unittest.TestCase):
         pc = PlayContext()
         pc.network_os = "ios"
         conn = connection_loader.get("network_cli", pc, "/dev/null")
-        conn._ssh_type = 'paramiko'
+        conn._ssh_type = "paramiko"
 
         terminal = MagicMock(supports_multiplexing=False)
         conn._terminal = terminal
@@ -137,7 +141,7 @@ class TestConnectionClass(unittest.TestCase):
         pc = PlayContext()
         pc.network_os = "ios"
         conn = connection_loader.get("network_cli", pc, "/dev/null")
-        conn._ssh_type = 'libssh'
+        conn._ssh_type = "libssh"
 
         terminal = MagicMock(supports_multiplexing=False)
         conn._terminal = terminal

--- a/tests/unit/plugins/connection/test_network_cli.py
+++ b/tests/unit/plugins/connection/test_network_cli.py
@@ -65,14 +65,42 @@ class TestConnectionClass(unittest.TestCase):
         "ansible_collections.ansible.netcommon.plugins.connection.network_cli.terminal_loader"
     )
     @patch("ansible.plugins.connection.paramiko_ssh.Connection._connect")
-    def test_network_cli__connect(self, mocked_super, mocked_terminal_loader):
+    def test_network_cli__connect_paramiko(self, mocked_super, mocked_terminal_loader):
         pc = PlayContext()
         pc.network_os = "ios"
         conn = connection_loader.get("network_cli", pc, "/dev/null")
 
         conn.ssh = MagicMock()
         conn.receive = MagicMock()
+        conn._terminal = MagicMock()
+        conn.set_options(direct={'ssh_type': 'paramiko'})
+        conn._connect()
+        self.assertTrue(conn._terminal.on_open_shell.called)
+        self.assertFalse(conn._terminal.on_become.called)
 
+        conn._play_context.become = True
+        conn._play_context.become_method = "enable"
+        conn._play_context.become_pass = "password"
+        conn._connected = False
+
+        conn._connect()
+        conn._terminal.on_become.assert_called_with(passwd="password")
+
+    @patch(
+        "ansible_collections.ansible.netcommon.plugins.connection.network_cli.terminal_loader"
+    )
+    @patch(
+        "ansible_collections.ansible.netcommon.plugins.connection.libssh.Connection._connect"
+    )
+    def test_network_cli__connect_libssh(self, mocked_super, mocked_terminal_loader):
+        pc = PlayContext()
+        pc.network_os = "ios"
+        conn = connection_loader.get("network_cli", pc, "/dev/null")
+
+        conn.ssh = MagicMock()
+        conn.receive = MagicMock()
+        conn._terminal = MagicMock()
+        conn.set_options(direct={'ssh_type': 'libssh'})
         conn._connect()
         self.assertTrue(conn._terminal.on_open_shell.called)
         self.assertFalse(conn._terminal.on_become.called)
@@ -86,21 +114,40 @@ class TestConnectionClass(unittest.TestCase):
         conn._terminal.on_become.assert_called_with(passwd="password")
 
     @patch("ansible.plugins.connection.paramiko_ssh.Connection.close")
-    def test_network_cli_close(self, mocked_super):
+    def test_network_cli_close_paramiko(self, mocked_super):
         pc = PlayContext()
         pc.network_os = "ios"
         conn = connection_loader.get("network_cli", pc, "/dev/null")
+        conn._ssh_type = 'paramiko'
 
         terminal = MagicMock(supports_multiplexing=False)
         conn._terminal = terminal
         conn._ssh_shell = MagicMock()
         conn._paramiko_conn = MagicMock()
         conn._connected = True
-
         conn.close()
         self.assertTrue(terminal.on_close_shell.called)
         self.assertIsNone(conn._ssh_shell)
-        self.assertIsNone(conn._paramiko_conn)
+        self.assertIsNone(conn._ssh_type_conn)
+
+    @patch(
+        "ansible_collections.ansible.netcommon.plugins.connection.libssh.Connection.close"
+    )
+    def test_network_cli_close_libssh(self, mocked_super):
+        pc = PlayContext()
+        pc.network_os = "ios"
+        conn = connection_loader.get("network_cli", pc, "/dev/null")
+        conn._ssh_type = 'libssh'
+
+        terminal = MagicMock(supports_multiplexing=False)
+        conn._terminal = terminal
+        conn._ssh_shell = MagicMock()
+        conn._paramiko_conn = MagicMock()
+        conn._connected = True
+        conn.close()
+        self.assertTrue(terminal.on_close_shell.called)
+        self.assertIsNone(conn._ssh_shell)
+        self.assertIsNone(conn._ssh_type_conn)
 
     @patch("ansible.plugins.connection.paramiko_ssh.Connection._connect")
     def test_network_cli_exec_command(self, mocked_super):
@@ -132,6 +179,7 @@ class TestConnectionClass(unittest.TestCase):
 
         pc = PlayContext()
         pc.network_os = "ios"
+        pc.remote_addr = "localhost"
         conn = connection_loader.get("network_cli", pc, "/dev/null")
 
         mock__terminal = MagicMock()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Add libssh connection type that uses
   pylibssh library (https://github.com/ansible/pylibssh)
   which is Python extension for libssh (https://www.libssh.org/)
*  Refactor network_cli connection plugin to work with both
   libssh and paramiko_ssh connection type under the hood.
   The default connection type is set to libssh and can be
   configured using `ssh_transport_type` network_cli
   plugin configuration.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/connection/libssh.py
plugins/connection/network_cli.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
