### PR TITLE
Remove ansible from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-ansible
 ansible-pylibssh
 jxmlease
 ncclient


### PR DESCRIPTION
This breaks devel testing against ansible, due to how ansible /
ansible-base now works.  We can safely remove this.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>