### PR TITLE
Update play context for netconf connection plugin as well

### DIFF
--- a/changelogs/fragments/259-netconf-play-context.yaml
+++ b/changelogs/fragments/259-netconf-play-context.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Variables in play_context will now be updated for netconf connections on each task run.


### PR DESCRIPTION
##### SUMMARY

When a playbook modifies host variables (like `ansible_password`)
before connecting, `ansible-connect` was still using the original
value. Make it update its value as well, in the same way this is done
for `network_cli`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
connections/netconf.py

##### ADDITIONAL INFORMATION
