### PR TITLE
Move warning message for cli_config module

### DIFF
--- a/changelogs/fragments/config_module_warning_msg.yaml
+++ b/changelogs/fragments/config_module_warning_msg.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Move cli_config idempotent warning message with the task response under `warnings` key
+    if `changed` is `True`

--- a/plugins/modules/cli_config.py
+++ b/plugins/modules/cli_config.py
@@ -326,13 +326,6 @@ def run(
             result["diff"] = resp["diff"]
 
     elif device_operations.get("supports_generate_diff"):
-        msg = (
-            "To ensure idempotency and correct diff the input configuration lines should be"
-            " similar to how they appear if present in"
-            " the running configuration on device including the indentation"
-        )
-        module.warn(msg)
-
         kwargs = {"candidate": candidate, "running": running}
         if diff_match:
             kwargs.update({"diff_match": diff_match})
@@ -387,6 +380,16 @@ def run(
                 diff += json.dumps(banner_diff)
             result["diff"] = {"prepared": diff}
 
+    if result.get("changed"):
+        msg = (
+            "To ensure idempotency and correct diff the input configuration lines should be"
+            " similar to how they appear if present in"
+            " the running configuration on device including the indentation"
+        )
+        if "warnings" in result:
+            result["warnings"].append(msg)
+        else:
+            result["warnings"] = msg
     return result
 
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Currently the warning message for diff is thrown
   for every module run.
*  Based on discussion here https://github.com/ansible/network/discussions/48
   a better way of logging the message is through verbose
   logs but verbose logging has a known issue https://github.com/ansible-collections/ansible.netcommon/issues/224
*  Hence moving the message under `warnings` key within the task
   response if `changed=True`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cli_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
