### PR TITLE
Handle netconf plugin ncclient import error when running in FIPS mode

### DIFF
--- a/changelogs/fragments/fips-ncclient-import-error.yaml
+++ b/changelogs/fragments/fips-ncclient-import-error.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ncclient - catch and handle exception to prevent stack trace when running in FIPS mode

--- a/changelogs/fragments/fips-ncclient-import-error.yaml
+++ b/changelogs/fragments/fips-ncclient-import-error.yaml
@@ -1,2 +1,3 @@
+---
 bugfixes:
   - ncclient - catch and handle exception to prevent stack trace when running in FIPS mode

--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -212,10 +212,10 @@ try:
 
     HAS_NCCLIENT = True
     NCCLIENT_IMP_ERR = None
-except (
-    ImportError,
-    AttributeError,
-) as err:  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
+# paramiko and gssapi are incompatible and raise AttributeError not ImportError
+# When running in FIPS mode, cryptography raises InternalError
+# https://bugzilla.redhat.com/show_bug.cgi?id=1778939
+except Exception as err:
     HAS_NCCLIENT = False
     NCCLIENT_IMP_ERR = err
 

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -675,7 +675,9 @@ class Connection(NetworkConnectionBase):
         data = self._ssh_shell.read_bulk_response()
         return data if data else None
 
-    def receive_paramiko(self, command=None,
+    def receive_paramiko(
+        self,
+        command=None,
         prompts=None,
         answer=None,
         newline=True,

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -675,9 +675,7 @@ class Connection(NetworkConnectionBase):
         data = self._ssh_shell.read_bulk_response()
         return data if data else None
 
-    def receive_paramiko(
-        self,
-        command=None,
+    def receive_paramiko(self, command=None,
         prompts=None,
         answer=None,
         newline=True,


### PR DESCRIPTION
*  While running in FIPS mode importing ncclient result in
   InternalError raised by cryptography
*  Refer https://github.com/ansible/ansible/pull/65477

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  While running in FIPS mode importing ncclient result in
   InternalError raised by cryptography
*  Refer https://github.com/ansible/ansible/pull/65477 and https://github.com/ansible/ansible/pull/73992

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
connections/netconf.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
