### PR TITLE
Better handling when ncclient encounters a nonexistent private key

### DIFF
--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -187,7 +187,10 @@ from ansible.plugins.connection import NetworkConnectionBase, ensure_connect
 try:
     from ncclient import manager
     from ncclient.operations import RPCError
-    from ncclient.transport.errors import SSHUnknownHostError
+    from ncclient.transport.errors import (
+        AuthenticationError,
+        SSHUnknownHostError,
+    )
     from ncclient.xml_ import to_ele, to_xml
 
     HAS_NCCLIENT = True
@@ -375,6 +378,14 @@ class Connection(NetworkConnectionBase):
             )
         except SSHUnknownHostError as exc:
             raise AnsibleConnectionFailure(to_native(exc))
+        except AuthenticationError as exc:
+            if str(exc).startswith("FileNotFoundError"):
+                raise AnsibleError(
+                    "Encountered FileNotFoundError in ncclient connect. Does {0} exist?".format(
+                        self.key_filename
+                    )
+                )
+            raise
         except ImportError:
             raise AnsibleError(
                 "connection=netconf is not supported on {0}".format(


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/ansible.netcommon/pull/54
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Helps ansible-collections/junipernetworks.junos#55 be less cryptic

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf