### PR TITLE
Add missing gcc dependency

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,5 +1,6 @@
 # This is a cross-platform list tracking distribution packages needed by tests;
 # see https://docs.openstack.org/infra/bindep/ for additional information.
 
+gcc-c++ [doc test platform:rpm]
 libyaml-devel [test platform:rpm]
 libyaml-dev [test platform:dpkg]


### PR DESCRIPTION
This will be needed to ensure all unit test jobs work as expected.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>