### PR TITLE
Fix for first IPv6 address not being a valid address

### DIFF
--- a/changelogs/fragments/72-ipv6-first-address-fix.yaml
+++ b/changelogs/fragments/72-ipv6-first-address-fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ipaddr filter - Fixed issue where the first IPv6 address in a subnet was not being considered a valid address.

--- a/plugins/filter/ipaddr.py
+++ b/plugins/filter/ipaddr.py
@@ -97,6 +97,9 @@ def _ip_query(v):
         # /31 networks in netaddr have no broadcast address
         if v.ip != v.network or not v.broadcast:
             return str(v.ip)
+        # For the first IPv6 address in a network, netaddr will return it as a network address, despite it being a valid host address.
+        elif v.version == 6 and v.ip == v.network:
+            return str(v.ip)
 
 
 def _address_prefix_query(v):

--- a/tests/unit/plugins/filter/test_ipaddr.py
+++ b/tests/unit/plugins/filter/test_ipaddr.py
@@ -93,6 +93,8 @@ class TestIpFilter(unittest.TestCase):
         self.assertEqual(ipaddr.ipaddr("192.0.2.0/31", "address"), "192.0.2.0")
         self.assertEqual(ipaddr.ipaddr("2001::1", "address"), "2001::1")
         self.assertEqual(ipaddr.ipaddr("2001::1/48", "address"), "2001::1")
+        self.assertEqual(ipaddr.ipaddr("2001::", "address"), "2001::")
+        self.assertEqual(ipaddr.ipaddr("2001::/48", "address"), "2001::")
 
     def test_ipaddr_bool_query(self):
         self.assertTrue(ipaddr.ipaddr("192.0.2.20", "bool"))


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/611
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/612

##### SUMMARY
Currently the first IPv6 addresses in a subnet will not return any ip if passed to the ipaddr filter.
**Example:**
_2001::/48_ will return nothing, as netaddr will consider the _2001::_ IP the network address in the subnet and will also return a broadcast address. 
It should return "_2001::_", as this is a valid address.

While this is technically wrong on the side of netaddr, as IPv6 has neither a network nor a broadcast address in the first place, Ive found many examples (also in the current ipaddr test suite) where this behaviour is expected. As such, the edge-case should be handled in ipaddr to return the first ip address as a valid address.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
plugins/filter/ipaddr.py

##### ADDITIONAL INFORMATION
I didnt find any test cases for ip addresses themselves, as such I havent added this to the unit tests. 
Please point me to the right direction if I have overlooked any.