### PR TITLE
Switch to network-ee for sanity / unit tests

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,5 @@
+---
+- project:
+    templates:
+      - network-ee-container-image-jobs
+      - network-ee-tests

--- a/changelogs/fragments/netconf_nxos_tests.yaml
+++ b/changelogs/fragments/netconf_nxos_tests.yaml
@@ -1,3 +1,3 @@
 ---
-tests:
+bugfixes:
   - Add netconf_config integration tests for nxos (https://github.com/ansible-collections/ansible.netcommon/pull/185)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.9.10,<2.11'
+requires_ansible: '>=2.9.10'
 plugin_routing:
   modules:
     net_banner:

--- a/plugins/modules/net_l3_interface.py
+++ b/plugins/modules/net_l3_interface.py
@@ -63,14 +63,20 @@ EXAMPLES = """
 - name: Set IP addresses on aggregate
   ansible.netcommon.net_l3_interface:
     aggregate:
-    - {name: eth1, ipv4: 192.168.2.10/24}
-    - {name: eth2, ipv4: 192.168.3.10/24, ipv6: fd5d:12c9:2201:1::1/64}
+    - name: eth1
+      ipv4: 192.168.2.10/24
+    - name: eth2
+      ipv4: 192.168.3.10/24
+      ipv6: fd5d:12c9:2201:1::1/64
 
 - name: Remove IP addresses on aggregate
   ansible.netcommon.net_l3_interface:
     aggregate:
-    - {name: eth1, ipv4: 192.168.2.10/24}
-    - {name: eth2, ipv4: 192.168.3.10/24, ipv6: fd5d:12c9:2201:1::1/64}
+    - name: eth1
+      ipv4: 192.168.2.10/24
+    - name: eth2
+      ipv4: 192.168.3.10/24
+      ipv6: fd5d:12c9:2201:1::1/64
     state: absent
 """
 

--- a/plugins/modules/net_vrf.py
+++ b/plugins/modules/net_vrf.py
@@ -58,8 +58,10 @@ EXAMPLES = """
 - name: Create aggregate of VRFs with purge
   ansible.netcommon.net_vrf:
     aggregate:
-    - {name: test4, rd: 1:204}
-    - {name: test5, rd: 1:205}
+    - name: test4
+      rd: 1:204
+    - name: test5
+      rd: 1:205
     state: present
     purge: yes
 

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,0 +1,5 @@
+plugins/action/net_base.py action-plugin-docs # base class for other net_* action plugins which have a matching module
+plugins/action/netconf.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+plugins/action/network.py action-plugin-docs # base class for network action plugins
+plugins/module_utils/compat/ipaddress.py no-assert
+plugins/module_utils/compat/ipaddress.py no-unicode-literals


### PR DESCRIPTION
This start the migration to network execution environments to manage our
testing needs.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/746
Depends-On: https://github.com/ansible/network-ee/pull/32
Signed-off-by: Paul Belanger <pabelanger@redhat.com>