### PR TITLE
Add nxos netconf_config tests

### DIFF
--- a/changelogs/fragments/netconf_nxos_tests.yaml
+++ b/changelogs/fragments/netconf_nxos_tests.yaml
@@ -1,0 +1,3 @@
+---
+tests:
+  - Add netconf_config integration tests for nxos (https://github.com/ansible-collections/ansible.netcommon/pull/185)

--- a/tests/integration/targets/netconf_config/meta/main.yml
+++ b/tests/integration/targets/netconf_config/meta/main.yml
@@ -4,3 +4,5 @@ dependencies:
     when: ansible_network_os == 'junipernetworks.junos.junos'
   - role: prepare_iosxr_tests
     when: ansible_network_os == 'cisco.iosxr.iosxr'
+  - role: prepare_nxos_tests
+    when: ansible_network_os == 'cisco.nxos.nxos'

--- a/tests/integration/targets/netconf_config/tasks/main.yaml
+++ b/tests/integration/targets/netconf_config/tasks/main.yaml
@@ -8,3 +8,8 @@
   when: ansible_network_os == 'cisco.iosxr.iosxr'
   tags:
     - netconf
+
+- include: nxos.yaml
+  when: ansible_network_os == 'cisco.nxos.nxos'
+  tags:
+    - netconf

--- a/tests/integration/targets/netconf_config/tasks/nxos.yaml
+++ b/tests/integration/targets/netconf_config/tasks/nxos.yaml
@@ -1,0 +1,16 @@
+---
+- name: collect all netconf test cases
+  find:
+    paths: '{{ role_path }}/tests/nxos'
+    patterns: '{{ testcase }}.yaml'
+  register: test_cases
+  connection: local
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test case (connection=ansible.netcommon.netconf)
+  include: '{{ test_case_to_run }}'
+  with_items: '{{ test_items }}'
+  loop_control:
+    loop_var: test_case_to_run

--- a/tests/integration/targets/netconf_config/tests/nxos/basic.yaml
+++ b/tests/integration/targets/netconf_config/tests/nxos/basic.yaml
@@ -1,0 +1,66 @@
+---
+- debug: msg="START netconf_config nxos/basic.yaml on connection={{ ansible_connection }}"
+
+- name: Setup - Remove Vlan
+  cisco.nxos.nxos_config:
+    lines:
+      - no vlan 42
+  ignore_errors: yes
+  when: not result.failed
+
+- include_vars: "fixtures/config.yaml"
+
+- block:
+  - name: Configure vlan
+    ansible.netcommon.netconf_config: &config_vlan
+      datastore: running
+      commit: false
+      get_filter: <System xmlns="http://cisco.com/ns/yang/cisco-nx-os-device"><bd-items><bd-items><BD-list></BD-list></bd-items></bd-items></System>
+      content: "{{ vlan_config }}"
+    register: result
+
+  - assert: &true
+      that:
+        - "result.changed == true"
+
+  - name: Configure vlan - idempotence check
+    ansible.netcommon.netconf_config: *config_vlan
+    register: result
+
+  - assert: &false
+      that:
+        - "result.changed == false"
+
+  - name: Query Running Config
+    ansible.netcommon.netconf_get:
+      source: running
+      filter: <System xmlns="http://cisco.com/ns/yang/cisco-nx-os-device"><bd-items><bd-items><BD-list></BD-list></bd-items></bd-items></System>
+    register: result
+
+  - assert:
+      that:
+        - "'vlan-42' in result.stdout"
+
+  vars:
+    ansible_connection: ansible.netcommon.netconf
+    ansible_port: 830
+
+  always:
+  - name: Disable feature netconf
+    cisco.nxos.nxos_feature:
+      feature: netconf
+      state: disabled
+    vars: &ssh_credentials
+      ansible_connection: ansible.netcommon.network_cli
+      ansible_ssh_port: 22
+    when: not result.failed
+
+  - name: Cleanup - Remove vlan
+    cisco.nxos.nxos_config:
+      lines:
+        - no vlan 42
+    vars: *ssh_credentials
+    ignore_errors: yes
+    when: not result.failed
+
+  - debug: msg="END nxos_netconf cli/basic.yaml"

--- a/tests/integration/targets/netconf_config/tests/nxos/fixtures/config.yaml
+++ b/tests/integration/targets/netconf_config/tests/nxos/fixtures/config.yaml
@@ -1,0 +1,14 @@
+---
+vlan_config: |
+          <config>
+          <System xmlns="http://cisco.com/ns/yang/cisco-nx-os-device">
+            <bd-items>
+              <bd-items>
+                <BD-list>
+                  <fabEncap>vlan-42</fabEncap>
+                  <name>vlan-42</name>
+                </BD-list>
+              </bd-items>
+            </bd-items>
+          </System>
+          </config>

--- a/tests/integration/targets/prepare_nxos_tests/tasks/main.yaml
+++ b/tests/integration/targets/prepare_nxos_tests/tasks/main.yaml
@@ -1,0 +1,14 @@
+---
+
+- name: Setup - Enable feature netconf
+  cisco.nxos.nxos_feature:
+    feature: netconf
+    state: enabled
+  vars: &ssh_credentials
+    ansible_connection: ansible.netcommon.network_cli
+    ansible_ssh_port: 22
+  register: result
+  ignore_errors: yes
+
+- debug: msg='Netconf feature is not supported on this platform!'
+  when: result.failed


### PR DESCRIPTION
##### SUMMARY
This PR adds back tests that used to be in `ansible/ansible`.

Original PR: https://github.com/ansible/ansible/pull/63593/files

This PR added the `get_filter` option and integration tests.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
netconf_config

Tested against version `9.3(3)`