### PR TITLE
Fix netconf_rpc response encoding issue

### DIFF
--- a/changelogs/fragments/151-netconf_rpc_fix.yaml
+++ b/changelogs/fragments/151-netconf_rpc_fix.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed netconf_rpc task fails due to encoding issue in the response
+    (https://github.com/ansible-collections/ansible.netcommon/issues/151)

--- a/plugins/module_utils/network/common/netconf.py
+++ b/plugins/module_utils/network/common/netconf.py
@@ -158,7 +158,10 @@ def remove_namespaces(data):
             "ncclient is required but does not appear to be installed.  "
             "It can be installed using `pip install ncclient`"
         )
-    return NCElement(to_text(data.strip(), errors="surrogate_then_replace"), transform_reply()).data_xml
+    return NCElement(
+        to_text(data.strip(), errors="surrogate_then_replace"),
+        transform_reply(),
+    ).data_xml
 
 
 def build_root_xml_node(tag):

--- a/plugins/module_utils/network/common/netconf.py
+++ b/plugins/module_utils/network/common/netconf.py
@@ -158,7 +158,7 @@ def remove_namespaces(data):
             "ncclient is required but does not appear to be installed.  "
             "It can be installed using `pip install ncclient`"
         )
-    return NCElement(data, transform_reply()).data_xml
+    return NCElement(to_text(data.strip(), errors="surrogate_then_replace"), transform_reply()).data_xml
 
 
 def build_root_xml_node(tag):


### PR DESCRIPTION

Fixes https://github.com/ansible-collections/ansible.netcommon/issues/151

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

*  While removing namespace convert the response data
   using `to_text`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf_rpc
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
