### PR TITLE
add the reverse of vlan_parser

### DIFF
--- a/changelogs/fragments/159-vlan-unparser.yaml
+++ b/changelogs/fragments/159-vlan-unparser.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - add filter to unparse (expand) IOS-style vlan list strings

--- a/plugins/filter/network.py
+++ b/plugins/filter/network.py
@@ -443,13 +443,13 @@ def comp_type5(
 def vlan_parser(vlan_list, first_line_len=48, other_line_len=44):
 
     """
-        Input: Unsorted list of vlan integers
-        Output: Sorted string list of integers according to IOS-like vlan list rules
+    Input: Unsorted list of vlan integers
+    Output: Sorted string list of integers according to IOS-like vlan list rules
 
-        1. Vlans are listed in ascending order
-        2. Runs of 3 or more consecutive vlans are listed with a dash
-        3. The first line of the list can be first_line_len characters long
-        4. Subsequent list lines can be other_line_len characters
+    1. Vlans are listed in ascending order
+    2. Runs of 3 or more consecutive vlans are listed with a dash
+    3. The first line of the list can be first_line_len characters long
+    4. Subsequent list lines can be other_line_len characters
     """
 
     # Sort and remove duplicates
@@ -528,9 +528,10 @@ def vlan_unparser(vlan_list_string):
     if re.match(r"^\d[\d\-,\s]+\d$", vlan_list_string):
 
         for num in re.findall(r"\D*(\d+)\D*", vlan_list_string):
-            if int(num) not in range(vlan_min, vlan_max+1):
+            if int(num) not in range(vlan_min, vlan_max + 1):
                 raise AnsibleFilterError(
-                    "Invalid VLAN value found: {}".format(num))
+                    "Invalid VLAN value found: {}".format(num)
+                )
 
         elems = re.split(r"\s*,\s*", vlan_list_string)
         for elem in elems:
@@ -539,15 +540,17 @@ def vlan_unparser(vlan_list_string):
                 if match is not None:
                     start = int(match.groups(0)[0])
                     end = int(match.groups(0)[1])
-                    result.extend(list(range(start, end+1)))
+                    result.extend(list(range(start, end + 1)))
                 else:
                     raise AnsibleFilterError(
-                        "Invalid VLAN range: {}".format(elem))
+                        "Invalid VLAN range: {}".format(elem)
+                    )
             else:
                 result.append(int(elem))
     else:
         raise AnsibleFilterError(
-            "Invalid VLAN range string: {}".format(vlan_list_string))
+            "Invalid VLAN range string: {}".format(vlan_list_string)
+        )
 
     return sorted(result)
 

--- a/plugins/filter/network.py
+++ b/plugins/filter/network.py
@@ -515,6 +515,33 @@ def vlan_parser(vlan_list, first_line_len=48, other_line_len=44):
     return result
 
 
+def vlan_unparser(s):
+    VLAN_MIN = 1
+    VLAN_MAX = 4094
+    result = []
+    if re.match(r"^[0-9\-,\s]+$", s):
+
+        for n in re.findall(r"\D*([0-9]+)\D*", s):
+            if not(int(n) in range(VLAN_MIN, VLAN_MAX+1)):
+                raise AnsibleFilterError(f"Invalid VLAN value found: {n}")
+
+        pairs = re.split(r"\s*,\s*", s)
+        for pair in pairs:
+            if "-" in pair:
+                m = re.match(r"^\s*([0-9]+)\s*-\s*([0-9]+)\s*$", pair)
+                if m is not None:
+                    (start, end) = (int(m.groups(0)[0]), int(m.groups(0)[1]))
+                    result.extend(list(range(start, end+1)))
+                else:
+                    raise AnsibleFilterError(f"Invalid VLAN range: {pair}")
+            else:
+                result.append(int(pair))
+    else:
+        raise AnsibleFilterError(f"Invalid VLAN range string: {s}")
+
+    return(result)
+
+
 class FilterModule(object):
     """Filters for working with output from network devices"""
 
@@ -526,6 +553,7 @@ class FilterModule(object):
         "hash_salt": hash_salt,
         "comp_type5": comp_type5,
         "vlan_parser": vlan_parser,
+        "vlan_unparser": vlan_unparser,
     }
 
     def filters(self):

--- a/plugins/filter/network.py
+++ b/plugins/filter/network.py
@@ -523,7 +523,7 @@ def vlan_unparser(s):
 
         for n in re.findall(r"\D*([0-9]+)\D*", s):
             if not(int(n) in range(VLAN_MIN, VLAN_MAX+1)):
-                raise AnsibleFilterError(f"Invalid VLAN value found: {n}")
+                raise AnsibleFilterError("Invalid VLAN value found: {}".format(n))
 
         pairs = re.split(r"\s*,\s*", s)
         for pair in pairs:
@@ -533,11 +533,11 @@ def vlan_unparser(s):
                     (start, end) = (int(m.groups(0)[0]), int(m.groups(0)[1]))
                     result.extend(list(range(start, end+1)))
                 else:
-                    raise AnsibleFilterError(f"Invalid VLAN range: {pair}")
+                    raise AnsibleFilterError("Invalid VLAN range: {}".format(pair))
             else:
                 result.append(int(pair))
     else:
-        raise AnsibleFilterError(f"Invalid VLAN range string: {s}")
+        raise AnsibleFilterError("Invalid VLAN range string: {}".format(s))
 
     return(result)
 

--- a/plugins/filter/network.py
+++ b/plugins/filter/network.py
@@ -525,9 +525,9 @@ def vlan_unparser(vlan_list_string):
     vlan_min = 1
     vlan_max = 4094
     result = []
-    if re.match(r"^[0-9\-,\s]+$", vlan_list_string):
+    if re.match(r"^\d[\d\-,\s]+\d$", vlan_list_string):
 
-        for num in re.findall(r"\D*([0-9]+)\D*", vlan_list_string):
+        for num in re.findall(r"\D*(\d+)\D*", vlan_list_string):
             if int(num) not in range(vlan_min, vlan_max+1):
                 raise AnsibleFilterError(
                     "Invalid VLAN value found: {}".format(num))
@@ -535,7 +535,7 @@ def vlan_unparser(vlan_list_string):
         elems = re.split(r"\s*,\s*", vlan_list_string)
         for elem in elems:
             if "-" in elem:
-                match = re.match(r"^\s*([0-9]+)\s*-\s*([0-9]+)\s*$", elem)
+                match = re.match(r"^\s*(\d+)\s*-\s*(\d+)\s*$", elem)
                 if match is not None:
                     start = int(match.groups(0)[0])
                     end = int(match.groups(0)[1])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Would like to compute the list of vlans from an IOS-style range string

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/filter/network.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
