### PR TITLE
Add netconf modules json input support

### DIFF
--- a/changelogs/fragments/netconf_xmltodict_support.yaml
+++ b/changelogs/fragments/netconf_xmltodict_support.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add support for json format input format for netconf modules using ``xmltodict``

--- a/plugins/module_utils/utils/data.py
+++ b/plugins/module_utils/utils/data.py
@@ -14,8 +14,12 @@ import sys
 import json
 
 from ansible.module_utils.basic import missing_required_lib
-from ansible.errors import AnsibleModuleError
 from ansible.module_utils._text import to_native
+
+try:
+    from ansible.errors import AnsibleError
+except ImportError:
+    pass
 
 try:
     HAS_LXML = True
@@ -74,14 +78,14 @@ def validate_and_normailize_data(data, fmt=None):
             try:
                 result = fromstring(data)
                 if fmt and fmt != "xml":
-                    raise AnsibleModuleError(
+                    raise AnsibleError(
                         "Invalid format '%s'. Expected format is 'xml' for data '%s'"
                         % (fmt, data)
                     )
                 return result, "xml"
             except XMLSyntaxError as exc:
                 if fmt == "xml":
-                    raise AnsibleModuleError(
+                    raise AnsibleError(
                         "'%s' XML validation failed with error '%s'"
                         % (
                             data,
@@ -91,21 +95,21 @@ def validate_and_normailize_data(data, fmt=None):
                 pass
             except Exception as exc:
                 error = "'%s' recognized as XML but was not valid." % data
-                raise AnsibleModuleError(
+                raise AnsibleError(
                     error + to_native(exc, errors="surrogate_then_replace")
                 )
         else:
             try:
                 result = json.loads(data)
                 if fmt and fmt != "json":
-                    raise AnsibleModuleError(
+                    raise AnsibleError(
                         "Invalid format '%s'. Expected format is 'json' for data '%s'"
                         % (fmt, data)
                     )
                 return result, "json"
             except (TypeError, json.decoder.JSONDecodeError) as exc:
                 if fmt == "json":
-                    raise AnsibleModuleError(
+                    raise AnsibleError(
                         "'%s' JSON validation failed with error '%s'"
                         % (
                             data,
@@ -115,24 +119,24 @@ def validate_and_normailize_data(data, fmt=None):
                 pass
             except Exception as exc:
                 error = "'%s' recognized as JSON but was not valid." % data
-                raise AnsibleModuleError(
+                raise AnsibleError(
                     error + to_native(exc, errors="surrogate_then_replace")
                 )
 
             try:
                 if not HAS_LXML:
-                    raise AnsibleModuleError(missing_required_lib("lxml"))
+                    raise AnsibleError(missing_required_lib("lxml"))
 
                 result = etree.XPath(data)
                 if fmt and fmt != "xpath":
-                    raise AnsibleModuleError(
+                    raise AnsibleError(
                         "Invalid format '%s'. Expected format is 'xpath' for data '%s'"
                         % (fmt, data)
                     )
                 return result, "xpath"
             except etree.XPathSyntaxError as exc:
                 if fmt == "xpath":
-                    raise AnsibleModuleError(
+                    raise AnsibleError(
                         "'%s' XPath validation failed with error '%s'"
                         % (
                             data,
@@ -142,13 +146,13 @@ def validate_and_normailize_data(data, fmt=None):
                 pass
             except Exception as exc:
                 error = "'%s' recognized as Xpath but was not valid." % data
-                raise AnsibleModuleError(
+                raise AnsibleError(
                     error + to_native(exc, errors="surrogate_then_replace")
                 )
 
     elif isinstance(data, dict):
         if fmt and fmt != "json":
-            raise AnsibleModuleError(
+            raise AnsibleError(
                 "Invalid format '%s'. Expected format is 'json' for data '%s'"
                 % (fmt, data)
             )
@@ -157,13 +161,13 @@ def validate_and_normailize_data(data, fmt=None):
             result = json.loads(json.dumps(data))
             return result, "json"
         except (TypeError, json.decoder.JSONDecodeError) as exc:
-            raise AnsibleModuleError(
+            raise AnsibleError(
                 "'%s' JSON validation failed with error '%s'"
                 % (data, to_native(exc, errors="surrogate_then_replace"))
             )
         except Exception as exc:
             error = "'%s' recognized as JSON but was not valid." % data
-            raise AnsibleModuleError(
+            raise AnsibleError(
                 error + to_native(exc, errors="surrogate_then_replace")
             )
 
@@ -176,7 +180,7 @@ def xml_to_dict(data):
             "xml to dict conversion requires 'xmltodict' for given data %s ."
             % data
         )
-        raise AnsibleModuleError(msg + missing_required_lib("xmltodict"))
+        raise AnsibleError(msg + missing_required_lib("xmltodict"))
 
     try:
         return xmltodict.parse(data, dict_constructor=dict)
@@ -185,7 +189,7 @@ def xml_to_dict(data):
             "'xmltodict' returned the following error when converting %s to dict. "
             % data
         )
-        raise AnsibleModuleError(
+        raise AnsibleError(
             error + to_native(exc, errors="surrogate_then_replace")
         )
 
@@ -202,7 +206,7 @@ def dict_to_xml(data, full_document=False):
             "dict to xml conversion requires 'xmltodict' for given data %s ."
             % data
         )
-        raise AnsibleModuleError(msg + missing_required_lib("xmltodict"))
+        raise AnsibleError(msg + missing_required_lib("xmltodict"))
 
     try:
         return xmltodict.unparse(data, full_document=full_document)
@@ -211,6 +215,6 @@ def dict_to_xml(data, full_document=False):
             "'xmltodict' returned the following error when converting %s to xml. "
             % data
         )
-        raise AnsibleModuleError(
+        raise AnsibleError(
             error + to_native(exc, errors="surrogate_then_replace")
         )

--- a/plugins/module_utils/utils/data.py
+++ b/plugins/module_utils/utils/data.py
@@ -74,30 +74,50 @@ def validate_and_normailize_data(data, fmt=None):
             try:
                 result = fromstring(data)
                 if fmt and fmt != "xml":
-                    raise AnsibleModuleError("Invalid format '%s'. Expected format is 'xml' for data '%s'" % (fmt, data))
+                    raise AnsibleModuleError(
+                        "Invalid format '%s'. Expected format is 'xml' for data '%s'"
+                        % (fmt, data)
+                    )
                 return result, "xml"
             except XMLSyntaxError as exc:
                 if fmt == "xml":
-                    raise AnsibleModuleError("'%s' XML validation failed with error '%s'"
-                                             % (data, to_native(exc, errors="surrogate_then_replace")))
+                    raise AnsibleModuleError(
+                        "'%s' XML validation failed with error '%s'"
+                        % (
+                            data,
+                            to_native(exc, errors="surrogate_then_replace"),
+                        )
+                    )
                 pass
             except Exception as exc:
                 error = "'%s' recognized as XML but was not valid." % data
-                raise AnsibleModuleError(error + to_native(exc, errors="surrogate_then_replace"))
+                raise AnsibleModuleError(
+                    error + to_native(exc, errors="surrogate_then_replace")
+                )
         else:
             try:
                 result = json.loads(data)
                 if fmt and fmt != "json":
-                    raise AnsibleModuleError("Invalid format '%s'. Expected format is 'json' for data '%s'" % (fmt, data))
+                    raise AnsibleModuleError(
+                        "Invalid format '%s'. Expected format is 'json' for data '%s'"
+                        % (fmt, data)
+                    )
                 return result, "json"
             except (TypeError, json.decoder.JSONDecodeError) as exc:
                 if fmt == "json":
-                    raise AnsibleModuleError("'%s' JSON validation failed with error '%s'"
-                                             % (data, to_native(exc, errors="surrogate_then_replace")))
+                    raise AnsibleModuleError(
+                        "'%s' JSON validation failed with error '%s'"
+                        % (
+                            data,
+                            to_native(exc, errors="surrogate_then_replace"),
+                        )
+                    )
                 pass
             except Exception as exc:
                 error = "'%s' recognized as JSON but was not valid." % data
-                raise AnsibleModuleError(error + to_native(exc, errors="surrogate_then_replace"))
+                raise AnsibleModuleError(
+                    error + to_native(exc, errors="surrogate_then_replace")
+                )
 
             try:
                 if not HAS_LXML:
@@ -105,44 +125,69 @@ def validate_and_normailize_data(data, fmt=None):
 
                 result = etree.XPath(data)
                 if fmt and fmt != "xpath":
-                    raise AnsibleModuleError("Invalid format '%s'. Expected format is 'xpath' for data '%s'" % (fmt, data))
+                    raise AnsibleModuleError(
+                        "Invalid format '%s'. Expected format is 'xpath' for data '%s'"
+                        % (fmt, data)
+                    )
                 return result, "xpath"
             except etree.XPathSyntaxError as exc:
                 if fmt == "xpath":
-                    raise AnsibleModuleError("'%s' XPath validation failed with error '%s'"
-                                             % (data, to_native(exc, errors="surrogate_then_replace")))
+                    raise AnsibleModuleError(
+                        "'%s' XPath validation failed with error '%s'"
+                        % (
+                            data,
+                            to_native(exc, errors="surrogate_then_replace"),
+                        )
+                    )
                 pass
             except Exception as exc:
                 error = "'%s' recognized as Xpath but was not valid." % data
-                raise AnsibleModuleError(error + to_native(exc, errors="surrogate_then_replace"))
+                raise AnsibleModuleError(
+                    error + to_native(exc, errors="surrogate_then_replace")
+                )
 
     elif isinstance(data, dict):
         if fmt and fmt != "json":
-            raise AnsibleModuleError("Invalid format '%s'. Expected format is 'json' for data '%s'" % (fmt, data))
+            raise AnsibleModuleError(
+                "Invalid format '%s'. Expected format is 'json' for data '%s'"
+                % (fmt, data)
+            )
 
         try:
             result = json.loads(data)
             return result, "json"
         except (TypeError, json.decoder.JSONDecodeError) as exc:
-            raise AnsibleModuleError("'%s' JSON validation failed with error '%s'"
-                                     % (data, to_native(exc, errors="surrogate_then_replace")))
+            raise AnsibleModuleError(
+                "'%s' JSON validation failed with error '%s'"
+                % (data, to_native(exc, errors="surrogate_then_replace"))
+            )
         except Exception as exc:
             error = "'%s' recognized as JSON but was not valid." % data
-            raise AnsibleModuleError(error + to_native(exc, errors="surrogate_then_replace"))
+            raise AnsibleModuleError(
+                error + to_native(exc, errors="surrogate_then_replace")
+            )
 
     return data, "None"
 
 
 def xml_to_dict(data):
     if not HAS_XMLTODICT:
-        msg = "xml to dict conversion requires 'xmltodict' for given data %s ." % data
+        msg = (
+            "xml to dict conversion requires 'xmltodict' for given data %s ."
+            % data
+        )
         raise AnsibleModuleError(msg + missing_required_lib("xmltodict"))
 
     try:
         return xmltodict.parse(data, dict_constructor=dict)
     except Exception as exc:
-        error = "'xmltodict' returned the following error when converting %s to dict. " % data
-        raise AnsibleModuleError(error + to_native(exc, errors="surrogate_then_replace"))
+        error = (
+            "'xmltodict' returned the following error when converting %s to dict. "
+            % data
+        )
+        raise AnsibleModuleError(
+            error + to_native(exc, errors="surrogate_then_replace")
+        )
 
 
 def dict_to_xml(data, full_document=False):
@@ -153,11 +198,19 @@ def dict_to_xml(data, full_document=False):
     :return: Valid XML string
     """
     if not HAS_XMLTODICT:
-        msg = "dict to xml conversion requires 'xmltodict' for given data %s ." % data
+        msg = (
+            "dict to xml conversion requires 'xmltodict' for given data %s ."
+            % data
+        )
         raise AnsibleModuleError(msg + missing_required_lib("xmltodict"))
 
     try:
         return xmltodict.unparse(data, full_document=full_document)
     except Exception as exc:
-        error = "'xmltodict' returned the following error when converting %s to xml. " % data
-        raise AnsibleModuleError(error + to_native(exc, errors="surrogate_then_replace"))
+        error = (
+            "'xmltodict' returned the following error when converting %s to xml. "
+            % data
+        )
+        raise AnsibleModuleError(
+            error + to_native(exc, errors="surrogate_then_replace")
+        )

--- a/plugins/module_utils/utils/data.py
+++ b/plugins/module_utils/utils/data.py
@@ -17,11 +17,6 @@ from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 
 try:
-    from ansible.errors import AnsibleError
-except ImportError:
-    pass
-
-try:
     HAS_LXML = True
     from lxml.etree import fromstring, XMLSyntaxError
     from lxml import etree
@@ -44,7 +39,7 @@ except ImportError:
     HAS_XMLTODICT = False
 
 
-def validate_and_normailize_data(data, fmt=None):
+def validate_and_normalize_data(data, fmt=None):
     """
     This function validates the data for given format (fmt).
     If the fmt is None it tires to guess the data format.
@@ -79,14 +74,14 @@ def validate_and_normailize_data(data, fmt=None):
             try:
                 result = fromstring(data)
                 if fmt and fmt != "xml":
-                    raise AnsibleError(
+                    raise Exception(
                         "Invalid format '%s'. Expected format is 'xml' for data '%s'"
                         % (fmt, data)
                     )
                 return result, "xml"
             except XMLSyntaxError as exc:
                 if fmt == "xml":
-                    raise AnsibleError(
+                    raise Exception(
                         "'%s' XML validation failed with error '%s'"
                         % (
                             data,
@@ -96,21 +91,21 @@ def validate_and_normailize_data(data, fmt=None):
                 pass
             except Exception as exc:
                 error = "'%s' recognized as XML but was not valid." % data
-                raise AnsibleError(
+                raise Exception(
                     error + to_native(exc, errors="surrogate_then_replace")
                 )
         else:
             try:
                 result = json.loads(data)
                 if fmt and fmt != "json":
-                    raise AnsibleError(
+                    raise Exception(
                         "Invalid format '%s'. Expected format is 'json' for data '%s'"
                         % (fmt, data)
                     )
                 return result, "json"
             except (TypeError, json.decoder.JSONDecodeError) as exc:
                 if fmt == "json":
-                    raise AnsibleError(
+                    raise Exception(
                         "'%s' JSON validation failed with error '%s'"
                         % (
                             data,
@@ -120,24 +115,24 @@ def validate_and_normailize_data(data, fmt=None):
                 pass
             except Exception as exc:
                 error = "'%s' recognized as JSON but was not valid." % data
-                raise AnsibleError(
+                raise Exception(
                     error + to_native(exc, errors="surrogate_then_replace")
                 )
 
             try:
                 if not HAS_LXML:
-                    raise AnsibleError(missing_required_lib("lxml"))
+                    raise Exception(missing_required_lib("lxml"))
 
                 result = etree.XPath(data)
                 if fmt and fmt != "xpath":
-                    raise AnsibleError(
+                    raise Exception(
                         "Invalid format '%s'. Expected format is 'xpath' for data '%s'"
                         % (fmt, data)
                     )
                 return result, "xpath"
             except etree.XPathSyntaxError as exc:
                 if fmt == "xpath":
-                    raise AnsibleError(
+                    raise Exception(
                         "'%s' XPath validation failed with error '%s'"
                         % (
                             data,
@@ -147,13 +142,13 @@ def validate_and_normailize_data(data, fmt=None):
                 pass
             except Exception as exc:
                 error = "'%s' recognized as Xpath but was not valid." % data
-                raise AnsibleError(
+                raise Exception(
                     error + to_native(exc, errors="surrogate_then_replace")
                 )
 
     elif isinstance(data, dict):
         if fmt and fmt != "json":
-            raise AnsibleError(
+            raise Exception(
                 "Invalid format '%s'. Expected format is 'json' for data '%s'"
                 % (fmt, data)
             )
@@ -162,13 +157,13 @@ def validate_and_normailize_data(data, fmt=None):
             result = json.loads(json.dumps(data))
             return result, "json"
         except (TypeError, json.decoder.JSONDecodeError) as exc:
-            raise AnsibleError(
+            raise Exception(
                 "'%s' JSON validation failed with error '%s'"
                 % (data, to_native(exc, errors="surrogate_then_replace"))
             )
         except Exception as exc:
             error = "'%s' recognized as JSON but was not valid." % data
-            raise AnsibleError(
+            raise Exception(
                 error + to_native(exc, errors="surrogate_then_replace")
             )
 
@@ -181,7 +176,7 @@ def xml_to_dict(data):
             "xml to dict conversion requires 'xmltodict' for given data %s ."
             % data
         )
-        raise AnsibleError(msg + missing_required_lib("xmltodict"))
+        raise Exception(msg + missing_required_lib("xmltodict"))
 
     try:
         return xmltodict.parse(data, dict_constructor=dict)
@@ -190,7 +185,7 @@ def xml_to_dict(data):
             "'xmltodict' returned the following error when converting %s to dict. "
             % data
         )
-        raise AnsibleError(
+        raise Exception(
             error + to_native(exc, errors="surrogate_then_replace")
         )
 
@@ -207,7 +202,7 @@ def dict_to_xml(data, full_document=False):
             "dict to xml conversion requires 'xmltodict' for given data %s ."
             % data
         )
-        raise AnsibleError(msg + missing_required_lib("xmltodict"))
+        raise Exception(msg + missing_required_lib("xmltodict"))
 
     try:
         return xmltodict.unparse(data, full_document=full_document)
@@ -216,6 +211,6 @@ def dict_to_xml(data, full_document=False):
             "'xmltodict' returned the following error when converting %s to xml. "
             % data
         )
-        raise AnsibleError(
+        raise Exception(
             error + to_native(exc, errors="surrogate_then_replace")
         )

--- a/plugins/module_utils/utils/data.py
+++ b/plugins/module_utils/utils/data.py
@@ -154,7 +154,7 @@ def validate_and_normailize_data(data, fmt=None):
             )
 
         try:
-            result = json.loads(data)
+            result = json.loads(json.dumps(data))
             return result, "json"
         except (TypeError, json.decoder.JSONDecodeError) as exc:
             raise AnsibleModuleError(

--- a/plugins/module_utils/utils/data.py
+++ b/plugins/module_utils/utils/data.py
@@ -9,11 +9,11 @@ __metaclass__ = type
 """
 Utils functions for handle data formatting
 """
-import re
 import sys
 import json
 
 from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 
 try:
@@ -73,8 +73,9 @@ def validate_and_normailize_data(data, fmt=None):
     if data is None:
         return None, None
 
-    if isinstance(data, str):
-        if re.match(r"^<.+>$", data) or fmt == "xml":
+    if isinstance(data, string_types):
+        data = data.strip()
+        if (data.startswith("<") and data.endswith(">")) or fmt == "xml":
             try:
                 result = fromstring(data)
                 if fmt and fmt != "xml":

--- a/plugins/module_utils/utils/data.py
+++ b/plugins/module_utils/utils/data.py
@@ -19,12 +19,12 @@ from ansible.module_utils._text import to_native
 
 try:
     HAS_LXML = True
-    from lxml.etree import tostring, fromstring, XMLSyntaxError
+    from lxml.etree import fromstring, XMLSyntaxError
     from lxml import etree
 
 except ImportError:
     HAS_LXML = False
-    from xml.etree.ElementTree import tostring, fromstring
+    from xml.etree.ElementTree import fromstring
 
     if sys.version_info < (2, 7):
         from xml.parsers.expat import ExpatError as XMLSyntaxError

--- a/plugins/module_utils/utils/data.py
+++ b/plugins/module_utils/utils/data.py
@@ -1,0 +1,163 @@
+#
+# -*- coding: utf-8 -*-
+# Copyright 2019 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+"""
+Utils functions for handle data formatting
+"""
+import re
+import sys
+import json
+
+from ansible.module_utils.basic import missing_required_lib
+from ansible.errors import AnsibleModuleError
+from ansible.module_utils._text import to_native
+
+try:
+    HAS_LXML = True
+    from lxml.etree import tostring, fromstring, XMLSyntaxError
+    from lxml import etree
+
+except ImportError:
+    HAS_LXML = False
+    from xml.etree.ElementTree import tostring, fromstring
+
+    if sys.version_info < (2, 7):
+        from xml.parsers.expat import ExpatError as XMLSyntaxError
+    else:
+        from xml.etree.ElementTree import ParseError as XMLSyntaxError
+
+
+try:
+    import xmltodict
+
+    HAS_XMLTODICT = True
+except ImportError:
+    HAS_XMLTODICT = False
+
+
+def validate_and_normailize_data(data, fmt=None):
+    """
+    This function validates the data for given format (fmt).
+    If the fmt is None it tires to guess the data format.
+    Currently support data format checks are
+    1) xml
+    2) json
+    3) xpath
+    :param data: The data which should be validated and normalised.
+    :param fmt: This is an optional argument which indicated the format
+    of the data. Valid values are "xml", "json" and "xpath". If the value
+    is None the format of the data will be guessed and returned in the output.
+    :return:
+        *  If the format identified is XML it parses the xml data and returns
+           a tuple of lxml.etree.Element class object and the data format type
+           which is "xml" in this case.
+
+        *  If the format identified is JSON it parses the json data and returns
+           a tuple of dict object and the data format type
+           which is "json" in this case.
+
+        *  If the format identified is XPATH it parses the XPATH data and returns
+           a tuple of etree.XPath class object and the data format type
+           which is "xpath" in this case. For this type lxml library is required
+           to be installed.
+    """
+    if data is None:
+        return None, None
+
+    if isinstance(data, str):
+        if re.match(r"^<.+>$", data) or fmt == "xml":
+            try:
+                result = fromstring(data)
+                if fmt and fmt != "xml":
+                    raise AnsibleModuleError("Invalid format '%s'. Expected format is 'xml' for data '%s'" % (fmt, data))
+                return result, "xml"
+            except XMLSyntaxError as exc:
+                if fmt == "xml":
+                    raise AnsibleModuleError("'%s' XML validation failed with error '%s'"
+                                             % (data, to_native(exc, errors="surrogate_then_replace")))
+                pass
+            except Exception as exc:
+                error = "'%s' recognized as XML but was not valid." % data
+                raise AnsibleModuleError(error + to_native(exc, errors="surrogate_then_replace"))
+        else:
+            try:
+                result = json.loads(data)
+                if fmt and fmt != "json":
+                    raise AnsibleModuleError("Invalid format '%s'. Expected format is 'json' for data '%s'" % (fmt, data))
+                return result, "json"
+            except (TypeError, json.decoder.JSONDecodeError) as exc:
+                if fmt == "json":
+                    raise AnsibleModuleError("'%s' JSON validation failed with error '%s'"
+                                             % (data, to_native(exc, errors="surrogate_then_replace")))
+                pass
+            except Exception as exc:
+                error = "'%s' recognized as JSON but was not valid." % data
+                raise AnsibleModuleError(error + to_native(exc, errors="surrogate_then_replace"))
+
+            try:
+                if not HAS_LXML:
+                    raise AnsibleModuleError(missing_required_lib("lxml"))
+
+                result = etree.XPath(data)
+                if fmt and fmt != "xpath":
+                    raise AnsibleModuleError("Invalid format '%s'. Expected format is 'xpath' for data '%s'" % (fmt, data))
+                return result, "xpath"
+            except etree.XPathSyntaxError as exc:
+                if fmt == "xpath":
+                    raise AnsibleModuleError("'%s' XPath validation failed with error '%s'"
+                                             % (data, to_native(exc, errors="surrogate_then_replace")))
+                pass
+            except Exception as exc:
+                error = "'%s' recognized as Xpath but was not valid." % data
+                raise AnsibleModuleError(error + to_native(exc, errors="surrogate_then_replace"))
+
+    elif isinstance(data, dict):
+        if fmt and fmt != "json":
+            raise AnsibleModuleError("Invalid format '%s'. Expected format is 'json' for data '%s'" % (fmt, data))
+
+        try:
+            result = json.loads(data)
+            return result, "json"
+        except (TypeError, json.decoder.JSONDecodeError) as exc:
+            raise AnsibleModuleError("'%s' JSON validation failed with error '%s'"
+                                     % (data, to_native(exc, errors="surrogate_then_replace")))
+        except Exception as exc:
+            error = "'%s' recognized as JSON but was not valid." % data
+            raise AnsibleModuleError(error + to_native(exc, errors="surrogate_then_replace"))
+
+    return data, "None"
+
+
+def xml_to_dict(data):
+    if not HAS_XMLTODICT:
+        msg = "xml to dict conversion requires 'xmltodict' for given data %s ." % data
+        raise AnsibleModuleError(msg + missing_required_lib("xmltodict"))
+
+    try:
+        return xmltodict.parse(data, dict_constructor=dict)
+    except Exception as exc:
+        error = "'xmltodict' returned the following error when converting %s to dict. " % data
+        raise AnsibleModuleError(error + to_native(exc, errors="surrogate_then_replace"))
+
+
+def dict_to_xml(data, full_document=False):
+    """
+    Converts dict object to a valid XML string
+    :param data: Python dict object
+    :param full_document: When set to True the will have exactly one root.
+    :return: Valid XML string
+    """
+    if not HAS_XMLTODICT:
+        msg = "dict to xml conversion requires 'xmltodict' for given data %s ." % data
+        raise AnsibleModuleError(msg + missing_required_lib("xmltodict"))
+
+    try:
+        return xmltodict.unparse(data, full_document=full_document)
+    except Exception as exc:
+        error = "'xmltodict' returned the following error when converting %s to xml. " % data
+        raise AnsibleModuleError(error + to_native(exc, errors="surrogate_then_replace"))

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -294,7 +294,7 @@ from ansible.module_utils.connection import Connection, ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.utils.data import (
     validate_and_normailize_data,
     xml_to_dict,
-    dict_to_xml
+    dict_to_xml,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.netconf.netconf import (
     get_capabilities,
@@ -453,7 +453,10 @@ def main():
     elif filter_type is None:
         filter_type = "subtree"
     else:
-        module.fail_json(msg="Invalid filter type detected %s for get_filter value %s" % (filter_type, filter))
+        module.fail_json(
+            msg="Invalid filter type detected %s for get_filter value %s"
+            % (filter_type, filter)
+        )
 
     conn = Connection(module._socket_path)
     capabilities = get_capabilities(module)
@@ -577,7 +580,9 @@ def main():
 
             if format != "text":
                 # check for format of type json/xml/xpath
-                config_obj, config_format = validate_and_normailize_data(config, format)
+                config_obj, config_format = validate_and_normailize_data(
+                    config, format
+                )
                 if config_format == "json":
                     config = dict_to_xml(config_obj)
                     format = "xml"

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -336,7 +336,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection, ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.utils.data import (
-    validate_and_normailize_data,
+    validate_and_normalize_data,
     dict_to_xml,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.netconf.netconf import (
@@ -478,12 +478,19 @@ def main():
     filter = module.params["get_filter"]
     format = module.params["format"]
 
-    filter_data, filter_type = validate_and_normailize_data(filter)
+    try:
+        filter_data, filter_type = validate_and_normalize_data(filter)
+    except Exception as exc:
+        module.fail_json(msg=to_text(exc))
+
     if filter_type:
         if filter_type == "xml":
             filter_type = "subtree"
         elif filter_type == "json":
-            filter = dict_to_xml(filter_data)
+            try:
+                filter = dict_to_xml(filter_data)
+            except Exception as exc:
+                module.fail_json(msg=to_text(exc))
             filter_type = "subtree"
         elif filter_type == "xpath":
             pass
@@ -615,11 +622,18 @@ def main():
 
             if format != "text":
                 # check for format of type json/xml/xpath
-                config_obj, config_format = validate_and_normailize_data(
-                    config, format
-                )
+                try:
+                    config_obj, config_format = validate_and_normalize_data(
+                        config, format
+                    )
+                except Exception as exc:
+                    module.fail_json(msg=to_text(exc))
+
                 if config_format == "json":
-                    config = dict_to_xml(config_obj)
+                    try:
+                        config = dict_to_xml(config_obj)
+                    except Exception as exc:
+                        module.fail_json(msg=to_text(exc))
                     format = "xml"
                 elif config_format is None:
                     format = "xml"

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -293,7 +293,6 @@ from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection, ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.utils.data import (
     validate_and_normailize_data,
-    xml_to_dict,
     dict_to_xml,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.netconf.netconf import (
@@ -302,17 +301,10 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.netconf.
     sanitize_xml,
 )
 
-import sys
-
 try:
-    from lxml.etree import tostring, fromstring, XMLSyntaxError
+    from lxml.etree import tostring, fromstring
 except ImportError:
     from xml.etree.ElementTree import tostring, fromstring
-
-    if sys.version_info < (2, 7):
-        from xml.parsers.expat import ExpatError as XMLSyntaxError
-    else:
-        from xml.etree.ElementTree import ParseError as XMLSyntaxError
 
 
 def validate_config(module, config, format="xml"):

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -33,7 +33,7 @@ options:
     - In case of I(text) format of the configuration should be supported by remote Netconf server.
     - If the value of C(content) option is in I(xml) format in that case the xml value should
       have I(config) as root tag.
-    type: str
+    type: raw
     aliases:
     - xml
   target:

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -30,7 +30,7 @@ options:
       be either in xml string format or text format or python dictionary representation of JSON format.
     - In case of json string format it will be converted to the corresponding xml string using
       xmltodict library before pushing onto the remote host.
-    - In case of I(text) format of the configuration should be supported by remote Netconf server.
+    - In case the value of this option isn I(text) format the format should be supported by remote Netconf server.
     - If the value of C(content) option is in I(xml) format in that case the xml value should
       have I(config) as root tag.
     type: raw
@@ -58,8 +58,7 @@ options:
     - source
   format:
     description:
-    - The format of the configuration provided as value of C(content). Accepted values
-      are I(xml), I(text) and I(json).
+    - The format of the configuration provided as value of C(content).
     - In case of json string format it will be converted to the corresponding xml string using
       xmltodict library before pushing onto the remote host.
     - In case of I(text) format of the configuration should be supported by remote Netconf server.
@@ -480,20 +479,19 @@ def main():
     format = module.params["format"]
 
     filter_data, filter_type = validate_and_normailize_data(filter)
-    if filter_type == "xml":
-        filter_type = "subtree"
-    elif filter_type == "json":
-        filter = dict_to_xml(filter_data)
-        filter_type = "subtree"
-    elif filter_type == "xpath":
-        pass
-    elif filter_type is None:
-        filter_type = "subtree"
-    else:
-        module.fail_json(
-            msg="Invalid filter type detected %s for get_filter value %s"
-            % (filter_type, filter)
-        )
+    if filter_type:
+        if filter_type == "xml":
+            filter_type = "subtree"
+        elif filter_type == "json":
+            filter = dict_to_xml(filter_data)
+            filter_type = "subtree"
+        elif filter_type == "xpath":
+            pass
+        else:
+            module.fail_json(
+                msg="Invalid filter type detected %s for get_filter value %s"
+                % (filter_type, filter)
+            )
 
     conn = Connection(module._socket_path)
     capabilities = get_capabilities(module)
@@ -625,6 +623,8 @@ def main():
                     format = "xml"
                 elif config_format is None:
                     format = "xml"
+                else:
+                    format = config_format
 
             validate_config(module, config, format)
 

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -27,7 +27,7 @@ options:
   content:
     description:
     - The configuration data as defined by the device's data models, the value can
-      be either in xml string format or text format or json string format.
+      be either in xml string format or text format or python dictionary representation of JSON format.
     - In case of json string format it will be converted to the corresponding xml string using
       xmltodict library before pushing onto the remote host.
     - In case of I(text) format of the configuration should be supported by remote Netconf server.
@@ -64,7 +64,7 @@ options:
       xmltodict library before pushing onto the remote host.
     - In case of I(text) format of the configuration should be supported by remote Netconf server.
     - If the value of C(format) options is not given it tries to guess the data format of
-      C(content) option as one of I(xml) or I(json) or I(xpath).
+      C(content) option as one of I(xml) or I(json) or I(text).
     - If the data format is not identified it is set to I(xml) by default.
     type: str
     choices:

--- a/plugins/modules/netconf_get.py
+++ b/plugins/modules/netconf_get.py
@@ -214,7 +214,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.n
     remove_namespaces,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.utils.data import (
-    validate_and_normailize_data,
+    validate_and_normalize_data,
     xml_to_dict,
     dict_to_xml,
 )
@@ -250,11 +250,18 @@ def main():
     source = module.params["source"]
     filter = module.params["filter"]
 
-    filter_data, filter_type = validate_and_normailize_data(filter)
+    try:
+        filter_data, filter_type = validate_and_normalize_data(filter)
+    except Exception as exc:
+        module.fail_json(msg=to_text(exc))
+
     if filter_type == "xml":
         filter_type = "subtree"
     elif filter_type == "json":
-        filter = dict_to_xml(filter_data)
+        try:
+            filter = dict_to_xml(filter_data)
+        except Exception as exc:
+            module.fail_json(msg=to_text(exc))
         filter_type = "subtree"
     elif filter_type == "xpath":
         pass
@@ -327,7 +334,10 @@ def main():
     elif display == "pretty":
         output = to_text(tostring(response, pretty_print=True))
     elif display == "native":
-        output = xml_to_dict(xml_resp)
+        try:
+            output = xml_to_dict(xml_resp)
+        except Exception as exc:
+            module.fail_json(msg=to_text(exc))
 
     result = {"stdout": xml_resp, "output": output}
 

--- a/plugins/modules/netconf_get.py
+++ b/plugins/modules/netconf_get.py
@@ -201,7 +201,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.n
 from ansible_collections.ansible.netcommon.plugins.module_utils.utils.data import (
     validate_and_normailize_data,
     xml_to_dict,
-    dict_to_xml
+    dict_to_xml,
 )
 from ansible.module_utils._text import to_text
 
@@ -246,7 +246,10 @@ def main():
     elif filter_type is None:
         filter_type = "subtree"
     else:
-        module.fail_json(msg="Invalid filter type detected %s for filter value %s" % (filter_type, filter))
+        module.fail_json(
+            msg="Invalid filter type detected %s for filter value %s"
+            % (filter_type, filter)
+        )
 
     lock = module.params["lock"]
     display = module.params["display"]

--- a/plugins/modules/netconf_get.py
+++ b/plugins/modules/netconf_get.py
@@ -187,13 +187,11 @@ output:
                transformed XML to JSON format from the RPC response with type dict
                or pretty XML string response (human-readable) or response with
                namespace removed from XML string.
-  returned:
-  - If the display format is selected as I(json) it is returned as dict type and the conversion
-    is done using jxmlease python library.
-  - If the display format is selected as I(native) it is returned as dict type and the conversion
-    is done using xmltodict python library.
-  - If the display format is xml or pretty it is returned as a string apart from low-level
-    errors (such as action plugin).
+  returned: If the display format is selected as I(json) it is returned as dict type
+            and the conversion is done using jxmlease python library. If the display
+            format is selected as I(native) it is returned as dict type and the conversion
+            is done using xmltodict python library. If the display format is xml or pretty
+            it is returned as a string apart from low-level errors (such as action plugin).
   type: complex
   contains:
     formatted_output:

--- a/plugins/modules/netconf_get.py
+++ b/plugins/modules/netconf_get.py
@@ -265,9 +265,11 @@ def main():
         filter_type = "subtree"
     elif filter_type == "xpath":
         pass
-    elif filter_type is None:
+    elif (filter_type is None) and (filter_data is not None):
+        # to maintain backward compatibility for ansible 2.9 which
+        # defaults to "subtree" filter type
         filter_type = "subtree"
-    else:
+    elif filter_type:
         module.fail_json(
             msg="Invalid filter type detected %s for filter value %s"
             % (filter_type, filter)

--- a/plugins/modules/netconf_get.py
+++ b/plugins/modules/netconf_get.py
@@ -177,17 +177,10 @@ output:
         - Contains formatted response received from remote host as per the value in display format.
       type: str
 """
-import sys
-
 try:
-    from lxml.etree import tostring, fromstring, XMLSyntaxError
+    from lxml.etree import tostring
 except ImportError:
-    from xml.etree.ElementTree import tostring, fromstring
-
-    if sys.version_info < (2, 7):
-        from xml.parsers.expat import ExpatError as XMLSyntaxError
-    else:
-        from xml.etree.ElementTree import ParseError as XMLSyntaxError
+    from xml.etree.ElementTree import tostring
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.netconf.netconf import (

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ jxmlease
 ncclient
 selectors2 ; python_version == '3.5'
 netaddr
+paramiko
+xmltodict

--- a/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -1,6 +1,16 @@
 ---
 - debug: msg="START netconf_config iosxr/basic.yaml on connection={{ ansible_connection }}"
 
+- name: setup
+  connection: ansible.netcommon.network_cli
+  cisco.iosxr.iosxr_config:
+    commands:
+      - no description
+      - shutdown
+    parents:
+      - interface Loopback999
+    match: none
+
 - name: save config test
   register: result
   connection: ansible.netcommon.netconf
@@ -31,6 +41,46 @@
 - assert:
     that:
       - "'failed' not in result"
+
+- name: "configure using JSON format configuration"
+  ansible.netcommon.netconf_config:
+    content: |
+            {
+                "config": {
+                    "interface-configurations": {
+                        "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
+                        "interface-configuration": {
+                            "active": "act",
+                            "description": "test for ansible Loopback999",
+                            "interface-name": "Loopback999",
+                        }
+                    }
+                }
+            }
+    get_filter: |
+              {
+                  "interface-configurations": {
+                      "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
+                      "interface-configuration": null
+                  }
+              }
+  register: result
+  diff: true
+
+- assert:
+    that:
+    - result.changed == true
+    - "'<description>test for ansible Loopback999</description>' in result.diff.after"
+
+- name: setup - teardown
+  connection: ansible.netcommon.network_cli
+  cisco.iosxr.iosxr_config:
+    commands:
+      - no description
+      - shutdown
+    parents:
+      - interface Loopback999
+    match: none
 
 - debug: msg="END netconf_config iosxr/basic.yaml on connection={{ ansible_connection
     }}"

--- a/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -82,5 +82,83 @@
       - interface Loopback999
     match: none
 
+- name: "configure using JSON format configuration"
+  ansible.netcommon.netconf_config:
+    content: |
+            {
+                "config": {
+                    "interface-configurations": {
+                        "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
+                        "interface-configuration": {
+                            "active": "act",
+                            "description": "test for ansible Loopback999",
+                            "interface-name": "Loopback999"
+                        }
+                    }
+                }
+            }
+    get_filter: |
+              {
+                  "interface-configurations": {
+                      "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
+                      "interface-configuration": null
+                  }
+              }
+  register: result
+  diff: true
+
+- assert:
+    that:
+      - result.changed == true
+      - "'<description>test for ansible Loopback999</description>' in result.diff.after"
+
+- name: setup - teardown
+  connection: ansible.netcommon.network_cli
+  cisco.iosxr.iosxr_config:
+    commands:
+      - no description
+      - shutdown
+    parents:
+      - interface Loopback999
+    match: none
+
+- name: "configure using direct native format configuration"
+  ansible.netcommon.netconf_config:
+    content: {
+      "config": {
+        "interface-configurations": {
+          "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
+          "interface-configuration": {
+            "active": "act",
+            "description": "test for ansible Loopback999",
+            "interface-name": "Loopback999"
+          }
+        }
+      }
+    }
+    get_filter: {
+      "interface-configurations": {
+        "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
+        "interface-configuration": null
+      }
+    }
+  register: result
+  diff: true
+
+- assert:
+    that:
+      - result.changed == true
+      - "'<description>test for ansible Loopback999</description>' in result.diff.after"
+
+- name: setup - teardown
+  connection: ansible.netcommon.network_cli
+  cisco.iosxr.iosxr_config:
+    commands:
+      - no description
+      - shutdown
+    parents:
+      - interface Loopback999
+    match: none
+
 - debug: msg="END netconf_config iosxr/basic.yaml on connection={{ ansible_connection
     }}"

--- a/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -69,8 +69,8 @@
 
 - assert:
     that:
-    - result.changed == true
-    - "'<description>test for ansible Loopback999</description>' in result.diff.after"
+      - result.changed == true
+      - "'<description>test for ansible Loopback999</description>' in result.diff.after"
 
 - name: setup - teardown
   connection: ansible.netcommon.network_cli

--- a/tests/integration/targets/netconf_get/tests/iosxr/basic.yaml
+++ b/tests/integration/targets/netconf_get/tests/iosxr/basic.yaml
@@ -173,6 +173,44 @@
       - "{{ result['output']['data']['@xmlns:nc'] == 'urn:ietf:params:xml:ns:netconf:base:1.0' }}"
       - "{{ result['output']['data']['interface-configurations']['interface-configuration'] is defined }}"
 
+- name: Define the interface filter
+  set_fact:
+    filter:
+      interface-configurations:
+        "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg"
+        interface-configuration: null
+
+- name: "get configuration with native filter type using set_facts"
+  ansible.netcommon.netconf_get:
+    filter: "{{ filter }}"
+    display: native
+  register: result
+
+- assert:
+    that:
+      - "{{ result['output']['data'] is defined}}"
+      - "{{ result['output']['data']['@xmlns'] == 'urn:ietf:params:xml:ns:netconf:base:1.0' }}"
+      - "{{ result['output']['data']['@xmlns:nc'] == 'urn:ietf:params:xml:ns:netconf:base:1.0' }}"
+      - "{{ result['output']['data']['interface-configurations']['interface-configuration'] is defined }}"
+
+- name: "get configuration with direct native filter type"
+  ansible.netcommon.netconf_get:
+    filter: {
+      "interface-configurations": {
+        "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
+        "interface-configuration": null
+      }
+    }
+    display: native
+  register: result
+
+- assert:
+    that:
+      - "{{ result['output']['data'] is defined}}"
+      - "{{ result['output']['data']['@xmlns'] == 'urn:ietf:params:xml:ns:netconf:base:1.0' }}"
+      - "{{ result['output']['data']['@xmlns:nc'] == 'urn:ietf:params:xml:ns:netconf:base:1.0' }}"
+      - "{{ result['output']['data']['interface-configurations']['interface-configuration'] is defined }}"
+
 - name: setup - teardown
   connection: ansible.netcommon.network_cli
   cisco.iosxr.iosxr_config:

--- a/tests/integration/targets/netconf_get/tests/iosxr/basic.yaml
+++ b/tests/integration/targets/netconf_get/tests/iosxr/basic.yaml
@@ -154,6 +154,25 @@
       - "'filter value \\'configuration/state\\' of type xpath is not supported'\
         \ in result.msg"
 
+- name: "get configuration with json filter and native output (using xmltodict)"
+  ansible.netcommon.netconf_get:
+    filter: |
+              {
+                  "interface-configurations": {
+                      "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
+                      "interface-configuration": null
+                  }
+              }
+    display: native
+  register: result
+
+- assert:
+    that:
+      - "{{ result['output']['data'] is defined}}"
+      - "{{ result['output']['data']['@xmlns'] == 'urn:ietf:params:xml:ns:netconf:base:1.0' }}"
+      - "{{ result['output']['data']['@xmlns:nc'] == 'urn:ietf:params:xml:ns:netconf:base:1.0' }}"
+      - "{{ result['output']['data']['interface-configurations']['interface-configuration'] is defined }}"
+
 - name: setup - teardown
   connection: ansible.netcommon.network_cli
   cisco.iosxr.iosxr_config:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  netconf_config - add suport to accept configuration in JSON
   format using xmltodict to convert JSON to XML and accept
   get_filter value in JSON format
*  netconf_get - add support to accept input filter in JSON
   format and convert the recevied XML repsonse to JSON and
   return in task output. The XML to JSON conversion is done
   using xmltodict python library
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf_config
netconf_get

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
