### PR TITLE
Handle negate configuration in vyos

### DIFF
--- a/changelogs/fragments/negate-command-vyos.yaml
+++ b/changelogs/fragments/negate-command-vyos.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - 'prefix' added to NetworkTemplate class, inorder to handle the negate operation for vyos config commands.
+  - "'prefix' added to NetworkTemplate class, inorder to handle the negate operation for vyos config commands."

--- a/changelogs/fragments/negate-command-vyos.yaml
+++ b/changelogs/fragments/negate-command-vyos.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - For negate operation in vyos, comapre func will pass delete=True, so that negation of the config is done by /set/delete/ .
+  - 'prefix' added to NetworkTemplate class, inorder to handle the negate operation for vyos config commands.

--- a/changelogs/fragments/negate-command-vyos.yaml
+++ b/changelogs/fragments/negate-command-vyos.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - For negate operation in vyos, comapre func will pass delete=True, so that negation of the config is done by /set/delete/ .

--- a/plugins/module_utils/network/common/network_template.py
+++ b/plugins/module_utils/network/common/network_template.py
@@ -82,9 +82,9 @@ class NetworkTemplate(object):
             return None
         if res and delete and negate:
             if isinstance(res, list):
-                cmd = [re.sub('set ', 'delete ', each) for each in res]
+                cmd = [re.sub("set ", "delete ", each) for each in res]
                 return cmd
-            return re.sub('set ', 'delete ', res)
+            return re.sub("set ", "delete ", res)
         elif res and negate:
             if isinstance(res, list):
                 cmd = [("no " + each) for each in res]

--- a/plugins/module_utils/network/common/network_template.py
+++ b/plugins/module_utils/network/common/network_template.py
@@ -81,26 +81,20 @@ class NetworkTemplate(object):
                 )
         except KeyError:
             return None
-        if self._prefix:
-            if negate and res and self._prefix.get("remove"):
+
+        if res:
+            if negate:
+                rem = "{0} ".format(self._prefix.get("remove", "no"))
                 if isinstance(res, list):
-                    cmd = [
-                        (self._prefix["remove"] + " " + each) for each in res
-                    ]
-                else:
-                    cmd = self._prefix["remove"] + " " + res
-                return cmd
-            elif self._prefix.get("set") and res:
+                    cmd = [(rem + each) for each in res]
+                    return cmd
+                return rem + res
+            elif self._prefix.get("set"):
+                set_cmd = "{0} ".format(self._prefix.get("set", ""))
                 if isinstance(res, list):
-                    cmd = [(self._prefix["set"] + " " + each) for each in res]
-                else:
-                    cmd = self._prefix["set"] + " " + res
-                return cmd
-        elif res and negate:
-            if isinstance(res, list):
-                cmd = [("no " + each) for each in res]
-                return cmd
-            return "no " + res
+                    cmd = [(set_cmd + each) for each in res]
+                    return cmd
+                return set_cmd + res
         return res
 
     def render(self, data, parser_name, negate=False):

--- a/plugins/module_utils/network/common/network_template.py
+++ b/plugins/module_utils/network/common/network_template.py
@@ -70,7 +70,7 @@ class NetworkTemplate(object):
         res = [p for p in self._tmplt.PARSERS if p["name"] == name]
         return res[0]
 
-    def _render(self, tmplt, data, negate):
+    def _render(self, tmplt, data, negate, delete=False):
         try:
             if callable(tmplt):
                 res = tmplt(data)
@@ -80,14 +80,19 @@ class NetworkTemplate(object):
                 )
         except KeyError:
             return None
-        if res and negate:
+        if res and delete and negate:
+            if isinstance(res, list):
+                cmd = [re.sub('set ', 'delete ', each) for each in res]
+                return cmd
+            return re.sub('set ', 'delete ', res)
+        elif res and negate:
             if isinstance(res, list):
                 cmd = [("no " + each) for each in res]
                 return cmd
             return "no " + res
         return res
 
-    def render(self, data, parser_name, negate=False):
+    def render(self, data, parser_name, negate=False, delete=False):
         """ render
         """
         if negate:
@@ -97,5 +102,5 @@ class NetworkTemplate(object):
             )
         else:
             tmplt = self.get_parser(parser_name)["setval"]
-        command = self._render(tmplt, data, negate)
+        command = self._render(tmplt, data, negate, delete)
         return command

--- a/plugins/module_utils/network/common/resource_module.py
+++ b/plugins/module_utils/network/common/resource_module.py
@@ -83,10 +83,10 @@ class ResourceModule(object):  # pylint: disable=R0902
         result["changed"] = self.changed
         return result
 
-    def addcmd(self, data, tmplt, negate=False):
+    def addcmd(self, data, tmplt, negate=False, delete=False):
         """ addcmd
         """
-        command = self._tmplt.render(data, tmplt, negate)
+        command = self._tmplt.render(data, tmplt, negate, delete)
         if command:
             self.commands.extend(to_list(command))
 
@@ -125,7 +125,7 @@ class ResourceModule(object):  # pylint: disable=R0902
             return self._connection
         return None
 
-    def compare(self, parsers, want=None, have=None):
+    def compare(self, parsers, want=None, have=None, delete=False):
         """ Run through all the parsers and compare
             the want and have dicts
         """
@@ -152,9 +152,9 @@ class ResourceModule(object):  # pylint: disable=R0902
                     self.addcmd(want, parser, False)
             elif inw is None and inh is not None:
                 if isinstance(inh, bool):
-                    self.addcmd(have, parser, inh)
+                    self.addcmd(have, parser, inh, delete)
                 else:
-                    self.addcmd(have, parser, True)
+                    self.addcmd(have, parser, True, delete)
 
     def run_commands(self):
         """ Send commands to the device

--- a/plugins/module_utils/network/common/resource_module.py
+++ b/plugins/module_utils/network/common/resource_module.py
@@ -83,10 +83,10 @@ class ResourceModule(object):  # pylint: disable=R0902
         result["changed"] = self.changed
         return result
 
-    def addcmd(self, data, tmplt, negate=False, delete=False):
+    def addcmd(self, data, tmplt, negate=False):
         """ addcmd
         """
-        command = self._tmplt.render(data, tmplt, negate, delete)
+        command = self._tmplt.render(data, tmplt, negate)
         if command:
             self.commands.extend(to_list(command))
 
@@ -125,7 +125,7 @@ class ResourceModule(object):  # pylint: disable=R0902
             return self._connection
         return None
 
-    def compare(self, parsers, want=None, have=None, delete=False):
+    def compare(self, parsers, want=None, have=None):
         """ Run through all the parsers and compare
             the want and have dicts
         """
@@ -152,9 +152,9 @@ class ResourceModule(object):  # pylint: disable=R0902
                     self.addcmd(want, parser, False)
             elif inw is None and inh is not None:
                 if isinstance(inh, bool):
-                    self.addcmd(have, parser, inh, delete)
+                    self.addcmd(have, parser, inh)
                 else:
-                    self.addcmd(have, parser, True, delete)
+                    self.addcmd(have, parser, True)
 
     def run_commands(self):
         """ Send commands to the device


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>
##### SUMMARY

The _render function adds a 'no' to the config commands, when negate is set to True. 
This does not suit VYOS. In case of VYOS, `set` is replaced with `delete` to handle the negation of config commands.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

resource_module.py
network_template.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```


```
