### PR TITLE
Fix the format of netconf return values

### DIFF
--- a/plugins/modules/netconf_get.py
+++ b/plugins/modules/netconf_get.py
@@ -155,7 +155,8 @@ output:
   type: complex
   contains:
     formatted_output:
-      - Contains formatted response received from remote host as per the value in display format.
+      description:
+        - Contains formatted response received from remote host as per the value in display format.
 """
 import sys
 

--- a/plugins/modules/netconf_rpc.py
+++ b/plugins/modules/netconf_rpc.py
@@ -144,7 +144,8 @@ output:
   type: complex
   contains:
     formatted_output:
-      - Contains formatted response received from remote host as per the value in display format.
+      description:
+        - Contains formatted response received from remote host as per the value in display format.
 """
 
 import ast


### PR DESCRIPTION
Fix netconf_get and netconf_rpc return docs.  These were formatted how
returndocs are expected which would have caused them not to render
correctly on the website.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
* netconf_rpc.py
* netconf_get.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
