### PR TITLE
Revert "Add network tag to galaxy.yml (#52)"

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ name: netcommon
 namespace: ansible
 readme: README.md
 repository: https://github.com/ansible-collections/ansible.netcommon
-tags: [networking, network, security, cloud, network_cli, netconf, httpapi, grpc]
+tags: [networking, security, cloud, network_cli, netconf, httpapi, grpc]
 # NOTE(pabelanger): We create an empty version key to keep ansible-galaxy
 # happy. We dynamically inject version info based on git information.
 version: null


### PR DESCRIPTION
This actually isn't needed now.

This reverts commit 8dcf5a0eea3dd6bc50cb62519d455fdc0c51bf97.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>