### PR TITLE
Add version key to keep ansible-galaxy happy

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,3 +7,6 @@ namespace: ansible
 readme: README.md
 repository: https://github.com/ansible-collections/ansible.netcommon
 tags: [networking, security, cloud, network_cli, netconf, httpapi, grpc]
+# NOTE(pabelanger): We create an empty version key to keep ansible-galaxy
+# happy. We dynamically inject version info based on git information.
+version: null


### PR DESCRIPTION
Because we have automated jobs for building / release collections in
zuul, our version information is dynamically created a job run time. Out
side of CI, this is an issue as people need to add version key to build
a collection.

Depends-On: https://github.com/ansible-collections/vyos.vyos/pull/32
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/474
Signed-off-by: Paul Belanger <pabelanger@redhat.com>