### PR TITLE
Add more things into bindep.txt

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -7,11 +7,17 @@ libyaml-dev [test platform:dpkg]
 python3-devel [test platform:rpm]
 python3 [test platform:rpm]
 
+# ansible-pylibssh
+gcc [compile platform:centos-8 platform:rhel-8]
+libssh-devel [compile platform:centos-8 platform:rhel-8]
+python38-Cython [compile platform:centos-8 platform:rhel-8]
+
 # ncclient
 python38-six [platform:centos-8 platform:rhel-8]
 python38-lxml [platform:centos-8 platform:rhel-8]
 
 # paramiko
+findutils [compile platform:centos-8 platform:rhel-8]
 gcc [compile platform:centos-8 platform:rhel-8]
 make [compile platform:centos-8 platform:rhel-8]
 python38-devel [compile platform:centos-8 platform:rhel-8]


### PR DESCRIPTION
These are needed to get downstream builds working for execution
envionments.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>