### PR TITLE
Fix netconf_config integration test failure

### DIFF
--- a/changelogs/fragments/177_netconf_config_test_issue.yaml
+++ b/changelogs/fragments/177_netconf_config_test_issue.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - Fix netconf_config module integration test assert issue (https://github.com/ansible-collections/ansible.netcommon/pull/177)
+  - Fix netconf_config module integration test issuea (https://github.com/ansible-collections/ansible.netcommon/pull/177)

--- a/changelogs/fragments/177_netconf_config_test_issue.yaml
+++ b/changelogs/fragments/177_netconf_config_test_issue.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix netconf_config module integration test assert issue (https://github.com/ansible-collections/ansible.netcommon/pull/177)

--- a/plugins/module_utils/utils/data.py
+++ b/plugins/module_utils/utils/data.py
@@ -94,7 +94,7 @@ def validate_and_normalize_data(data, fmt=None):
                 raise Exception(
                     error + to_native(exc, errors="surrogate_then_replace")
                 )
-        else:
+        elif (data.startswith("{") and data.endswith("}")) or fmt == "json":
             try:
                 result = json.loads(data)
                 if fmt and fmt != "json":
@@ -103,7 +103,10 @@ def validate_and_normalize_data(data, fmt=None):
                         % (fmt, data)
                     )
                 return result, "json"
-            except (TypeError, json.decoder.JSONDecodeError) as exc:
+            except (
+                TypeError,
+                getattr(json.decoder, "JSONDecodeError", ValueError),
+            ) as exc:
                 if fmt == "json":
                     raise Exception(
                         "'%s' JSON validation failed with error '%s'"
@@ -112,13 +115,12 @@ def validate_and_normalize_data(data, fmt=None):
                             to_native(exc, errors="surrogate_then_replace"),
                         )
                     )
-                pass
             except Exception as exc:
                 error = "'%s' recognized as JSON but was not valid." % data
                 raise Exception(
                     error + to_native(exc, errors="surrogate_then_replace")
                 )
-
+        else:
             try:
                 if not HAS_LXML:
                     raise Exception(missing_required_lib("lxml"))
@@ -156,7 +158,10 @@ def validate_and_normalize_data(data, fmt=None):
         try:
             result = json.loads(json.dumps(data))
             return result, "json"
-        except (TypeError, json.decoder.JSONDecodeError) as exc:
+        except (
+            TypeError,
+            getattr(json.decoder, "JSONDecodeError", ValueError),
+        ) as exc:
             raise Exception(
                 "'%s' JSON validation failed with error '%s'"
                 % (data, to_native(exc, errors="surrogate_then_replace"))
@@ -167,7 +172,7 @@ def validate_and_normalize_data(data, fmt=None):
                 error + to_native(exc, errors="surrogate_then_replace")
             )
 
-    return data, "None"
+    return data, None
 
 
 def xml_to_dict(data):

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -268,6 +268,7 @@ EXAMPLES = """
 
 - name: "configure using direct native format configuration (cisco iosxr)"
   ansible.netcommon.netconf_config:
+    format: json
     content: {
                 "config": {
                     "interface-configurations": {
@@ -289,6 +290,7 @@ EXAMPLES = """
 
 - name: "configure using json string format configuration (cisco iosxr)"
   ansible.netcommon.netconf_config:
+    format: json
     content: |
             {
                 "config": {
@@ -417,10 +419,16 @@ except ImportError:
 
 def validate_config(module, config, format="xml"):
     if format == "xml":
-        root = fromstring(config)
-        if not root.tag.endswith("config"):
+        try:
+            root = fromstring(config)
+            if not root.tag.endswith("config"):
+                module.fail_json(
+                    msg="content value should have XML string with config tag as the root node"
+                )
+        except Exception as exc:
             module.fail_json(
-                msg="content value should have XML string with config tag as the root node"
+                "Value of content option is invalid as per the identified format %s, validation failed with error: %s"
+                % (format, to_text(exc, errors="surrogate_then_replace"))
             )
 
 
@@ -547,22 +555,28 @@ def main():
     except Exception as exc:
         module.fail_json(msg=to_text(exc))
 
-    if filter_type:
-        if filter_type == "xml":
-            filter_type = "subtree"
-        elif filter_type == "json":
-            try:
-                filter = dict_to_xml(filter_data)
-            except Exception as exc:
-                module.fail_json(msg=to_text(exc))
-            filter_type = "subtree"
-        elif filter_type == "xpath":
-            pass
-        else:
-            module.fail_json(
-                msg="Invalid filter type detected %s for get_filter value %s"
-                % (filter_type, filter)
-            )
+    if filter_type == "xml":
+        filter_type = "subtree"
+    elif filter_type == "json":
+        try:
+            filter = dict_to_xml(filter_data)
+        except Exception as exc:
+            module.fail_json(msg=to_text(exc))
+        filter_type = "subtree"
+    elif filter_type == "xpath":
+        pass
+    elif (filter_type is None) and (filter_data is not None):
+        # to maintain backward compatibility for ansible 2.9 which
+        # defaults to "subtree" filter type
+        filter_type = "subtree"
+        module.warn(
+            "The data format of get_filter option value couldn't be identified, hence set to 'subtree'"
+        )
+    else:
+        module.fail_json(
+            msg="Invalid filter type detected %s for get_filter value %s"
+            % (filter_type, filter)
+        )
 
     conn = Connection(module._socket_path)
     capabilities = get_capabilities(module)
@@ -701,6 +715,9 @@ def main():
                     format = "xml"
                 elif config_format is None:
                     format = "xml"
+                    module.warn(
+                        "The data format of content option value couldn't be identified, hence set to 'xml'"
+                    )
                 else:
                     format = config_format
 

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -565,13 +565,16 @@ def main():
         filter_type = "subtree"
     elif filter_type == "xpath":
         pass
-    elif (filter_type is None) and (filter_data is not None):
-        # to maintain backward compatibility for ansible 2.9 which
-        # defaults to "subtree" filter type
-        filter_type = "subtree"
-        module.warn(
-            "The data format of get_filter option value couldn't be identified, hence set to 'subtree'"
-        )
+    elif filter_type is None:
+        if filter_data is not None:
+            # to maintain backward compatibility for ansible 2.9 which
+            # defaults to "subtree" filter type
+            filter_type = "subtree"
+            module.warn(
+                "The data format of get_filter option value couldn't be identified, hence set to 'subtree'"
+            )
+        else:
+            pass
     else:
         module.fail_json(
             msg="Invalid filter type detected %s for get_filter value %s"

--- a/plugins/modules/netconf_get.py
+++ b/plugins/modules/netconf_get.py
@@ -328,13 +328,16 @@ def main():
         filter_type = "subtree"
     elif filter_type == "xpath":
         pass
-    elif (filter_type is None) and (filter_data is not None):
-        # to maintain backward compatibility for ansible 2.9 which
-        # defaults to "subtree" filter type
-        filter_type = "subtree"
-        module.warn(
-            "The data format of filter option value couldn't be identified, hence set to 'subtree'"
-        )
+    elif filter_type is None:
+        if filter_data is not None:
+            # to maintain backward compatibility for ansible 2.9 which
+            # defaults to "subtree" filter type
+            filter_type = "subtree"
+            module.warn(
+                "The data format of filter option value couldn't be identified, hence set to 'subtree'"
+            )
+        else:
+            pass
     elif filter_type:
         module.fail_json(
             msg="Invalid filter type detected %s for filter value %s"

--- a/plugins/modules/netconf_get.py
+++ b/plugins/modules/netconf_get.py
@@ -332,6 +332,9 @@ def main():
         # to maintain backward compatibility for ansible 2.9 which
         # defaults to "subtree" filter type
         filter_type = "subtree"
+        module.warn(
+            "The data format of filter option value couldn't be identified, hence set to 'subtree'"
+        )
     elif filter_type:
         module.fail_json(
             msg="Invalid filter type detected %s for filter value %s"

--- a/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -42,6 +42,40 @@
     that:
       - "result['failed'] == false"
 
+- name: "test invalid JSON string format configuration"
+  connection: ansible.netcommon.netconf
+  ansible.netcommon.netconf_config:
+    content: |
+            {
+                "config": {
+                    "@xmlns": "urn:ietf:params:xml:ns:netconf:base:1.0",
+                    "@xmlns:nc": "urn:ietf:params:xml:ns:netconf:base:1.0",
+                    "interface-configurations": {
+                        "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
+                        "interface-configuration": {
+                            "active": "act",
+                            "description": "test for ansible Loopback999",
+                            "interface-name": "Loopback999",
+                        }
+                    }
+                }
+            }
+    get_filter: |
+              {
+                  "interface-configurations": {
+                      "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
+                      "interface-configuration": null
+                  }
+              }
+  register: result
+  ignore_errors: true
+  diff: true
+
+- assert:
+    that:
+      - result.failed == true
+      - "'Value of content option is invalid as per the identified format xml' in result.msg"
+
 - name: "configure using JSON string format configuration"
   connection: ansible.netcommon.netconf
   ansible.netcommon.netconf_config:

--- a/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -40,7 +40,7 @@
 
 - assert:
     that:
-      - "'failed' not in result"
+      - "result['failed'] == false"
 
 - name: "configure using JSON format configuration"
   ansible.netcommon.netconf_config:

--- a/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -42,51 +42,15 @@
     that:
       - "result['failed'] == false"
 
-- name: "configure using JSON format configuration"
+- name: "configure using JSON string format configuration"
+  connection: ansible.netcommon.netconf
   ansible.netcommon.netconf_config:
+    format: json
     content: |
             {
                 "config": {
-                    "interface-configurations": {
-                        "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
-                        "interface-configuration": {
-                            "active": "act",
-                            "description": "test for ansible Loopback999",
-                            "interface-name": "Loopback999",
-                        }
-                    }
-                }
-            }
-    get_filter: |
-              {
-                  "interface-configurations": {
-                      "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
-                      "interface-configuration": null
-                  }
-              }
-  register: result
-  diff: true
-
-- assert:
-    that:
-      - result.changed == true
-      - "'<description>test for ansible Loopback999</description>' in result.diff.after"
-
-- name: setup - teardown
-  connection: ansible.netcommon.network_cli
-  cisco.iosxr.iosxr_config:
-    commands:
-      - no description
-      - shutdown
-    parents:
-      - interface Loopback999
-    match: none
-
-- name: "configure using JSON format configuration"
-  ansible.netcommon.netconf_config:
-    content: |
-            {
-                "config": {
+                    "@xmlns": "urn:ietf:params:xml:ns:netconf:base:1.0",
+                    "@xmlns:nc": "urn:ietf:params:xml:ns:netconf:base:1.0",
                     "interface-configurations": {
                         "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
                         "interface-configuration": {
@@ -123,9 +87,13 @@
     match: none
 
 - name: "configure using direct native format configuration"
+  connection: ansible.netcommon.netconf
   ansible.netcommon.netconf_config:
+    format: json
     content: {
       "config": {
+        "@xmlns": "urn:ietf:params:xml:ns:netconf:base:1.0",
+        "@xmlns:nc": "urn:ietf:params:xml:ns:netconf:base:1.0",
         "interface-configurations": {
           "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg",
           "interface-configuration": {

--- a/tests/integration/targets/netconf_get/tests/iosxr/basic.yaml
+++ b/tests/integration/targets/netconf_get/tests/iosxr/basic.yaml
@@ -155,6 +155,7 @@
         \ in result.msg"
 
 - name: "get configuration with json filter and native output (using xmltodict)"
+  connection: ansible.netcommon.netconf
   ansible.netcommon.netconf_get:
     filter: |
               {
@@ -181,6 +182,7 @@
         interface-configuration: null
 
 - name: "get configuration with native filter type using set_facts"
+  connection: ansible.netcommon.netconf
   ansible.netcommon.netconf_get:
     filter: "{{ filter }}"
     display: native
@@ -194,6 +196,7 @@
       - "{{ result['output']['data']['interface-configurations']['interface-configuration'] is defined }}"
 
 - name: "get configuration with direct native filter type"
+  connection: ansible.netcommon.netconf
   ansible.netcommon.netconf_get:
     filter: {
       "interface-configurations": {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix netconf_config integration test failure
Check the failed key is the result is set to false.
https://0d814a7899aa2d75b4c1-464e9c07d5d57f082eab7f40f1ed712a.ssl.cf1.rackcdn.com/176/7987c638a02ad3a6182cca9d5bd66d181946b7bc/check/ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python36/78dc089/job-output.html#l2832

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests/integration/targets/netconf_config/tests/iosxr/basic.yaml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
