### PR TITLE
sort_list support for python 3

### DIFF
--- a/changelogs/fragments/114-sort_list_listofdicts.yaml
+++ b/changelogs/fragments/114-sort_list_listofdicts.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - sort_list will sort a list of dicts using the sorted method with key as an argument.

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -150,6 +150,11 @@ def transform_commands(module):
 
 def sort_list(val):
     if isinstance(val, list):
+        if isinstance(val[0], dict):
+            # Assuming the dictionaries have the same keys and
+            # they have to be sorted based on the first key
+            k = list(val[0].keys())[0]
+            return sorted(val, key = lambda i: i[k])
         return sorted(val)
     return val
 

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -151,10 +151,14 @@ def transform_commands(module):
 def sort_list(val):
     if isinstance(val, list):
         if isinstance(val[0], dict):
-            # Assuming the dictionaries have the same keys and
-            # they have to be sorted based on the first key
-            k = list(val[0].keys())[0]
-            return sorted(val, key = lambda i: i[k])
+            sorted_keys = [tuple(sorted(dict_.keys())) for dict_ in val]
+            # All keys should be identical
+            if len(set(sorted_keys)) != 1:
+                raise ValueError("dictionaries do not match")
+
+            return sorted(
+                val, key=lambda d: tuple(d[k] for k in sorted_keys[0])
+            )
         return sorted(val)
     return val
 

--- a/tests/unit/module_utils/network/common/test_utils.py
+++ b/tests/unit/module_utils/network/common/test_utils.py
@@ -144,12 +144,36 @@ def test_transform_commands():
     ]
 
 
-def test_sort():
+def test_sort_list():
     data = [3, 1, 2]
     assert [1, 2, 3] == utils.sort_list(data)
 
-    string_data = "123"
+    string_data = "312"
     assert string_data == utils.sort_list(string_data)
+
+    data = [{"a": 1, "b": 2}, {"a": 1, "c": 1}, {"a": 1, "b": 0}]
+    with pytest.raises(ValueError, match="dictionaries do not match"):
+        utils.sort_list(data)
+
+    data = [{"a": 1, "b": 2}, {"a": 1, "b": 1}, {"a": 0, "b": 3}]
+    assert utils.sort_list(data) == [
+        {"a": 0, "b": 3},
+        {"a": 1, "b": 1},
+        {"a": 1, "b": 2},
+    ]
+
+    data = [
+        {"a": 1, "c": [1, 2, 3], "b": 1},
+        {"a": 1, "c": [3, 4, 5], "b": 0},
+        {"a": 1, "c": [1, 1], "b": 0},
+        {"a": 0, "c": [99, 98, 97, 96, 95], "b": 27},
+    ]
+    assert utils.sort_list(data) == [
+        {"a": 0, "b": 27, "c": [99, 98, 97, 96, 95]},
+        {"a": 1, "b": 0, "c": [1, 1]},
+        {"a": 1, "b": 0, "c": [3, 4, 5]},
+        {"a": 1, "b": 1, "c": [1, 2, 3]},
+    ]
 
 
 def test_dict_diff():


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
Fixes #114 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
/netcommon/plugins/module_utils/network/common/utils.py


##### ADDITIONAL INFORMATION
```
In Python 3, just as in Python 2, we can't sort a dict / dictionary. sort_list function fails when list of dict is passed.
```
