### PR TITLE
Add support for private key based authentication with libssh transport

### DIFF
--- a/changelogs/fragments/168-libssh-privatekey-support.yaml
+++ b/changelogs/fragments/168-libssh-privatekey-support.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Added support for private key based authentication with libssh transport
+    (https://github.com/ansible-collections/ansible.netcommon/issues/168)

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -301,6 +301,16 @@ class Connection(ConnectionBase):
         proxy_command = self._get_proxy_command(port)
 
         try:
+            private_key = None
+            if self._play_context.private_key_file:
+                with open(
+                    os.path.expanduser(self._play_context.private_key_file)
+                ) as fp:
+                    b_content = fp.read()
+                    private_key = to_bytes(
+                        b_content, errors="surrogate_or_strict"
+                    )
+
             if proxy_command:
                 ssh_connect_kwargs["proxycommand"] = proxy_command
 
@@ -314,6 +324,7 @@ class Connection(ConnectionBase):
                 look_for_keys=self.get_option("look_for_keys"),
                 host_key_checking=self.get_option("host_key_checking"),
                 password=self._play_context.password,
+                private_key=private_key,
                 timeout=self._play_context.timeout,
                 port=port,
                 **ssh_connect_kwargs


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes
https://github.com/ansible-collections/ansible.netcommon/issues/168

*  If the private key file is provided in task read it in the libssh
   connection plugin and pass it to the libssh ``connect()`` method
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
connection/libssh.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
---
- hosts: ios
  gather_facts: no
  connection: ansible.netcommon.network_cli
  tasks:
    - name: Ensure ssh key is not world readable
      file:
        path: './files/test_rsa'
        mode: 384

    - name: test with {{ ansible_user }} user
      cisco.ios.ios_command:
        commands:
          - show version

    - name: reset connection with {{ ansible_user }
      meta: reset_connection

    - name: test with {{ ansible_user }} user
      cisco.ios.ios_command:
        commands:
          - show version
      vars:
        ansible_user: ssh_user
        ansible_private_key_file: "./files/test_rsa"

    - name: reset connection with {{ ansible_user }}
      meta: reset_connection

    - name: test with {{ ansible_user }} user without keys
      cisco.ios.ios_command:
        commands:
          - show version
      ignore_errors: true
      register: results
      vars:
        ansible_user: ssh_user
        ansible_private_key_file: ""

    - name: reset connection with {{ ansible_user }}
      meta: reset_connection

    - name: check that attempt failed
      assert:
        that:
          - results.failed
```
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/682