### PR TITLE
allow root tag with namespace prefix

### DIFF
--- a/changelogs/fragments/allow_root_tag_with_prefix.yaml
+++ b/changelogs/fragments/allow_root_tag_with_prefix.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - The netconf_config module now allows root tag with namespace prefix.

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -316,9 +316,9 @@ def get_filter_type(filter):
 def validate_config(module, config, format="xml"):
     if format == "xml":
         root = fromstring(config)
-        if root.tag != "config":
+        if not root.tag.endswith("config"):
             module.fail_json(
-                msg="content value should have xml string with <config> tag as root"
+                msg="content value should have XML string with config tag as the root node"
             )
 
 

--- a/tests/integration/targets/netconf_config/tests/junos/basic.yaml
+++ b/tests/integration/targets/netconf_config/tests/junos/basic.yaml
@@ -60,7 +60,7 @@
 - assert:
     that:
       - result.failed == true
-      - "'content value should have xml string with <config> tag as root' in result.msg"
+      - "'content value should have XML string with config tag as the root node' in result.msg"
 
 - name: test backup
   register: result


### PR DESCRIPTION
Signed-off-by: Rohit Thakur <rohitthakur2590@outlook.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf_config
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
for a config with prefix 
```
<nc:config
              xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"
              xmlns:oc-if="http://openconfig.net/yang/interfaces"
              xmlns:if="urn:ietf:params:xml:ns:yang:ietf-interfaces"
              xmlns:md="urn:ietf:params:xml:ns:yang:ietf-yang-metadata"
              xmlns:nc-op="https://github.com/ansible-network/yang/nc-op"
              xmlns:oc-ext="http://openconfig.net/yang/openconfig-ext"
              xmlns:oc-types="http://openconfig.net/yang/openconfig-types"
              xmlns:oc-yang="http://openconfig.net/yang/types/yang"
              xmlns:yang="urn:ietf:params:xml:ns:yang:ietf-yang-types">
              <oc-if:interfaces>
                  <oc-if:interface>
                      <oc-if:name>GigabitEthernet0/0/0/2</oc-if:name>
                      <oc-if:config>
                          <oc-if:description>Configured with yang collection</oc-if:description>
                          <oc-if:name>GigabitEthernet0/0/0/2</oc-if:name>
                      </oc-if:config>
                  </oc-if:interface>
              </oc-if:interfaces>
          </nc:config>
```
the module gave the error:
```
"msg": "content value should have xml string with <config> tag as root"
```
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
