### PR TITLE
Add state purged to ACTION_STATES in old RM base class

### DIFF
--- a/changelogs/fragments/new_action_state.yaml
+++ b/changelogs/fragments/new_action_state.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Add state purged to ACTION_STATES.

--- a/plugins/module_utils/network/common/cfg/base.py
+++ b/plugins/module_utils/network/common/cfg/base.py
@@ -19,7 +19,7 @@ class ConfigBase(object):
     """ The base class for all resource modules
     """
 
-    ACTION_STATES = ["merged", "replaced", "overridden", "deleted"]
+    ACTION_STATES = ["merged", "replaced", "overridden", "deleted", "purged"]
 
     def __init__(self, module):
         self._module = module


### PR DESCRIPTION
##### SUMMARY
- This patch adds state purged to the ACTION_STATES list in the old resource module base class.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
common/cfg/base.py