### PR TITLE
Bugfix issue in net_put when mode is text

### DIFF
--- a/changelogs/fragments/235-fix-net-put-issue.yaml
+++ b/changelogs/fragments/235-fix-net-put-issue.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+ - Remove temp file created when file already exist on destination when mode is 'text'.

--- a/plugins/action/net_put.py
+++ b/plugins/action/net_put.py
@@ -106,7 +106,6 @@ class ActionModule(ActionBase):
 
         if dest is None:
             dest = src_file_path_name
-
         try:
             changed = self._handle_existing_file(
                 conn, output_file, dest, proto, sock_timeout
@@ -114,6 +113,9 @@ class ActionModule(ActionBase):
             if changed is False:
                 result["changed"] = changed
                 result["destination"] = dest
+                if mode == "text":
+                    # Cleanup tmp file expanded wih ansible vars
+                    os.remove(output_file)
                 return result
         except Exception as exc:
             result["msg"] = (
@@ -169,7 +171,6 @@ class ActionModule(ActionBase):
                 if os.path.exists(tmp_source_file):
                     os.remove(tmp_source_file)
                 return True
-
         try:
             with open(source, "r") as f:
                 new_content = f.read()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Depends-On: ansible-collections/vyos.vyos#140
Depends-On: ansible-collections/arista.eos#183
Depends-On: ansible-collections/junipernetworks.junos#161

fixes: https://github.com/ansible-collections/ansible.netcommon/issues/235
cleanup temp file while file is already present on dest and mode is text


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
net_put
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
