### PR TITLE
Deprecate napalm connection plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Name | Description
 Name | Description
 --- | ---
 [ansible.netcommon.httpapi](https://github.com/ansible-collections/ansible.netcommon/blob/master/docs/ansible.netcommon.httpapi.rst)|Use httpapi to run command on network appliances
-[ansible.netcommon.napalm](https://github.com/ansible-collections/ansible.netcommon/blob/master/docs/ansible.netcommon.napalm.rst)|Provides persistent connection using NAPALM
+[ansible.netcommon.napalm](https://github.com/ansible-collections/ansible.netcommon/blob/master/docs/ansible.netcommon.napalm_connection.rst)|Provides persistent connection using NAPALM
 [ansible.netcommon.netconf](https://github.com/ansible-collections/ansible.netcommon/blob/master/docs/ansible.netcommon.netconf.rst)|Provides a persistent connection using the netconf protocol
 [ansible.netcommon.network_cli](https://github.com/ansible-collections/ansible.netcommon/blob/master/docs/ansible.netcommon.network_cli.rst)|Use network_cli to run command on network appliances
 [ansible.netcommon.persistent](https://github.com/ansible-collections/ansible.netcommon/blob/master/docs/ansible.netcommon.persistent.rst)|Use a persistent unix socket for connection

--- a/docs/ansible.netcommon.napalm_connection.rst
+++ b/docs/ansible.netcommon.napalm_connection.rst
@@ -15,6 +15,13 @@ Version added: 1.0.0
    :local:
    :depth: 1
 
+DEPRECATED
+----------
+:Removed in collection release after 2022-06-01
+:Why: I am pretty sure no one has ever tried to use these modules
+:Alternative: None. If anyone actually wants to use this plugin, open an issue and we'll rescind the deprecation
+
+
 
 Synopsis
 --------
@@ -265,6 +272,10 @@ Parameters
 
 Status
 ------
+
+
+- This connection will be removed in version . *[deprecated]*
+- For more information see `DEPRECATED`_.
 
 
 Authors

--- a/plugins/connection/napalm.py
+++ b/plugins/connection/napalm.py
@@ -17,6 +17,10 @@ description:
   enabled on network devices depending on the destination device operating system.  The
   connection plugin requires C(napalm) to be installed locally on the Ansible controller.
 version_added: 1.0.0
+deprecated:
+  alternative: None. If anyone actually wants to use this plugin, open an issue and we'll rescind the deprecation
+  why: I am pretty sure no one has ever tried to use these modules
+  removed_at_date: '2022-06-01'
 requirements:
 - napalm
 options:


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/ansible.netcommon/pull/54

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
napalm