### PR TITLE
Initialize want before the empty config check

### DIFF
--- a/plugins/module_utils/network/common/resource_module.py
+++ b/plugins/module_utils/network/common/resource_module.py
@@ -25,6 +25,9 @@ class ResourceModule(object):  # pylint: disable=R0902
 
         self._connection = None
         self.state = self._module.params["state"]
+        self.want = remove_empties(self._module.params).get(
+            "config", self._empty_fact_val
+        )
         # Error out if empty config is passed for following states
         if (
             self.state in ("overridden", "merged", "replaced", "rendered")
@@ -37,14 +40,10 @@ class ResourceModule(object):  # pylint: disable=R0902
             )
 
         self.before = self.gather_current()
+        self.have = deepcopy(self.before)
         self.changed = False
         self.commands = []
         self.warnings = []
-
-        self.have = deepcopy(self.before)
-        self.want = remove_empties(self._module.params).get(
-            "config", self._empty_fact_val
-        )
 
         self._get_connection()
 


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY

The empty config was being checked before want was populated from task params.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
resource_module.py
