### PR TITLE
Fix cli_parse issue with parsers in utils collection

### DIFF
--- a/changelogs/fragments/cli_parse_fix.yaml
+++ b/changelogs/fragments/cli_parse_fix.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix cli_parse issue with parsers in utils collection
+    (https://github.com/ansible-collections/ansible.netcommon/pull/270)

--- a/plugins/action/cli_parse.py
+++ b/plugins/action/cli_parse.py
@@ -131,6 +131,9 @@ class ActionModule(ActionBase):
                 )
             )
             self._display.warning(msg)
+            parserlib = "ansible_collections.{corg}.{cname}.plugins.sub_plugins.cli_parser.{plugin}_parser".format(
+                **cref
+            )
         elif cref["cname"] == "netcommon" and cref["plugin"] in [
             "native",
             "ntc_templates",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,5 +7,6 @@ yamllint
 
 # The follow are 3rd party libs for cli_parse
 ntc_templates
-pyats ; python_version >= '3.6' and python_version < '3.9'
-genie ; python_version >= '3.6' and python_version < '3.9'
+# 21.4 changed the output of an error message we check in tests
+pyats >= 21.4 ; python_version >= '3.6'
+genie >= 21.4 ; python_version >= '3.6'

--- a/tests/unit/plugins/cli_parsers/test_pyats_parser.py
+++ b/tests/unit/plugins/cli_parsers/test_pyats_parser.py
@@ -145,7 +145,7 @@ class TestPyatsParser(unittest.TestCase):
         error = {
             "errors": [
                 "The pyats library return an error for 'show inventory' for 'wrong_os'. "
-                "Error: Could not find parser for 'show inventory' under ('wrong_os',)."
+                "Error: Could not find parser for show inventory under ('wrong_os',)."
             ]
         }
         self.assertEqual(result, error)

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -9,8 +9,9 @@ netaddr
 
 # The follow are 3rd party libs for cli_parse
 ntc_templates
-pyats ; python_version >= '3.6' and python_version < '3.9'
-genie ; python_version >= '3.6' and python_version < '3.9'
+# 21.4 changed the output of an error message we check in tests
+pyats >= 21.4 ; python_version >= '3.6'
+genie >= 21.4 ; python_version >= '3.6'
 textfsm
 ttp
 xmltodict


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  If the parser engine is one of `json`, `textfsm`,
   `ttp` or `xml` load the parser plugn from utils collection
   as these plugins are moved to utils collection
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.netcommon.cli_parsers

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
