### PR TITLE
Support removal of non-config lines from running config while taking backup

### DIFF
--- a/changelogs/fragments/non_config.yaml
+++ b/changelogs/fragments/non_config.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Support removal of non-config lines from running config while taking backup.

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -109,9 +109,14 @@ class ActionModule(_ActionModule):
         filename = None
         backup_path = None
         try:
+            non_config_regexes = self._connection.cliconf.get_option(
+                "non_config_lines", task_vars
+            )
+        except KeyError:
+            non_config_regexes = []
+        try:
             content = self._sanitize_contents(
-                contents=result.pop("__backup__"),
-                filters=result.pop("__non_config_lines__", []),
+                contents=result.pop("__backup__"), filters=non_config_regexes
             )
         except KeyError:
             raise AnsibleError("Failed while reading configuration backup")

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -112,7 +112,7 @@ class ActionModule(_ActionModule):
             non_config_regexes = self._connection.cliconf.get_option(
                 "non_config_lines", task_vars
             )
-        except KeyError:
+        except (AttributeError, KeyError):
             non_config_regexes = []
         try:
             content = self._sanitize_contents(

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -111,7 +111,7 @@ class ActionModule(_ActionModule):
         try:
             content = self._sanitize_contents(
                 contents=result.pop("__backup__"),
-                filters=result.pop("__non_config_lines__"),
+                filters=result.pop("__non_config_lines__", []),
             )
         except KeyError:
             raise AnsibleError("Failed while reading configuration backup")

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -108,7 +108,6 @@ class ActionModule(_ActionModule):
 
         filename = None
         backup_path = None
-
         try:
             content = self._sanitize_contents(
                 contents=result.pop("__backup__"),


### PR DESCRIPTION
##### SUMMARY
Depends-on: https://github.com/ansible-collections/ansible.netcommon/pull/271
Depends-on: https://github.com/ansible/ansible-zuul-jobs/pull/1139

- This patch allows the platform specific config modules to remove non-config lines from backup files.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
action/network.py
