### PR TITLE
[DNM] fix strip method doesn't exist for getReply

### DIFF
--- a/changelogs/fragments/96_strip_doesnt_exist_for_getReply_issue.yaml
+++ b/changelogs/fragments/96_strip_doesnt_exist_for_getReply_issue.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix strip() method does't exist for getReply (https://github.com/ansible-collections/cisco.iosxr/issues/96)

--- a/plugins/module_utils/network/common/netconf.py
+++ b/plugins/module_utils/network/common/netconf.py
@@ -159,7 +159,7 @@ def remove_namespaces(data):
             "It can be installed using `pip install ncclient`"
         )
     return NCElement(
-        to_text(data.strip(), errors="surrogate_then_replace"),
+        to_text(data, errors="surrogate_then_replace"),
         transform_reply(),
     ).data_xml
 


### PR DESCRIPTION
Signed-off-by: Rohit Thakur <rothakur@localhost.localdomain>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
resolve: https://github.com/ansible-collections/cisco.iosxr/issues/96
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
