### PR TITLE
Add support for ProxyCommand with netconf connection

### DIFF
--- a/changelogs/fragments/support_proxycommand_netconf.yaml
+++ b/changelogs/fragments/support_proxycommand_netconf.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add support for ProxyCommand with netconf connection.

--- a/docs/ansible.netcommon.netconf_connection.rst
+++ b/docs/ansible.netcommon.netconf_connection.rst
@@ -312,6 +312,31 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_command</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">""</div>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[paramiko_connection]<br>proxy_command = </p>
+                            </div>
+                                <div>env:ANSIBLE_NETCONF_PROXY_COMMAND</div>
+                                <div>var: ansible_paramiko_proxy_command</div>
+                                <div>var: ansible_netconf_proxy_command</div>
+                    </td>
+                <td>
+                        <div>Proxy information for running the connection via a jumphost.</div>
+                        <div>This requires ncclient &gt;= 0.6.10 to be installed on the controller.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>remote_user</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/tests/unit/plugins/connection/test_netconf.py
+++ b/tests/unit/plugins/connection/test_netconf.py
@@ -39,6 +39,7 @@ PY3 = sys.version_info[0] == 3
 builtin_import = __import__
 
 mock_ncclient = MagicMock(name="ncclient")
+mock_ncclient.__version__ = "0.6.10"
 
 
 def import_mock(name, *args):


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- ncclient 0.6.10 added support for passing a ProxyCommand object with jumphost settings to connect().
- This patch is aimed at leveraging the above so that users do not have to always depend on populating their SSH config file while using jumphosts.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf.py
