### PR TITLE
Get list of capabilites, not Capabilities object

### DIFF
--- a/changelogs/fragments/netconf-capabilites-fix.yaml
+++ b/changelogs/fragments/netconf-capabilites-fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixed "Object of type Capabilities is not JSON serializable" when using default netconf plugin.

--- a/plugins/netconf/default.py
+++ b/plugins/netconf/default.py
@@ -64,8 +64,8 @@ class Netconf(NetconfBase):
         result["rpc"] = self.get_base_rpc()
         result["network_api"] = "netconf"
         result["device_info"] = self.get_device_info()
-        result["server_capabilities"] = self.m.server_capabilities
-        result["client_capabilities"] = self.m.client_capabilities
+        result["server_capabilities"] = list(self.m.server_capabilities)
+        result["client_capabilities"] = list(self.m.client_capabilities)
         result["session_id"] = self.m.session_id
         result["device_operations"] = self.get_device_operations(
             result["server_capabilities"]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes `Object of type Capabilities is not JSON serializable` error

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf/default.py
