### PR TITLE
Correctly set `ansible_host_key_checking` option for network_cli

### DIFF
--- a/changelogs/fragments/set_host_key_checking.yaml
+++ b/changelogs/fragments/set_host_key_checking.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+ - Allow setting `host_key_checking` through a play/task var for `network_cli`.

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -443,8 +443,7 @@ class Connection(NetworkConnectionBase):
                         and not self._play_context.private_key_file
                     ),
                     "host_key_checking": self.get_option("host_key_checking"),
-                },
-
+                }
             )
             self.queue_message(
                 "vvvv", "ssh type is set to %s" % self.get_option("ssh_type")

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -432,10 +432,10 @@ class Connection(NetworkConnectionBase):
             # TODO: Remove this check if/when libssh connection plugin is moved to ansible-base
             if self._ssh_type == "libssh":
                 self._ssh_type = "ansible.netcommon.libssh"
+
             self._ssh_type_conn = connection_loader.get(
                 self._ssh_type, self._play_context, "/dev/null"
             )
-
             self._ssh_type_conn.set_options(
                 direct={
                     "look_for_keys": not bool(

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -432,7 +432,6 @@ class Connection(NetworkConnectionBase):
             # TODO: Remove this check if/when libssh connection plugin is moved to ansible-base
             if self._ssh_type == "libssh":
                 self._ssh_type = "ansible.netcommon.libssh"
-
             self._ssh_type_conn = connection_loader.get(
                 self._ssh_type, self._play_context, "/dev/null"
             )
@@ -447,7 +446,6 @@ class Connection(NetworkConnectionBase):
                 },
 
             )
-
             self.queue_message(
                 "vvvv", "ssh type is set to %s" % self.get_option("ssh_type")
             )

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -269,6 +269,21 @@ options:
           key: ssh_type
     vars:
     - name: ansible_network_cli_ssh_type
+  host_key_checking:
+    description: 'Set this to "False" if you want to avoid host key checking by the underlying tools Ansible uses to connect to the host'
+    type: boolean
+    default: True
+    env:
+    - name: ANSIBLE_HOST_KEY_CHECKING
+    - name: ANSIBLE_SSH_HOST_KEY_CHECKING
+    ini:
+    - section: defaults
+      key: host_key_checking
+    - section: persistent_connection
+      key: host_key_checking
+    vars:
+    - name: ansible_host_key_checking
+    - name: ansible_ssh_host_key_checking
   single_user_mode:
     type: boolean
     default: false
@@ -421,14 +436,18 @@ class Connection(NetworkConnectionBase):
             self._ssh_type_conn = connection_loader.get(
                 self._ssh_type, self._play_context, "/dev/null"
             )
+
             self._ssh_type_conn.set_options(
                 direct={
                     "look_for_keys": not bool(
                         self._play_context.password
                         and not self._play_context.private_key_file
-                    )
-                }
+                    ),
+                    "host_key_checking": self.get_option("host_key_checking"),
+                },
+
             )
+
             self.queue_message(
                 "vvvv", "ssh type is set to %s" % self.get_option("ssh_type")
             )


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes https://github.com/ansible/ansible/issues/49254
- The `ansible_host_key_checking` option was not being correctly read when set through a var.
- Adding the options in network_cli and setting this on the connection object fixes this issue.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
network_cli.py
