### PR TITLE
Adding exception handling for network template deepformat call

### DIFF
--- a/plugins/module_utils/network/common/network_template.py
+++ b/plugins/module_utils/network/common/network_template.py
@@ -60,7 +60,12 @@ class NetworkTemplate(object):
                     if parser.get("shared"):
                         shared = capdict
                     vals = dict_merge(capdict, shared)
-                    res = self._deepformat(deepcopy(parser["result"]), vals)
+                    try:
+                        res = self._deepformat(
+                            deepcopy(parser["result"]), vals
+                        )
+                    except Exception as ex:
+                        continue
                     result = dict_merge(result, res)
                     break
         return result

--- a/plugins/module_utils/network/common/network_template.py
+++ b/plugins/module_utils/network/common/network_template.py
@@ -64,7 +64,7 @@ class NetworkTemplate(object):
                         res = self._deepformat(
                             deepcopy(parser["result"]), vals
                         )
-                    except Exception as ex:
+                    except UndefinedError:
                         continue
                     result = dict_merge(result, res)
                     break


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding exception handling for network template `deepformat` call, which might result in failure where parsing regex is common for global n child config and we need to segregate based on child config on certain shared parameter available to child regex match.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
network_template

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
router bgp 65000
 neighbor 192.0.2.1 remote-as 100
 neighbor 192.0.2.1 description replace neighbor
 !
 address-family ipv4 multicast vrf blue
    neighbor 192.0.2.1 remote-as 100
 exit-address-family
```
Now, for AF config if we segregate based on AFI shared val since `remote-as` regex is common for parent n child config, `deepformat` w/o the exception handling would result in traceback which isn’t expected, and with exception handling, in place, it'd continue the search in the entire config and then child config `remote-as` would get matched based on AFI formatting