### PR TITLE
Use ansible.netcommon.netconf connection for iosxr tests

### DIFF
--- a/changelogs/fragments/176-iosxr-tests.yaml
+++ b/changelogs/fragments/176-iosxr-tests.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  Force ansible.netcommon.netconf connection for netconf_* testing.

--- a/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -43,6 +43,7 @@
       - "'failed' not in result"
 
 - name: "configure using JSON format configuration"
+  connection: ansible.netcommon.netconf
   ansible.netcommon.netconf_config:
     content: |
             {

--- a/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -42,12 +42,14 @@
     that:
       - "'failed' not in result"
 
-- name: "configure using JSON format configuration"
+- name: "configure using JSON string format configuration"
   connection: ansible.netcommon.netconf
   ansible.netcommon.netconf_config:
     content: |
             {
                 "config": {
+                    "@xmlns": "urn:ietf:params:xml:ns:netconf:base:1.0",
+                    "@xmlns:nc": "urn:ietf:params:xml:ns:netconf:base:1.0",
                     "interface-configurations": {
                         "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
                         "interface-configuration": {
@@ -83,50 +85,13 @@
       - interface Loopback999
     match: none
 
-- name: "configure using JSON format configuration"
-  ansible.netcommon.netconf_config:
-    content: |
-            {
-                "config": {
-                    "interface-configurations": {
-                        "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
-                        "interface-configuration": {
-                            "active": "act",
-                            "description": "test for ansible Loopback999",
-                            "interface-name": "Loopback999"
-                        }
-                    }
-                }
-            }
-    get_filter: |
-              {
-                  "interface-configurations": {
-                      "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
-                      "interface-configuration": null
-                  }
-              }
-  register: result
-  diff: true
-
-- assert:
-    that:
-      - result.changed == true
-      - "'<description>test for ansible Loopback999</description>' in result.diff.after"
-
-- name: setup - teardown
-  connection: ansible.netcommon.network_cli
-  cisco.iosxr.iosxr_config:
-    commands:
-      - no description
-      - shutdown
-    parents:
-      - interface Loopback999
-    match: none
-
 - name: "configure using direct native format configuration"
+  connection: ansible.netcommon.netconf
   ansible.netcommon.netconf_config:
     content: {
       "config": {
+        "@xmlns": "urn:ietf:params:xml:ns:netconf:base:1.0",
+        "@xmlns:nc": "urn:ietf:params:xml:ns:netconf:base:1.0",
         "interface-configurations": {
           "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
           "interface-configuration": {

--- a/tests/integration/targets/netconf_get/tests/iosxr/basic.yaml
+++ b/tests/integration/targets/netconf_get/tests/iosxr/basic.yaml
@@ -155,6 +155,7 @@
         \ in result.msg"
 
 - name: "get configuration with json filter and native output (using xmltodict)"
+  connection: ansible.netcommon.netconf
   ansible.netcommon.netconf_get:
     filter: |
               {
@@ -181,6 +182,7 @@
         interface-configuration: null
 
 - name: "get configuration with native filter type using set_facts"
+  connection: ansible.netcommon.netconf
   ansible.netcommon.netconf_get:
     filter: "{{ filter }}"
     display: native
@@ -194,6 +196,7 @@
       - "{{ result['output']['data']['interface-configurations']['interface-configuration'] is defined }}"
 
 - name: "get configuration with direct native filter type"
+  connection: ansible.netcommon.netconf
   ansible.netcommon.netconf_get:
     filter: {
       "interface-configurations": {


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/ansible.netcommon/pull/177
This fixes a bug where we would try to use SSH for netconf testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>