### PR TITLE
Make setting ansible_network_os optional for network_cli and netconf connections

### DIFF
--- a/changelogs/fragments/network_os_optional_network_cli_netconf.yaml
+++ b/changelogs/fragments/network_os_optional_network_cli_netconf.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Make ansible_network_os as optional param for network_cli and netconf connection plugins.

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -380,16 +380,6 @@ class Connection(NetworkConnectionBase):
                 raise AnsibleConnectionFailure(
                     "network os %s is not supported" % platform_type
                 )
-            else:
-                self.queue_message(
-                    "vvvv",
-                    "loaded terminal plugin %s from path %s for network_os %s"
-                    % (
-                        self.terminal._load_name,
-                        self.terminal._original_path,
-                        platform_type,
-                    ),
-                )
 
             self.cliconf = cliconf_loader.get(platform_type, self)
             if self.cliconf:
@@ -417,6 +407,7 @@ class Connection(NetworkConnectionBase):
                 "Unable to automatically determine host network os. Please "
                 "manually configure platform_type value for this host"
             )
+        self._network_os = platform_type
         self.queue_message("log", "platform_type is set to %s" % platform_type)
 
     @property
@@ -633,6 +624,11 @@ class Connection(NetworkConnectionBase):
             self._ssh_shell = ssh.ssh.invoke_shell()
             if self._ssh_type == "paramiko":
                 self._ssh_shell.settimeout(command_timeout)
+
+            self.queue_message(
+                "vvvv",
+                "loaded terminal plugin for network_os %s" % self._network_os,
+            )
 
             terminal_initial_prompt = (
                 self.get_option("terminal_initial_prompt")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Make setting ansible_network_os optional
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
network_cli
netconf

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
