### PR TITLE
Gracefully handle connection closing in pylibssh

### DIFF
--- a/changelogs/fragments/217-pylibssh-conn-closed.yaml
+++ b/changelogs/fragments/217-pylibssh-conn-closed.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - network_cli - When using ssh_type libssh, handle closed connection gracefully instead of throwing an exception

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -764,7 +764,11 @@ class Connection(NetworkConnectionBase):
                 else:
                     return self._command_response
             else:
-                data = self._ssh_shell.read_bulk_response()
+                try:
+                    data = self._ssh_shell.read_bulk_response()
+                except ConnectionError:
+                    # Socket has closed
+                    break
 
             if not data:
                 continue

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -766,7 +766,8 @@ class Connection(NetworkConnectionBase):
             else:
                 try:
                     data = self._ssh_shell.read_bulk_response()
-                except ConnectionError:
+                # TODO: Should be ConnectionError when pylibssh drops Python 2 support
+                except OSError:
                     # Socket has closed
                     break
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This roughly mirrors the handling of a closed socket in paramiko, only paramiko does not raise an exception to catch.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
network_cli

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
