### PR TITLE
Add a function to convert hexadecimal representations of IPv4 addreses into decimal

### DIFF
--- a/plugins/filter/ipaddr.py
+++ b/plugins/filter/ipaddr.py
@@ -1135,6 +1135,28 @@ def ip4_hex(arg, delimiter=""):
         *numbers, sep=delimiter
     )
 
+def hex_ip4(arg, delimiter="."):
+    """ Convert hexadecimal notation IPv4 address given as a string to decimal notation """
+    # if it's not an 8 character string it's not a representation of an ipv4 address
+    if not isinstance(arg, str) or len(arg) < 8:
+        # some kind of error
+    else:
+        split_str = ["".join(x) for x in zip(*[list(arg[z::2]) for z in range(2)])]
+        # check if every item in split_str is a valid hex number
+        try:
+            unhexed = delimiter.join([str(int(x, 16)) for x in split_str])
+            if netaddr.valid_ipv4(unhexed):
+                return unhexed
+            else:
+               raise errors.AnsibleFilterError(
+                "%s is not a valid IPv4 address representation." % arg
+            ) 
+        except ValueError:
+            raise errors.AnsibleFilterError(
+                "%s is not a valid IPv4 address representation." % arg
+            )
+
+
 
 # ---- Ansible filters ----
 class FilterModule(object):
@@ -1147,6 +1169,7 @@ class FilterModule(object):
         "ipmath": ipmath,
         "ipwrap": ipwrap,
         "ip4_hex": ip4_hex,
+        "hex_ip4": hex_ip4,
         "ipv4": ipv4,
         "ipv6": ipv6,
         "ipsubnet": ipsubnet,

--- a/plugins/filter/ipaddr.py
+++ b/plugins/filter/ipaddr.py
@@ -1139,7 +1139,9 @@ def hex_ip4(arg, delimiter="."):
     """ Convert hexadecimal notation IPv4 address given as a string to decimal notation """
     # if it's not an 8 character string it's not a representation of an ipv4 address
     if not isinstance(arg, str) or len(arg) < 8:
-        # some kind of error
+        raise errors.AnsibleFilterError(
+                "%s is not a valid IPv4 address representation." % arg
+            )
     else:
         split_str = ["".join(x) for x in zip(*[list(arg[z::2]) for z in range(2)])]
         # check if every item in split_str is a valid hex number

--- a/tests/unit/plugins/filter/test_ipaddr.py
+++ b/tests/unit/plugins/filter/test_ipaddr.py
@@ -895,3 +895,7 @@ class TestIpFilter(unittest.TestCase):
     def test_ip4_hex(self):
         self.assertEqual(ipaddr.ip4_hex("192.0.2.24"), "c0000218")
         self.assertEqual(ipaddr.ip4_hex("192.0.2.24", "."), "c0.00.02.18")
+
+    def test_hex_ip4(self):
+        self.assertEqual(ipaddr.ip4_hex("c0000218"), "192.0.2.24")
+        self.assertEqual(ipaddr.ip4_hex("c0000218", ":"), "192:0:2:24")


### PR DESCRIPTION
##### SUMMARY
There currently is no option to convert from a hexadecimal representation of an IPv4 address to a decimal representation in Ansible, leading to ugly Jinja2 expressions like the below when it becomes necessary.
`"{{ ['0x'] | product(hex_ipv4_string | slice(4) | map('join', '')) | map('join', '') | map('int', 0, 16) | join('.') }}"`
This would be more convenient as a filter plugin instead.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

