### PR TITLE
Add ansible_network_direct_execution

### DIFF
--- a/changelogs/fragments/ansible_network_direct_execution.yaml
+++ b/changelogs/fragments/ansible_network_direct_execution.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Reduce CPU usage and network module run time when using `ansible_network_direct_execution`

--- a/changelogs/fragments/ansible_network_direct_execution.yaml
+++ b/changelogs/fragments/ansible_network_direct_execution.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - Reduce CPU usage and network module run time when using `ansible_network_direct_execution`
+  - Reduce CPU usage and network module run time when using `ansible_network_import_modules`

--- a/docs/ansible.netcommon.httpapi_connection.rst
+++ b/docs/ansible.netcommon.httpapi_connection.rst
@@ -84,29 +84,6 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>direct_execution</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">boolean</span>
-                    </div>
-                </td>
-                <td>
-                        <b>Default:</b><br/><div style="color: blue">"no"</div>
-                </td>
-                    <td>
-                            <div> ini entries:
-                                    <p>[ansible_network]<br>direct_execution = no</p>
-                            </div>
-                                <div>env:ANSIBLE_NETWORK_DIRECT_EXECUTION</div>
-                                <div>var: ansible_network_direct_execution</div>
-                    </td>
-                <td>
-                        <div>Reduce CPU usage and network module execution time by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process. Note- Incompatible with <code>asynchronous mode</code>. Note- Python 3 and Ansible 2.9.16 or greater required. Note- With Ansible 2.9.x fully qualified modules names are required in tasks.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -121,6 +98,29 @@ Parameters
                     </td>
                 <td>
                         <div>Specifies the remote device FQDN or IP address to establish the HTTP(S) connection to.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>import_modules</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"no"</div>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[ansible_network]<br>import_modules = no</p>
+                            </div>
+                                <div>env:ANSIBLE_NETWORK_IMPORT_MODULES</div>
+                                <div>var: ansible_network_import_modules</div>
+                    </td>
+                <td>
+                        <div>Reduce CPU usage and network module execution time by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process. Note- Incompatible with <code>asynchronous mode</code>. Note- Python 3 and Ansible 2.9.16 or greater required. Note- With Ansible 2.9.x fully qualified modules names are required in tasks.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/ansible.netcommon.httpapi_connection.rst
+++ b/docs/ansible.netcommon.httpapi_connection.rst
@@ -101,7 +101,7 @@ Parameters
                                 <div>var: ansible_network_direct_execution</div>
                     </td>
                 <td>
-                        <div>Gain potential preformance improvements for network modules by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process.</div>
+                        <div>Reduce CPU usage and network module execution time by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process. Note- Incompatible with <code>asynchronous mode</code>. Note- Python 3 and Ansible 2.9.16 or greater required. Note- With Ansible 2.9.x fully qualified modules names are required in tasks.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/ansible.netcommon.httpapi_connection.rst
+++ b/docs/ansible.netcommon.httpapi_connection.rst
@@ -84,6 +84,29 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>direct_execution</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"no"</div>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[ansible_network]<br>direct_execution = no</p>
+                            </div>
+                                <div>env:ANSIBLE_NETWORK_DIRECT_EXECUTION</div>
+                                <div>var: ansible_network_direct_execution</div>
+                    </td>
+                <td>
+                        <div>Gain potential preformance for network modules by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/docs/ansible.netcommon.httpapi_connection.rst
+++ b/docs/ansible.netcommon.httpapi_connection.rst
@@ -101,7 +101,7 @@ Parameters
                                 <div>var: ansible_network_direct_execution</div>
                     </td>
                 <td>
-                        <div>Gain potential preformance for network modules by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process.</div>
+                        <div>Gain potential preformance improvements for network modules by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/ansible.netcommon.netconf_connection.rst
+++ b/docs/ansible.netcommon.netconf_connection.rst
@@ -44,6 +44,29 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>direct_execution</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"no"</div>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[ansible_network]<br>direct_execution = no</p>
+                            </div>
+                                <div>env:ANSIBLE_NETWORK_DIRECT_EXECUTION</div>
+                                <div>var: ansible_network_direct_execution</div>
+                    </td>
+                <td>
+                        <div>Gain potential preformance for network modules by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/docs/ansible.netcommon.netconf_connection.rst
+++ b/docs/ansible.netcommon.netconf_connection.rst
@@ -61,7 +61,7 @@ Parameters
                                 <div>var: ansible_network_direct_execution</div>
                     </td>
                 <td>
-                        <div>Gain potential preformance for network modules by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process.</div>
+                        <div>Gain potential preformance improvements for network modules by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/ansible.netcommon.netconf_connection.rst
+++ b/docs/ansible.netcommon.netconf_connection.rst
@@ -44,29 +44,6 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>direct_execution</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">boolean</span>
-                    </div>
-                </td>
-                <td>
-                        <b>Default:</b><br/><div style="color: blue">"no"</div>
-                </td>
-                    <td>
-                            <div> ini entries:
-                                    <p>[ansible_network]<br>direct_execution = no</p>
-                            </div>
-                                <div>env:ANSIBLE_NETWORK_DIRECT_EXECUTION</div>
-                                <div>var: ansible_network_direct_execution</div>
-                    </td>
-                <td>
-                        <div>Reduce CPU usage and network module execution time by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process. Note- Incompatible with <code>asynchronous mode</code>. Note- Python 3 and Ansible 2.9.16 or greater required. Note- With Ansible 2.9.x fully qualified modules names are required in tasks.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -109,6 +86,29 @@ Parameters
                     </td>
                 <td>
                         <div>Set this to &quot;False&quot; if you want to avoid host key checking by the underlying tools Ansible uses to connect to the host</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>import_modules</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"no"</div>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[ansible_network]<br>import_modules = no</p>
+                            </div>
+                                <div>env:ANSIBLE_NETWORK_IMPORT_MODULES</div>
+                                <div>var: ansible_network_import_modules</div>
+                    </td>
+                <td>
+                        <div>Reduce CPU usage and network module execution time by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process. Note- Incompatible with <code>asynchronous mode</code>. Note- Python 3 and Ansible 2.9.16 or greater required. Note- With Ansible 2.9.x fully qualified modules names are required in tasks.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/ansible.netcommon.netconf_connection.rst
+++ b/docs/ansible.netcommon.netconf_connection.rst
@@ -61,7 +61,7 @@ Parameters
                                 <div>var: ansible_network_direct_execution</div>
                     </td>
                 <td>
-                        <div>Gain potential preformance improvements for network modules by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process.</div>
+                        <div>Reduce CPU usage and network module execution time by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process. Note- Incompatible with <code>asynchronous mode</code>. Note- Python 3 and Ansible 2.9.16 or greater required. Note- With Ansible 2.9.x fully qualified modules names are required in tasks.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/ansible.netcommon.network_cli_connection.rst
+++ b/docs/ansible.netcommon.network_cli_connection.rst
@@ -101,7 +101,7 @@ Parameters
                                 <div>var: ansible_network_direct_execution</div>
                     </td>
                 <td>
-                        <div>Gain potential preformance improvements for network modules by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process.</div>
+                        <div>Reduce CPU usage and network module execution time by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process. Note- Incompatible with <code>asynchronous mode</code>. Note- Python 3 and Ansible 2.9.16 or greater required. Note- With Ansible 2.9.x fully qualified modules names are required in tasks.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/ansible.netcommon.network_cli_connection.rst
+++ b/docs/ansible.netcommon.network_cli_connection.rst
@@ -84,6 +84,29 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>direct_execution</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"no"</div>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[ansible_network]<br>direct_execution = no</p>
+                            </div>
+                                <div>env:ANSIBLE_NETWORK_DIRECT_EXECUTION</div>
+                                <div>var: ansible_network_direct_execution</div>
+                    </td>
+                <td>
+                        <div>Gain potential preformance for network modules by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/docs/ansible.netcommon.network_cli_connection.rst
+++ b/docs/ansible.netcommon.network_cli_connection.rst
@@ -101,7 +101,7 @@ Parameters
                                 <div>var: ansible_network_direct_execution</div>
                     </td>
                 <td>
-                        <div>Gain potential preformance for network modules by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process.</div>
+                        <div>Gain potential preformance improvements for network modules by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/ansible.netcommon.network_cli_connection.rst
+++ b/docs/ansible.netcommon.network_cli_connection.rst
@@ -84,29 +84,6 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>direct_execution</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">boolean</span>
-                    </div>
-                </td>
-                <td>
-                        <b>Default:</b><br/><div style="color: blue">"no"</div>
-                </td>
-                    <td>
-                            <div> ini entries:
-                                    <p>[ansible_network]<br>direct_execution = no</p>
-                            </div>
-                                <div>env:ANSIBLE_NETWORK_DIRECT_EXECUTION</div>
-                                <div>var: ansible_network_direct_execution</div>
-                    </td>
-                <td>
-                        <div>Reduce CPU usage and network module execution time by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process. Note- Incompatible with <code>asynchronous mode</code>. Note- Python 3 and Ansible 2.9.16 or greater required. Note- With Ansible 2.9.x fully qualified modules names are required in tasks.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -144,6 +121,29 @@ Parameters
                 <td>
                         <div>By default, Ansible will prompt the user before adding SSH keys to the known hosts file.  Since persistent connections such as network_cli run in background processes, the user will never be prompted.  By enabling this option, unknown host keys will automatically be added to the known hosts file.</div>
                         <div>Be sure to fully understand the security implications of enabling this option on production systems as it could create a security vulnerability.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>import_modules</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"no"</div>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[ansible_network]<br>import_modules = no</p>
+                            </div>
+                                <div>env:ANSIBLE_NETWORK_IMPORT_MODULES</div>
+                                <div>var: ansible_network_import_modules</div>
+                    </td>
+                <td>
+                        <div>Reduce CPU usage and network module execution time by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process. Note- Incompatible with <code>asynchronous mode</code>. Note- Python 3 and Ansible 2.9.16 or greater required. Note- With Ansible 2.9.x fully qualified modules names are required in tasks.</div>
                 </td>
             </tr>
             <tr>

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,4 +10,4 @@ repository: https://github.com/ansible-collections/ansible.netcommon
 tags: [networking, security, cloud, network_cli, netconf, httpapi, grpc]
 # NOTE(pabelanger): We create an empty version key to keep ansible-galaxy
 # happy. We dynamically inject version info based on git information.
-version: null
+version: 1

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,4 +10,4 @@ repository: https://github.com/ansible-collections/ansible.netcommon
 tags: [networking, security, cloud, network_cli, netconf, httpapi, grpc]
 # NOTE(pabelanger): We create an empty version key to keep ansible-galaxy
 # happy. We dynamically inject version info based on git information.
-version: 1
+version: null

--- a/plugins/action/cli_command.py
+++ b/plugins/action/cli_command.py
@@ -20,10 +20,11 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.plugins.action.normal import ActionModule as _ActionModule
+from ansible_collections.ansible.netcommon.plugins.action.network import (
+    ActionModule as ActionNetworkModule,
+)
 
-
-class ActionModule(_ActionModule):
+class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         if self._play_context.connection.split(".")[-1] != "network_cli":
             return {
@@ -31,5 +32,4 @@ class ActionModule(_ActionModule):
                 "msg": "Connection type %s is not valid for this module"
                 % self._play_context.connection,
             }
-
         return super(ActionModule, self).run(task_vars=task_vars)

--- a/plugins/action/cli_command.py
+++ b/plugins/action/cli_command.py
@@ -24,6 +24,7 @@ from ansible_collections.ansible.netcommon.plugins.action.network import (
     ActionModule as ActionNetworkModule,
 )
 
+
 class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         if self._play_context.connection.split(".")[-1] != "network_cli":

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -46,10 +46,12 @@ class ActionModule(_ActionModule):
             except AnsibleError as exc:
                 return dict(failed=True, msg=to_text(exc))
 
-        direct_execution = self.get_connection_option('direct_execution')
-        ansible_host = task_vars['ansible_host']
-        prefix = "<{ah}> ANSIBLE_NETWORK_DIRECT_EXECUTION: ".format(ah=ansible_host)
-        # if direct_execution: 
+        direct_execution = self.get_connection_option("direct_execution")
+        ansible_host = task_vars["ansible_host"]
+        prefix = "<{ah}> ANSIBLE_NETWORK_DIRECT_EXECUTION: ".format(
+            ah=ansible_host
+        )
+        # if direct_execution:
         if PY3:  # FIXME
             display.vvvv("{prefix} enabled".format(prefix=prefix))
 
@@ -64,7 +66,11 @@ class ActionModule(_ActionModule):
 
             mloadr = self._shared_loader_obj.module_loader
             filename = mloadr.find_plugin(self._task.action)
-            display.vvvv("{prefix} loading {fname}".format(prefix=prefix, fname=filename))
+            display.vvvv(
+                "{prefix} loading {fname}".format(
+                    prefix=prefix, fname=filename
+                )
+            )
 
             spec = importlib.util.spec_from_file_location(
                 self._task.action, filename
@@ -129,7 +135,11 @@ class ActionModule(_ActionModule):
             result = module_result
         else:
             display.vvvv("{prefix} disabled".format(prefix=prefix))
-            display.vvvv("{prefix} playbook execution time may be extended".format(prefix=prefix))
+            display.vvvv(
+                "{prefix} playbook execution time may be extended".format(
+                    prefix=prefix
+                )
+            )
 
             result = super(ActionModule, self).run(task_vars=task_vars)
 

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -57,7 +57,6 @@ class ActionModule(_ActionModule):
 
             import importlib
             import io
-            import json
             import sys
             from ansible.module_utils.basic import (
                 AnsibleModule as _AnsibleModule,

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -49,7 +49,7 @@ class ActionModule(_ActionModule):
         dexec_prefix = "ANSIBLE_NETWORK_DIRECT_EXECUTION:"
         host = task_vars["ansible_host"]
 
-        FIXME:  REMOVE ME BEFORE MERGE
+        # FIXME:  REMOVE ME BEFORE MERGE
         if PY3:
             direct_execution = True
 
@@ -279,7 +279,7 @@ class ActionModule(_ActionModule):
         import importlib
 
         mloadr = self._shared_loader_obj.module_loader
-       
+
         # find the module & import
         filename = mloadr.find_plugin(
             self._task.action, collection_list=self._task.collections

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -31,7 +31,6 @@ from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.display import Display
 from ansible.module_utils.six import PY3
 
-
 display = Display()
 
 PRIVATE_KEYS_RE = re.compile("__.+__")

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -46,8 +46,8 @@ class ActionModule(_ActionModule):
             except AnsibleError as exc:
                 return dict(failed=True, msg=to_text(exc))
 
-        make_fast = task_vars.get("ansible_network_make_fast")
-        if make_fast or True and PY3:  # FIXME
+    
+        if PY3:  # FIXME
             display.vvvv("1220 Platform performance enhancements enabled")
 
             import importlib
@@ -113,6 +113,8 @@ class ActionModule(_ActionModule):
             )
 
             # load the json from module exit_json or fail_json
+            display.vvvv("1220 Recevied the following stdout from module")
+            display.vvvv(output)
             result = json.loads(output)
         else:
             result = super(ActionModule, self).run(task_vars=task_vars)
@@ -123,6 +125,9 @@ class ActionModule(_ActionModule):
             and not result.get("failed")
         ):
             self._handle_backup_option(result, task_vars)
+
+        if 'stdout' in result and 'stdout_lines' not in result:
+            result['stdout_lines'] = result['stdout'].splitlines()
 
         return result
 

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -116,6 +116,14 @@ class ActionModule(_ActionModule):
             display.vvvv(output)
 
             # load the response
+            module_result = json.loads(output)
+
+            # TODO: figure out why this is necessary
+            # arista/eos/tests/integration/targets/eos_l2_interface/tests/eapi/no_interface.yaml:35
+            
+            if 'warnings' in module_result and not module_result['warnings']:
+                del module_result['warnings']
+
             result = json.loads(output)
         else:
             result = super(ActionModule, self).run(task_vars=task_vars)

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -49,9 +49,9 @@ class ActionModule(_ActionModule):
         dexec_prefix = "ANSIBLE_NETWORK_DIRECT_EXECUTION:"
         host = task_vars["ansible_host"]
 
-        # FIXME:  REMOVE ME BEFORE MERGE
-        # if PY3:
-        #     direct_execution = True
+        FIXME:  REMOVE ME BEFORE MERGE
+        if PY3:
+            direct_execution = True
 
         if dexec:
             display.vvvv(
@@ -279,7 +279,7 @@ class ActionModule(_ActionModule):
         import importlib
 
         mloadr = self._shared_loader_obj.module_loader
-
+       
         # find the module & import
         filename = mloadr.find_plugin(
             self._task.action, collection_list=self._task.collections
@@ -290,6 +290,7 @@ class ActionModule(_ActionModule):
         )
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
+
         return filename, module
 
     def _patch_update_module(self, module, task_vars):

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -50,8 +50,8 @@ class ActionModule(_ActionModule):
         host = task_vars["ansible_host"]
 
         # FIXME:  REMOVE ME BEFORE MERGE
-        if PY3:
-            dexec = True
+        # if PY3:
+        #     dexec = True
 
         if dexec:
             display.vvvv(
@@ -365,7 +365,18 @@ class ActionModule(_ActionModule):
             "stderr": stderr,
             "stderr_lines": stderr.splitlines(),
         }
-        module_result = self._parse_returned_data(dict_out)
+        data = self._parse_returned_data(dict_out)
         # Clean up the response like action _execute_module
-        remove_internal_keys(module_result)
-        return module_result
+        remove_internal_keys(data)
+
+        # split stdout/stderr into lines if needed
+        if "stdout" in data and "stdout_lines" not in data:
+            # if the value is 'False', a default won't catch it.
+            txt = data.get("stdout", None) or u""
+            data["stdout_lines"] = txt.splitlines()
+        if "stderr" in data and "stderr_lines" not in data:
+            # if the value is 'False', a default won't catch it.
+            txt = data.get("stderr", None) or u""
+            data["stderr_lines"] = txt.splitlines()
+
+        return data

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -49,11 +49,7 @@ class ActionModule(_ActionModule):
         dexec_prefix = "ANSIBLE_NETWORK_DIRECT_EXECUTION:"
         host = task_vars["ansible_host"]
 
-        # FIXME:  REMOVE ME BEFORE MERGE
-        if PY3:
-            dexec = True
-
-        if dexec:
+        if dexec and PY3:
             display.vvvv(
                 "{prefix} enabled".format(prefix=dexec_prefix), host=host
             )
@@ -82,7 +78,10 @@ class ActionModule(_ActionModule):
                 result = self._exec_module(module)
                 # dump the result
                 display.vvvv(
-                    "{prefix} complete. Result: {result}".format(
+                    "{prefix} complete.".format(prefix=dexec_prefix), host
+                )
+                display.vvvvv(
+                    "{prefix} Result: {result}".format(
                         prefix=dexec_prefix, result=result
                     ),
                     host,
@@ -342,8 +341,6 @@ class ActionModule(_ActionModule):
         sys.stdout = io.StringIO()
 
         # run the module, catch the SystemExit so we continue
-        # capture sys.stdout as stdout
-        # capture str(Exception) as stderr
         try:
             module.main()
         except SystemExit:
@@ -351,7 +348,7 @@ class ActionModule(_ActionModule):
             stdout = sys.stdout.getvalue()
             stderr = ""
         except Exception as exc:
-            # dirty module or connection
+            # dirty module or connection traceback
             stderr = to_native(exc)
             stdout = ""
 

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -48,6 +48,8 @@ class ActionModule(_ActionModule):
 
         make_fast = task_vars.get("ansible_network_make_fast")
         if make_fast or True and PY3:  # FIXME
+            display.vvvv("1220 Platform performance enhancements enabled")
+
             import importlib, io, json, sys
             from ansible.module_utils.basic import (
                 AnsibleModule as _AnsibleModule,
@@ -55,6 +57,8 @@ class ActionModule(_ActionModule):
 
             mloadr = self._shared_loader_obj.module_loader
             filename = mloadr.find_plugin(self._task.action)
+            display.vvvv("1220 loading {fname}".format(fname=filename))
+
             spec = importlib.util.spec_from_file_location(
                 self._task.action, filename
             )
@@ -78,6 +82,13 @@ class ActionModule(_ActionModule):
             module.AnsibleModule = AnsibleModule
 
             # redirect stdout to a buffer, because the module "prints"
+            display.vvvv(
+                "1220 capturing stdout, running main from {fname}".format(
+                    fname=filename
+                )
+            )
+            display.vvvv("1220 please remain quiet")
+
             stdout = sys.stdout
             sys.stdout = io.StringIO()
 
@@ -92,6 +103,11 @@ class ActionModule(_ActionModule):
 
             # restore stdout
             sys.stdout = stdout
+            display.vvvv(
+                "1220 stdout restored, ran main from {fname}".format(
+                    fname=filename
+                )
+            )
 
             # load the json from module exit_json or fail_json
             result = json.loads(output)

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -50,7 +50,10 @@ class ActionModule(_ActionModule):
         if make_fast or True and PY3:  # FIXME
             display.vvvv("1220 Platform performance enhancements enabled")
 
-            import importlib, io, json, sys
+            import importlib
+            import io
+            import json
+            import sys
             from ansible.module_utils.basic import (
                 AnsibleModule as _AnsibleModule,
             )
@@ -75,7 +78,7 @@ class ActionModule(_ActionModule):
                 self._task.action, self._task.args, task_vars
             )
 
-            # set the params of the ansible module cause we're using stdin
+            # set the params of the ansible module cause we're not using stdin
             AnsibleModule.params = self._task.args
 
             # give the module our revised AnsibleModule

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -260,9 +260,6 @@ class ActionModule(_ActionModule):
         """
         dexec = self.get_connection_option("direct_execution")
 
-        # FIXME: Prior to a merge
-        dexec = True
-
         # log early about dexec
         if dexec:
             display.vvvv(

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -60,6 +60,7 @@ class ActionModule(_ActionModule):
             from ansible.module_utils.basic import (
                 AnsibleModule as _AnsibleModule,
             )
+            from ansible.vars.clean import remove_internal_keys
 
             mloadr = self._shared_loader_obj.module_loader
             filename = mloadr.find_plugin(self._task.action)
@@ -123,7 +124,6 @@ class ActionModule(_ActionModule):
             module_result = json.loads(output)
 
             # Clean up the response like action _execute_module
-            from ansible.vars.clean import remove_internal_keys
             remove_internal_keys(module_result)
             display.vvvv("{prefix} complete".format(prefix=prefix))
             result = module_result

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -261,7 +261,7 @@ class ActionModule(_ActionModule):
         dexec = self.get_connection_option("direct_execution")
 
         # FIXME: Prior to a merge
-        dexec_eligible = True
+        dexec = True
 
         # log early about dexec
         if dexec:

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -115,9 +115,6 @@ class ActionModule(_ActionModule):
         ):
             self._handle_backup_option(result, task_vars)
 
-        if "stdout" in result and "stdout_lines" not in result:
-            result["stdout_lines"] = result["stdout"].splitlines()
-
         return result
 
     def _handle_backup_option(self, result, task_vars):

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -302,6 +302,7 @@ class ActionModule(_ActionModule):
         :param task_vars: The vars provided to the task
         :type task_vars: dict
         """
+        import copy
         from ansible.module_utils.basic import AnsibleModule as _AnsibleModule
 
         # build an AnsibleModule that doesn't load params
@@ -313,7 +314,8 @@ class ActionModule(_ActionModule):
         self._update_module_args(self._task.action, self._task.args, task_vars)
 
         # set the params of the ansible module cause we're not using stdin
-        PatchedAnsibleModule.params = self._task.args
+        # use a copy so the module doesn't change the original task args
+        PatchedAnsibleModule.params = copy.deepcopy(self._task.args)
 
         # give the module our revised AnsibleModule
         module.AnsibleModule = PatchedAnsibleModule

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -322,7 +322,7 @@ class ActionModule(_ActionModule):
             filename = context.plugin_resolved_path
             module = importlib.import_module(context.plugin_resolved_name)
         # 2.9
-        except AttributeError as _exc:
+        except AttributeError:
             fullname, filename = mloadr.find_plugin_with_name(
                 self._task.action, collection_list=self._task.collections
             )

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -120,11 +120,10 @@ class ActionModule(_ActionModule):
 
             # TODO: figure out why this is necessary
             # arista/eos/tests/integration/targets/eos_l2_interface/tests/eapi/no_interface.yaml:35
-            
+
             if 'warnings' in module_result and not module_result['warnings']:
                 del module_result['warnings']
-
-            result = json.loads(output)
+            result = module_result
         else:
             result = super(ActionModule, self).run(task_vars=task_vars)
 

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -50,8 +50,8 @@ class ActionModule(_ActionModule):
         host = task_vars["ansible_host"]
 
         # FIXME:  REMOVE ME BEFORE MERGE
-        # if PY3:
-        #     dexec = True
+        if PY3:
+            dexec = True
 
         if dexec:
             display.vvvv(

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -51,7 +51,7 @@ class ActionModule(_ActionModule):
 
         # FIXME:  REMOVE ME BEFORE MERGE
         if PY3:
-            direct_execution = True
+            dexec = True
 
         if dexec:
             display.vvvv(

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -118,11 +118,9 @@ class ActionModule(_ActionModule):
             # load the response
             module_result = json.loads(output)
 
-            # TODO: figure out why this is necessary
-            # arista/eos/tests/integration/targets/eos_l2_interface/tests/eapi/no_interface.yaml:35
-
-            if 'warnings' in module_result and not module_result['warnings']:
-                del module_result['warnings']
+            # Clean up the response like action _execute_module
+            from ansible.vars.clean import remove_internal_keys
+            remove_internal_keys(module_result)
             result = module_result
         else:
             result = super(ActionModule, self).run(task_vars=task_vars)

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -34,7 +34,7 @@ from ansible.module_utils.six import PY3
 display = Display()
 
 PRIVATE_KEYS_RE = re.compile("__.+__")
-DEXEC_PREFIX = "ANSIBLE_NETWORK_DIRECT_EXECUTION:"
+DEXEC_PREFIX = "ANSIBLE_NETWORK_IMPORT_MODULES:"
 
 
 class ActionModule(_ActionModule):
@@ -258,7 +258,7 @@ class ActionModule(_ActionModule):
     def _check_dexec_eligibility(self, host):
         """ Check if current python and task are eligble
         """
-        dexec = self.get_connection_option("direct_execution")
+        dexec = self.get_connection_option("import_modules")
 
         # log early about dexec
         if dexec:

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -50,8 +50,8 @@ class ActionModule(_ActionModule):
         host = task_vars["ansible_host"]
 
         # FIXME:  REMOVE ME BEFORE MERGE
-        if PY3:
-            direct_execution = True
+        # if PY3:
+        #     direct_execution = True
 
         if dexec:
             display.vvvv(
@@ -89,7 +89,7 @@ class ActionModule(_ActionModule):
                 )
 
             else:
-                direct_execution = False
+                dexec = False
                 display.vvvv(
                     "{prefix} {module} doesn't support direct execution".format(
                         prefix=dexec_prefix, module=self._task.action
@@ -97,7 +97,7 @@ class ActionModule(_ActionModule):
                     host,
                 )
 
-        if not direct_execution:
+        if not dexec:
             display.vvvv("{prefix} disabled".format(prefix=dexec_prefix), host)
             display.vvvv(
                 "{prefix} module execution time may be extended".format(

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -95,11 +95,11 @@ class ActionModule(_ActionModule):
             stdout = sys.stdout
             sys.stdout = io.StringIO()
 
-            # redefine sys.exit, otherwise the module exits & dead worker
-            sys.exit = lambda x: None
-
-            # run the module
-            module.main()
+            # run the module, catch the SystemExit so we continue
+            try:
+                module.main()
+            except SystemExit:
+                pass
 
             # capture the module's output
             output = sys.stdout.getvalue()
@@ -114,25 +114,9 @@ class ActionModule(_ActionModule):
 
             display.vvvv("1220 module ran got:")
             display.vvvv(output)
+
             # load the response
-            try:
-                result = json.loads(output)
-            except json.decoder.JSONDecodeError as exc:
-                display.vvvv(
-                    "1220 json decode error: {err}".format(err=str(exc))
-                )
-                display.vvvv("1220 sometime we get 2 json dicts")
-                try:
-                    display.vvvv("1220 using the first json dict")
-                    result = json.loads(output.split("\n\n")[0])
-                except json.decoder.JSONDecodeError as exc:
-                    display.vvvv("1220 using the first json dict")
-                    display.vvvv(
-                        "1220 final json decode error: {err}".format(
-                            err=str(exc)
-                        )
-                    )
-                    result = {"stdout": output}
+            result = json.loads(output)
         else:
             result = super(ActionModule, self).run(task_vars=task_vars)
 

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -44,10 +44,12 @@ class ActionModule(_ActionModule):
             except AnsibleError as exc:
                 return dict(failed=True, msg=to_text(exc))
 
-        make_fast = task_vars.get('ansible_network_make_fast')
-        if make_fast or True:  #FIXME
+        make_fast = task_vars.get("ansible_network_make_fast")
+        if make_fast or True:  # FIXME
             import importlib, io, json, sys
-            from ansible.module_utils.basic import AnsibleModule as _AnsibleModule
+            from ansible.module_utils.basic import (
+                AnsibleModule as _AnsibleModule,
+            )
 
             # get the loader, module file name and import
             mloadr = self._shared_loader_obj.module_loader
@@ -60,9 +62,11 @@ class ActionModule(_ActionModule):
             class AnsibleModule(_AnsibleModule):
                 def _load_params(self):
                     pass
-            
+
             # update the task args w/ all the magic vars
-            self._update_module_args(self._task.action, self._task.args, task_vars)
+            self._update_module_args(
+                self._task.action, self._task.args, task_vars
+            )
 
             # set the params of the ansible module cause we're using stdin
             AnsibleModule.params = self._task.args

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -29,6 +29,8 @@ from ansible.module_utils._text import to_text, to_bytes
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.display import Display
+from ansible.module_utils.six import PY3
+
 
 display = Display()
 
@@ -45,16 +47,17 @@ class ActionModule(_ActionModule):
                 return dict(failed=True, msg=to_text(exc))
 
         make_fast = task_vars.get("ansible_network_make_fast")
-        if make_fast or True:  # FIXME
+        if make_fast or True and PY3:  # FIXME
             import importlib, io, json, sys
             from ansible.module_utils.basic import (
                 AnsibleModule as _AnsibleModule,
             )
 
-            # get the loader, module file name and import
             mloadr = self._shared_loader_obj.module_loader
             filename = mloadr.find_plugin(self._task.action)
-            spec = importlib.util.spec_from_file_location("module", filename)
+            spec = importlib.util.spec_from_file_location(
+                self._task.action, filename
+            )
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
 

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -314,12 +314,19 @@ class ActionModule(_ActionModule):
 
         mloadr = self._shared_loader_obj.module_loader
 
-        context = mloadr.find_plugin_with_context(
-            self._task.action, collection_list=self._task.collections
-        )
-        filename = context.plugin_resolved_path
-        module = importlib.import_module(context.plugin_resolved_name)
-
+        # 2.10
+        try:
+            context = mloadr.find_plugin_with_context(
+                self._task.action, collection_list=self._task.collections
+            )
+            filename = context.plugin_resolved_path
+            module = importlib.import_module(context.plugin_resolved_name)
+        # 2.9
+        except AttributeError as _exc:
+            fullname, filename = mloadr.find_plugin_with_name(
+                self._task.action, collection_list=self._task.collections
+            )
+            module = importlib.import_module(fullname)
         return filename, module
 
     def _patch_update_module(self, module, task_vars):

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -14,6 +14,21 @@ description:
   api.
 version_added: 1.0.0
 options:
+  direct_execution:
+    type: boolean
+    description:
+    - Gain potential preformance for network modules by enabling direct execution.
+      Instead of the module being packaged and executed by the shell, it will
+      be directly executed by the Ansible control node using the same python interpreter
+      as the Ansible process.
+    default: false
+    ini:
+    - section: ansible_network
+      key: direct_execution
+    env:
+    - name: ANSIBLE_NETWORK_DIRECT_EXECUTION
+    vars:
+    - name: ansible_network_direct_execution
   host:
     description:
     - Specifies the remote device FQDN or IP address to establish the HTTP(S) connection

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -17,10 +17,10 @@ options:
   direct_execution:
     type: boolean
     description:
-    - Gain potential preformance for network modules by enabling direct execution.
-      Instead of the module being packaged and executed by the shell, it will
-      be directly executed by the Ansible control node using the same python interpreter
-      as the Ansible process.
+    - Gain potential preformance improvements for network modules
+      by enabling direct execution. Instead of the module being packaged 
+      and executed by the shell, it will be directly executed by the Ansible 
+      control node using the same python interpreter as the Ansible process.
     default: false
     ini:
     - section: ansible_network

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -14,7 +14,7 @@ description:
   api.
 version_added: 1.0.0
 options:
-  direct_execution:
+  import_modules:
     type: boolean
     description:
     - Reduce CPU usage and network module execution time
@@ -27,11 +27,11 @@ options:
     default: false
     ini:
     - section: ansible_network
-      key: direct_execution
+      key: import_modules
     env:
-    - name: ANSIBLE_NETWORK_DIRECT_EXECUTION
+    - name: ANSIBLE_NETWORK_IMPORT_MODULES
     vars:
-    - name: ansible_network_direct_execution
+    - name: ansible_network_import_modules
   host:
     description:
     - Specifies the remote device FQDN or IP address to establish the HTTP(S) connection

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -18,8 +18,8 @@ options:
     type: boolean
     description:
     - Gain potential preformance improvements for network modules
-      by enabling direct execution. Instead of the module being packaged 
-      and executed by the shell, it will be directly executed by the Ansible 
+      by enabling direct execution. Instead of the module being packaged
+      and executed by the shell, it will be directly executed by the Ansible
       control node using the same python interpreter as the Ansible process.
     default: false
     ini:

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -17,10 +17,13 @@ options:
   direct_execution:
     type: boolean
     description:
-    - Gain potential preformance improvements for network modules
+    - Reduce CPU usage and network module execution time
       by enabling direct execution. Instead of the module being packaged
       and executed by the shell, it will be directly executed by the Ansible
       control node using the same python interpreter as the Ansible process.
+      Note- Incompatible with C(asynchronous mode).
+      Note- Python 3 and Ansible 2.9.16 or greater required.
+      Note- With Ansible 2.9.x fully qualified modules names are required in tasks.
     default: false
     ini:
     - section: ansible_network

--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -23,10 +23,13 @@ options:
   direct_execution:
     type: boolean
     description:
-    - Gain potential preformance improvements for network modules
+    - Reduce CPU usage and network module execution time
       by enabling direct execution. Instead of the module being packaged
       and executed by the shell, it will be directly executed by the Ansible
       control node using the same python interpreter as the Ansible process.
+      Note- Incompatible with C(asynchronous mode).
+      Note- Python 3 and Ansible 2.9.16 or greater required.
+      Note- With Ansible 2.9.x fully qualified modules names are required in tasks.
     default: false
     ini:
     - section: ansible_network

--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -20,7 +20,7 @@ version_added: 1.0.0
 requirements:
 - ncclient
 options:
-  direct_execution:
+  import_modules:
     type: boolean
     description:
     - Reduce CPU usage and network module execution time
@@ -33,11 +33,11 @@ options:
     default: false
     ini:
     - section: ansible_network
-      key: direct_execution
+      key: import_modules
     env:
-    - name: ANSIBLE_NETWORK_DIRECT_EXECUTION
+    - name: ANSIBLE_NETWORK_IMPORT_MODULES
     vars:
-    - name: ansible_network_direct_execution
+    - name: ansible_network_import_modules
   host:
     description:
     - Specifies the remote device FQDN or IP address to establish the SSH connection

--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -20,6 +20,21 @@ version_added: 1.0.0
 requirements:
 - ncclient
 options:
+  direct_execution:
+    type: boolean
+    description:
+    - Gain potential preformance for network modules by enabling direct execution.
+      Instead of the module being packaged and executed by the shell, it will
+      be directly executed by the Ansible control node using the same python interpreter
+      as the Ansible process.
+    default: false
+    ini:
+    - section: ansible_network
+      key: direct_execution
+    env:
+    - name: ANSIBLE_NETWORK_DIRECT_EXECUTION
+    vars:
+    - name: ansible_network_direct_execution
   host:
     description:
     - Specifies the remote device FQDN or IP address to establish the SSH connection

--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -24,8 +24,8 @@ options:
     type: boolean
     description:
     - Gain potential preformance improvements for network modules
-      by enabling direct execution. Instead of the module being packaged 
-      and executed by the shell, it will be directly executed by the Ansible 
+      by enabling direct execution. Instead of the module being packaged
+      and executed by the shell, it will be directly executed by the Ansible
       control node using the same python interpreter as the Ansible process.
     default: false
     ini:

--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -23,10 +23,10 @@ options:
   direct_execution:
     type: boolean
     description:
-    - Gain potential preformance for network modules by enabling direct execution.
-      Instead of the module being packaged and executed by the shell, it will
-      be directly executed by the Ansible control node using the same python interpreter
-      as the Ansible process.
+    - Gain potential preformance improvements for network modules
+      by enabling direct execution. Instead of the module being packaged 
+      and executed by the shell, it will be directly executed by the Ansible 
+      control node using the same python interpreter as the Ansible process.
     default: false
     ini:
     - section: ansible_network

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -105,6 +105,21 @@ options:
     - name: ANSIBLE_BECOME_METHOD
     vars:
     - name: ansible_become_method
+  direct_execution:
+    type: boolean
+    description:
+    - Gain potential preformance for network modules by enabling direct execution.
+      Instead of the module being packaged and executed by the shell, it will
+      be directly executed by the Ansible control node using the same python interpreter
+      as the Ansible process.
+    default: false
+    ini:
+    - section: ansible_network
+      key: direct_execution
+    env:
+    - name: ANSIBLE_NETWORK_DIRECT_EXECUTION
+    vars:
+    - name: ansible_network_direct_execution
   host_key_auto_add:
     type: boolean
     description:

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -108,10 +108,13 @@ options:
   direct_execution:
     type: boolean
     description:
-    - Gain potential preformance improvements for network modules
+    - Reduce CPU usage and network module execution time
       by enabling direct execution. Instead of the module being packaged
       and executed by the shell, it will be directly executed by the Ansible
       control node using the same python interpreter as the Ansible process.
+      Note- Incompatible with C(asynchronous mode).
+      Note- Python 3 and Ansible 2.9.16 or greater required.
+      Note- With Ansible 2.9.x fully qualified modules names are required in tasks.
     default: false
     ini:
     - section: ansible_network

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -105,7 +105,7 @@ options:
     - name: ANSIBLE_BECOME_METHOD
     vars:
     - name: ansible_become_method
-  direct_execution:
+  import_modules:
     type: boolean
     description:
     - Reduce CPU usage and network module execution time
@@ -118,11 +118,11 @@ options:
     default: false
     ini:
     - section: ansible_network
-      key: direct_execution
+      key: import_modules
     env:
-    - name: ANSIBLE_NETWORK_DIRECT_EXECUTION
+    - name: ANSIBLE_NETWORK_IMPORT_MODULES
     vars:
-    - name: ansible_network_direct_execution
+    - name: ansible_network_import_modules
   host_key_auto_add:
     type: boolean
     description:

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -109,8 +109,8 @@ options:
     type: boolean
     description:
     - Gain potential preformance improvements for network modules
-      by enabling direct execution. Instead of the module being packaged 
-      and executed by the shell, it will be directly executed by the Ansible 
+      by enabling direct execution. Instead of the module being packaged
+      and executed by the shell, it will be directly executed by the Ansible
       control node using the same python interpreter as the Ansible process.
     default: false
     ini:

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -108,10 +108,10 @@ options:
   direct_execution:
     type: boolean
     description:
-    - Gain potential preformance for network modules by enabling direct execution.
-      Instead of the module being packaged and executed by the shell, it will
-      be directly executed by the Ansible control node using the same python interpreter
-      as the Ansible process.
+    - Gain potential preformance improvements for network modules
+      by enabling direct execution. Instead of the module being packaged 
+      and executed by the shell, it will be directly executed by the Ansible 
+      control node using the same python interpreter as the Ansible process.
     default: false
     ini:
     - section: ansible_network


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/693

**Need to figure out integration tests for this prior to merge**
**This will require a backport PR for 2.9 in task executor so 2.9 fully qualfied modules use the platform action from the same collection**

This PR add a new connection parameter call `ansible_network_direct_execution`. 

When enabled actions using `plugins/action/network.py ActionModule` as their base class, this include platform actions (cisco.nxos.noxs etc) and  other actions (cli_command), the task's module will be imported by the action
instead of it being tarred to the /tmp/directory.

example:
```
from ansible_collections.ansible.netcommon.plugins.action.network import (
    ActionModule as ActionNetworkModule,
)
```

`cli_command` was updated to the the base class above.
