### PR TITLE
Fixes error parsing Cisco IOS interface configuration with parse_cli

### DIFF
--- a/plugins/filter/network.py
+++ b/plugins/filter/network.py
@@ -131,6 +131,7 @@ def parse_cli(output, tmpl):
                     if lines:
                         lines.append(line)
                         blocks.append("\n".join(lines))
+                        lines = None
                     block_started = False
 
                 elif block_started:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Suggest patch from/closes #29
Set lines = None if match_end = end_block.match(line).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
parse_cli
