### PR TITLE
Add missing gcc dependency

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,5 +1,6 @@
 # This is a cross-platform list tracking distribution packages needed by tests;
 # see https://docs.openstack.org/infra/bindep/ for additional information.
 
+gcc-c++ [doc test platform:rpm]
 libyaml-devel [test platform:rpm]
 libyaml-dev [test platform:dpkg]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 black==19.3b0 ; python_version > '3.5'
 coverage==4.5.4
 flake8
+mock ; python_version < '3.5'
 pytest-xdist
 yamllint


### PR DESCRIPTION
This will be needed to ensure all unit test jobs work as expected.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/597
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/603
Signed-off-by: Paul Belanger <pabelanger@redhat.com>