### PR TITLE
 [changed] should be true for ACTION STATES  when check_mode : yes

### DIFF
--- a/changelogs/fragments/82-changed_true_action_states_check_mode_yes.yml
+++ b/changelogs/fragments/82-changed_true_action_states_check_mode_yes.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Resource Modules: changed flag is set to true in check_mode for all ACTION_STATES (https://github.com/ansible-collections/ansible.netcommon/pull/82)"

--- a/plugins/module_utils/network/common/resource_module.py
+++ b/plugins/module_utils/network/common/resource_module.py
@@ -159,8 +159,7 @@ class ResourceModule(object):  # pylint: disable=R0902
     def run_commands(self):
         """ Send commands to the device
         """
-        if self.commands:
+        if self.commands and self.state in self.ACTION_STATES:
             if not self._module.check_mode:
-                if self.state != "rendered":
-                    self._connection.edit_config(self.commands)
-                    self.changed = True
+                self._connection.edit_config(self.commands)
+            self.changed = True


### PR DESCRIPTION
 ```changed``` should be true when ```check_mode: yes```  and diff  commands got generated for 'ACTION_STATES'
 
Signed-off-by: Rohit Thakur <rohitthakur2590@outlook.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
 Bugfix
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
 resource_module.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
