### PR TITLE
netconf: Avoid sending nonexistant params to old versions of ncclient

### DIFF
--- a/changelogs/fragments/ncclient-sock-arg.yaml
+++ b/changelogs/fragments/ncclient-sock-arg.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - netconf - Fix connection with ncclient versions < 0.6.10


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Older versions of ncclient do not have the sock parameter and will error with `"connect() got an unexpected keyword argument 'sock'"`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf