### PR TITLE
Fix network_cli error regex handling

### DIFF
--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -869,10 +869,8 @@ class Connection(NetworkConnectionBase):
                         % (stderr_regex.pattern, response)
                     )
                 if errored_response:
-                    self._log_messages("--break from outer for loop with errored_response: %s--" % errored_response)
                     break
 
-        self._log_messages("--Value of is_error_message: %s--" % is_error_message)
         if not is_error_message:
             for regex in self._terminal_stdout_re:
                 match = regex.search(response)
@@ -887,17 +885,12 @@ class Connection(NetworkConnectionBase):
                             response,
                         )
                     )
-                    self._log_messages("--Value of errored_response 1: %s--" % errored_response)
                     if not errored_response:
-                        self._log_messages("--return from _find_prompt--")
                         return True
 
-        self._log_messages("--Value of errored_response 2: %s--" % errored_response)
         if errored_response:
-            self._log_messages("--raise execption with message: %s--" % errored_response)
             raise AnsibleConnectionFailure(errored_response)
 
-        self._log_messages("--return false--")
         return False
 
     def _validate_timeout_value(self, timeout, timer_name):

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -869,8 +869,10 @@ class Connection(NetworkConnectionBase):
                         % (stderr_regex.pattern, response)
                     )
                 if errored_response:
+                    self._log_messages("--break from outer for loop with errored_response: %s--" % errored_response)
                     break
 
+        self._log_messages("--Value of is_error_message: %s--" % is_error_message)
         if not is_error_message:
             for regex in self._terminal_stdout_re:
                 match = regex.search(response)
@@ -885,12 +887,17 @@ class Connection(NetworkConnectionBase):
                             response,
                         )
                     )
+                    self._log_messages("--Value of errored_response 1: %s--" % errored_response)
                     if not errored_response:
+                        self._log_messages("--return from _find_prompt--")
                         return True
 
+        self._log_messages("--Value of errored_response 2: %s--" % errored_response)
         if errored_response:
+            self._log_messages("--raise execption with message: %s--" % errored_response)
             raise AnsibleConnectionFailure(errored_response)
 
+        self._log_messages("--return false--")
         return False
 
     def _validate_timeout_value(self, timeout, timer_name):


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/ansible.netcommon/pull/54

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  If the cli prompt is found when error regex is matched
   don't continue to check for other error regex match
*  More verbose error regex matching logs
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
network_cli
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
