### PR TITLE
Add 'purged' to action states.

### DIFF
--- a/changelogs/fragments/add_purged_action_state.yaml
+++ b/changelogs/fragments/add_purged_action_state.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add 'purged' to ACTION_STATES.

--- a/plugins/module_utils/network/common/resource_module.py
+++ b/plugins/module_utils/network/common/resource_module.py
@@ -17,7 +17,7 @@ class ResourceModule(object):  # pylint: disable=R0902
     """ Base class for Network Resource Modules
     """
 
-    ACTION_STATES = ["merged", "replaced", "overridden", "deleted"]
+    ACTION_STATES = ["merged", "replaced", "overridden", "deleted", "purged"]
 
     def __init__(self, *_args, **kwargs):
         self._empty_fact_val = kwargs.get("empty_fact_val", [])


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

'purged' state is added to action states. This state , when used,  deletes the resource from the device, where as, 'deleted' deletes  only the configuration under the resource. 

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
