### PR TITLE
Fix config diff logic in case of multiple parent lines

### DIFF
--- a/changelogs/fragments/189_config_diff_fix.yaml
+++ b/changelogs/fragments/189_config_diff_fix.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix config diff logic if parent configuration is present more than once in the candidate config and
+    update docs (https://github.com/ansible-collections/ansible.netcommon/pull/189)

--- a/plugins/module_utils/network/common/config.py
+++ b/plugins/module_utils/network/common/config.py
@@ -381,20 +381,31 @@ class NetworkConfig(object):
 
         visited = set()
         expanded = list()
-        prev_item = None
 
-        for item in updates:
-            if prev_item is None or (
-                item._parents
-                and prev_item.text != item._parents[-1].text
-                and prev_item._parents != item._parents
-            ):
-                for p in item._parents:
+        for curr_elem in updates:
+            add_parents = False
+            if expanded:
+                last_elem = expanded[-1]
+                # If parent of current line not added in expanded list flag it
+                # to be added later on
+                if (
+                    all([curr_elem.has_parents, last_elem.has_parents])
+                    and curr_elem.parents[0] != last_elem.parents[0]
+                ):
+                    add_parents = True
+                # check if parent of current line is already added, if added don't
+                # add again
+                if (
+                    last_elem.has_children
+                    and last_elem.children[0] != curr_elem.text
+                ):
+                    add_parents = True
+            for p in curr_elem._parents:
+                if p.line not in visited or add_parents:
                     visited.add(p.line)
                     expanded.append(p)
-            expanded.append(item)
-            visited.add(item.line)
-            prev_item = item
+            expanded.append(curr_elem)
+            visited.add(curr_elem.line)
 
         return expanded
 

--- a/plugins/module_utils/network/common/config.py
+++ b/plugins/module_utils/network/common/config.py
@@ -381,14 +381,20 @@ class NetworkConfig(object):
 
         visited = set()
         expanded = list()
+        prev_item = None
 
         for item in updates:
-            for p in item._parents:
-                if p.line not in visited:
+            if prev_item is None or (
+                item._parents
+                and prev_item.text != item._parents[-1].text
+                and prev_item._parents != item._parents
+            ):
+                for p in item._parents:
                     visited.add(p.line)
                     expanded.append(p)
             expanded.append(item)
             visited.add(item.line)
+            prev_item = item
 
         return expanded
 

--- a/plugins/modules/cli_config.py
+++ b/plugins/modules/cli_config.py
@@ -16,6 +16,9 @@ notes:
 - The commands will be returned only for platforms that do not support onbox diff.
   The C(--diff) option with the playbook will return the difference in configuration
   for devices that has support for onbox diff
+- To ensure idempotency and correct diff the configuration lines in the relevant module
+  options should be similar to how they appear if present in the running configuration on
+  device including the indentation.
 short_description: Push text based configuration to network devices over network_cli
 description:
 - This module provides platform agnostic way of pushing text based configuration to
@@ -27,8 +30,9 @@ options:
   config:
     description:
     - The config to be pushed to the network device. This argument is mutually exclusive
-      with C(rollback) and either one of the option should be given as input. The
-      config should have indentation that the device uses.
+      with C(rollback) and either one of the option should be given as input. To ensure
+      idempotency and correct diff the configuration lines should be similar to how they
+      appear if present in the running configuration on device including the indentation.
     type: str
   commit:
     description:
@@ -322,6 +326,13 @@ def run(
             result["diff"] = resp["diff"]
 
     elif device_operations.get("supports_generate_diff"):
+        msg = (
+            "To ensure idempotency and correct diff the input configuration lines should be"
+            " similar to how they appear if present in"
+            " the running configuration on device including the indentation"
+        )
+        module.warn(msg)
+
         kwargs = {"candidate": candidate, "running": running}
         if diff_match:
             kwargs.update({"diff_match": diff_match})

--- a/tests/unit/module_utils/network/common/test_config.py
+++ b/tests/unit/module_utils/network/common/test_config.py
@@ -26,6 +26,8 @@ import re
 
 import pytest
 
+from copy import deepcopy
+
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     config,
 )
@@ -45,6 +47,65 @@ interface Management1
    ip address dhcp
 !"""
 
+WANT_SRC_1 = """
+router ospfv3
+   fips restrictions
+   address-family ipv4
+      fips restrictions
+      redistribute connected
+      exit
+   address-family ipv6
+      router-id 10.1.1.1
+      exit
+   exit
+router ospfv3 vrf vrf01
+   fips restrictions
+   address-family ipv4
+      passive-interface default
+      exit
+   address-family ipv6
+      fips restrictions
+      exit
+   exit
+router ospfv3 vrf vrf02
+   fips restrictions
+   address-family ipv6
+      fips restrictions
+      exit
+   exit
+"""
+
+HAVE_SRC_1 = ""
+
+WANT_SRC_2 = """
+interface loopback0
+ ip ospf 1 area 0.0.0.0
+!
+interface GigabitEthernet0/1
+ ip ospf 1 area 0.0.0.0
+interface GigabitEthernet0/2
+ ip ospf 1 area 0.0.0.0
+!
+router isis fabric
+ is-type level-2
+ net 49.0000.0000.0003.00
+!
+interface loopback0
+ ip router isis fabric
+!
+interface GigabitEthernet0/1
+ ip router isis fabric
+interface GigabitEthernet0/2
+ ip router isis fabric
+"""
+
+HAVE_SRC_2 = """
+interface GigabitEthernet0/1
+interface GigabitEthernet0/2
+"""
+
+ORIGINAL_DEFAULT_IGNORE_LINES_RE = deepcopy(config.DEFAULT_IGNORE_LINES_RE)
+
 
 def test_config_items():
     net_config = config.NetworkConfig(indent=3, contents=RUNNING)
@@ -59,6 +120,9 @@ def test_config_items():
         indent=3, contents=RUNNING, ignore_lines=[re.compile(r"\s*no .*")]
     )
     assert len(net_config.items) == 6
+    # above updates the global DEFAULT_IGNORE_LINES_RE list, revert back the global
+    # to it's original value
+    config.DEFAULT_IGNORE_LINES_RE = ORIGINAL_DEFAULT_IGNORE_LINES_RE
 
 
 def test_config_get_block():
@@ -84,3 +148,51 @@ def test_line_hierarchy():
     assert not lines[0].has_parents
     assert not lines[1].has_children
     assert lines[1].has_parents
+
+
+def test_updates_repeat_lines():
+    candidate_obj = config.NetworkConfig(indent=3)
+    candidate_obj.load(WANT_SRC_1)
+
+    running_obj = config.NetworkConfig(indent=3, contents=HAVE_SRC_1)
+
+    configdiffobjs = candidate_obj.difference(running_obj)
+    diff_list = config.dumps(configdiffobjs, "commands").split("\n")
+    want_src_list = WANT_SRC_1.strip().split("\n")
+    for generated_diff_line, candidate_diff_line in zip(
+        diff_list, want_src_list
+    ):
+        assert generated_diff_line == candidate_diff_line.strip()
+
+
+def test_updates_repeat_parents():
+    expected_diff = [
+        "interface loopback0",
+        "ip ospf 1 area 0.0.0.0",
+        "interface GigabitEthernet0/1",
+        "ip ospf 1 area 0.0.0.0",
+        "interface GigabitEthernet0/2",
+        "ip ospf 1 area 0.0.0.0",
+        "router isis fabric",
+        "is-type level-2",
+        "net 49.0000.0000.0003.00",
+        "interface loopback0",
+        "ip router isis fabric",
+        "interface GigabitEthernet0/1",
+        "ip router isis fabric",
+        "interface GigabitEthernet0/2",
+        "ip router isis fabric",
+    ]
+    candidate_obj = config.NetworkConfig(indent=1)
+    candidate_obj.load(WANT_SRC_2)
+
+    running_obj = config.NetworkConfig(indent=1, contents=HAVE_SRC_2)
+
+    configdiffobjs = candidate_obj.difference(running_obj)
+    diff_list = config.dumps(configdiffobjs, "commands").split("\n")
+
+    for generated_diff_line, candidate_diff_line in zip(
+        diff_list, expected_diff
+    ):
+        print(generated_diff_line, candidate_diff_line)
+        assert generated_diff_line == candidate_diff_line.strip()

--- a/tests/unit/module_utils/network/common/test_config.py
+++ b/tests/unit/module_utils/network/common/test_config.py
@@ -26,8 +26,6 @@ import re
 
 import pytest
 
-from copy import deepcopy
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     config,
 )
@@ -104,7 +102,7 @@ interface GigabitEthernet0/1
 interface GigabitEthernet0/2
 """
 
-ORIGINAL_DEFAULT_IGNORE_LINES_RE = deepcopy(config.DEFAULT_IGNORE_LINES_RE)
+ORIGINAL_DEFAULT_IGNORE_LINES_RE = config.DEFAULT_IGNORE_LINES_RE.copy()
 
 
 def test_config_items():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible-collections/ansible.netcommon/issues/189


* If the parent config lines appear at multiple places in the
  configuration update list add it in the final diff along
  with child elements.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/network/common/config.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
