### PR TITLE
Update no_log_values in validate_config

### DIFF
--- a/changelogs/fragments/no_log_fix.yaml
+++ b/changelogs/fragments/no_log_fix.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Let `validate_config()` update no_log_values from module spec and facts generated.

--- a/plugins/module_utils/network/common/rm_base/network_template.py
+++ b/plugins/module_utils/network/common/rm_base/network_template.py
@@ -5,11 +5,9 @@ __metaclass__ = type
 import re
 from copy import deepcopy
 
-import json
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     validate_config,
 )
-from ansible.module_utils._text import to_bytes
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     Template,
     dict_merge,

--- a/plugins/module_utils/network/common/rm_base/network_template.py
+++ b/plugins/module_utils/network/common/rm_base/network_template.py
@@ -5,14 +5,26 @@ __metaclass__ = type
 import re
 from copy import deepcopy
 
+import json
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    validate_config,
+)
+from ansible.module_utils._text import to_bytes
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     Template,
     dict_merge,
 )
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.resource_module_base import (
     RmEngineBase,
 )
+
+try:
+    # this method was renamed in 2.11 devel
+    from ansible.module_utils.common.parameters import (
+        _list_no_log_values as list_no_log_values,
+    )
+except ImportError:
+    from ansible.module_utils.common.parameters import list_no_log_values
 
 
 class NetworkTemplate(RmEngineBase):
@@ -114,3 +126,11 @@ class NetworkTemplate(RmEngineBase):
             tmplt = self.get_parser(parser_name)["setval"]
         command = self._render(tmplt, data, negate)
         return command
+
+    def validate_config(self, spec, data, redact=False):
+        validated_data = validate_config(spec, data)
+        if redact:
+            self._module.no_log_values.update(
+                list_no_log_values(spec, validated_data)
+            )
+        return validated_data

--- a/plugins/module_utils/network/common/rm_base/network_template.py
+++ b/plugins/module_utils/network/common/rm_base/network_template.py
@@ -6,11 +6,9 @@ import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    validate_config,
-)
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     Template,
     dict_merge,
+    validate_config as _validate_config,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.resource_module_base import (
     RmEngineBase,
@@ -126,7 +124,7 @@ class NetworkTemplate(RmEngineBase):
         return command
 
     def validate_config(self, spec, data, redact=False):
-        validated_data = validate_config(spec, data)
+        validated_data = _validate_config(spec, data)
         if redact:
             self._module.no_log_values.update(
                 list_no_log_values(spec, validated_data)

--- a/plugins/module_utils/network/common/rm_base/network_template.py
+++ b/plugins/module_utils/network/common/rm_base/network_template.py
@@ -15,11 +15,11 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.r
 )
 
 try:
-    # this method was renamed in 2.11 devel
     from ansible.module_utils.common.parameters import (
         _list_no_log_values as list_no_log_values,
     )
 except ImportError:
+    # TODO: Remove this import when we no longer support ansible < 2.11
     from ansible.module_utils.common.parameters import list_no_log_values
 
 

--- a/plugins/module_utils/network/common/rm_base/resource_module.py
+++ b/plugins/module_utils/network/common/rm_base/resource_module.py
@@ -13,8 +13,6 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.r
     RmEngineBase,
 )
 
-# from . import RmEngineBase
-
 
 class ResourceModule(RmEngineBase):  # pylint: disable=R0902
     """ Base class for Network Resource Modules

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -81,14 +81,6 @@ try:
 except ImportError:
     HAS_YAML = False
 
-try:
-    # this method was renamed in 2.11 devel
-    from ansible.module_utils.common.parameters import (
-        _list_no_log_values as list_no_log_values,
-    )
-except ImportError:
-    from ansible.module_utils.common.parameters import list_no_log_values
-
 OPERATORS = frozenset(["ge", "gt", "eq", "neq", "lt", "le"])
 ALIASES = frozenset(
     [("min", "ge"), ("max", "le"), ("exactly", "eq"), ("neq", "ne")]
@@ -675,7 +667,7 @@ def remove_empties(cfg_dict):
     return final_cfg
 
 
-def validate_config(spec, data, module=None):
+def validate_config(spec, data):
     """
     Validate if the input data against the AnsibleModule spec format
     :param spec: Ansible argument spec
@@ -686,8 +678,6 @@ def validate_config(spec, data, module=None):
     basic._ANSIBLE_ARGS = to_bytes(json.dumps({"ANSIBLE_MODULE_ARGS": data}))
     validated_data = basic.AnsibleModule(spec).params
     basic._ANSIBLE_ARGS = params
-    if module:
-        module.no_log_values.update(list_no_log_values(spec, validated_data))
     return validated_data
 
 

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -81,6 +81,14 @@ try:
 except ImportError:
     HAS_YAML = False
 
+try:
+    # this method was renamed in 2.11 devel
+    from ansible.module_utils.common.parameters import (
+        _list_no_log_values as list_no_log_values,
+    )
+except ImportError:
+    from ansible.module_utils.common.parameters import list_no_log_values
+
 OPERATORS = frozenset(["ge", "gt", "eq", "neq", "lt", "le"])
 ALIASES = frozenset(
     [("min", "ge"), ("max", "le"), ("exactly", "eq"), ("neq", "ne")]
@@ -679,9 +687,7 @@ def validate_config(spec, data, module=None):
     validated_data = basic.AnsibleModule(spec).params
     basic._ANSIBLE_ARGS = params
     if module:
-        module.no_log_values.update(
-            basic.list_no_log_values(spec, validated_data)
-        )
+        module.no_log_values.update(list_no_log_values(spec, validated_data))
     return validated_data
 
 

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -667,7 +667,7 @@ def remove_empties(cfg_dict):
     return final_cfg
 
 
-def validate_config(spec, data):
+def validate_config(spec, data, module=None):
     """
     Validate if the input data against the AnsibleModule spec format
     :param spec: Ansible argument spec
@@ -678,6 +678,10 @@ def validate_config(spec, data):
     basic._ANSIBLE_ARGS = to_bytes(json.dumps({"ANSIBLE_MODULE_ARGS": data}))
     validated_data = basic.AnsibleModule(spec).params
     basic._ANSIBLE_ARGS = params
+    if module:
+        module.no_log_values.update(
+            basic.list_no_log_values(spec, validated_data)
+        )
     return validated_data
 
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vyos.vyos/pull/140
Depends-On: https://github.com/ansible-collections/arista.eos/pull/183
Depends-On: https://github.com/ansible-collections/junipernetworks.junos/pull/161

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- This fix allows keys with `no_log: True` to be masked in cases where those are not present in task input but appear in module run result.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
common/utils.py