### PR TITLE
Add custom filters `any` and `all`  for j2

### DIFF
--- a/changelogs/fragments/support_custom_filters.yaml
+++ b/changelogs/fragments/support_custom_filters.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Support any() and all() filters in Jinja2.

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -728,7 +728,7 @@ class Template:
             )
 
         self.env = Environment(undefined=StrictUndefined)
-        self.env.filters.update({"ternary": ternary})
+        self.env.filters.update({"ternary": ternary, "all": all, "any": any})
 
     def __call__(self, value, variables=None, fail_on_undefined=True):
         variables = variables or {}


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- We often end up writing large if-else conditions in the rm_templates while building facts tree or generating commands.
- Supporting any() and all() in j2 helps a bit.
Example:
"{{ True if var1 is defined and ((not var2, var3, var4, not var5)|all) }}"

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module_utils/network/common/utils.py