### PR TITLE
Allow netcommon's base plugins to pass PluginLoader

### DIFF
--- a/changelogs/fragments/358-pluginloader.yaml
+++ b/changelogs/fragments/358-pluginloader.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - Fixed plugins inheriting from netcommon's base plugins (for example
+    httpapi/restconf or netconf/default) so that they can be properly loaded
+    (https://github.com/ansible-collections/ansible.netcommon/issues/356).

--- a/plugins/plugin_utils/cliconf_base.py
+++ b/plugins/plugin_utils/cliconf_base.py
@@ -94,7 +94,7 @@ class CliconfBase(CliconfBaseBase):
     ]
 
     def __init__(self, connection):
-        super(CliconfBase, self).__init__()
+        super(CliconfBase, self).__init__(connection)
         self._connection = connection
         self.history = list()
         self.response_logging = False

--- a/plugins/plugin_utils/cliconf_base.py
+++ b/plugins/plugin_utils/cliconf_base.py
@@ -23,9 +23,11 @@ __metaclass__ = type
 from abc import abstractmethod
 from functools import wraps
 
-from ansible.plugins import AnsiblePlugin
 from ansible.errors import AnsibleError, AnsibleConnectionFailure
 from ansible.module_utils._text import to_bytes, to_text
+
+# Needed to satisfy PluginLoader's required_base_class
+from ansible.plugins.cliconf import CliconfBase as CliconfBaseBase
 
 try:
     from scp import SCPClient
@@ -50,7 +52,7 @@ def enable_mode(func):
     return wrapped
 
 
-class CliconfBase(AnsiblePlugin):
+class CliconfBase(CliconfBaseBase):
     """
     A base class for implementing cli connections
 

--- a/plugins/plugin_utils/httpapi_base.py
+++ b/plugins/plugin_utils/httpapi_base.py
@@ -7,10 +7,11 @@ __metaclass__ = type
 
 from abc import abstractmethod
 
-from ansible.plugins import AnsiblePlugin
+# Needed to satisfy PluginLoader's required_base_class
+from ansible.plugins.httpapi import HttpApiBase as HttpApiBaseBase
 
 
-class HttpApiBase(AnsiblePlugin):
+class HttpApiBase(HttpApiBaseBase):
     def __init__(self, connection):
         super(HttpApiBase, self).__init__()
 

--- a/plugins/plugin_utils/httpapi_base.py
+++ b/plugins/plugin_utils/httpapi_base.py
@@ -13,7 +13,7 @@ from ansible.plugins.httpapi import HttpApiBase as HttpApiBaseBase
 
 class HttpApiBase(HttpApiBaseBase):
     def __init__(self, connection):
-        super(HttpApiBase, self).__init__()
+        super(HttpApiBase, self).__init__(connection)
 
         self.connection = connection
         self._become = False

--- a/plugins/plugin_utils/netconf_base.py
+++ b/plugins/plugin_utils/netconf_base.py
@@ -134,7 +134,7 @@ class NetconfBase(NetconfBaseBase):
     ]
 
     def __init__(self, connection):
-        super(NetconfBase, self).__init__()
+        super(NetconfBase, self).__init__(connection)
         self._connection = connection
 
     @property

--- a/plugins/plugin_utils/netconf_base.py
+++ b/plugins/plugin_utils/netconf_base.py
@@ -24,9 +24,11 @@ from abc import abstractmethod
 from functools import wraps
 
 from ansible.errors import AnsibleError
-from ansible.plugins import AnsiblePlugin
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import missing_required_lib
+
+# Needed to satisfy PluginLoader's required_base_class
+from ansible.plugins.netconf import NetconfBase as NetconfBaseBase
 
 try:
     from ncclient.operations import RPCError
@@ -63,7 +65,7 @@ def ensure_ncclient(func):
     return wrapped
 
 
-class NetconfBase(AnsiblePlugin):
+class NetconfBase(NetconfBaseBase):
     """
     A base class for implementing Netconf connections
 

--- a/plugins/plugin_utils/terminal_base.py
+++ b/plugins/plugin_utils/terminal_base.py
@@ -22,10 +22,6 @@ __metaclass__ = type
 
 import re
 
-from abc import ABCMeta
-
-from ansible.module_utils.six import with_metaclass
-
 # Needed to satisfy PluginLoader's required_base_class
 from ansible.plugins.terminal import TerminalBase as TerminalBaseBase
 

--- a/plugins/plugin_utils/terminal_base.py
+++ b/plugins/plugin_utils/terminal_base.py
@@ -26,8 +26,11 @@ from abc import ABCMeta
 
 from ansible.module_utils.six import with_metaclass
 
+# Needed to satisfy PluginLoader's required_base_class
+from ansible.plugins.terminal import TerminalBase as TerminalBaseBase
 
-class TerminalBase(with_metaclass(ABCMeta, object)):
+
+class TerminalBase(TerminalBaseBase):
     """
     A base class for implementing cli connections
 

--- a/plugins/plugin_utils/terminal_base.py
+++ b/plugins/plugin_utils/terminal_base.py
@@ -62,6 +62,7 @@ class TerminalBase(TerminalBaseBase):
     terminal_inital_prompt_newline = True
 
     def __init__(self, connection):
+        super(TerminalBase, self).__init__(connection)
         self._connection = connection
 
     def _exec_cli_command(self, cmd, check_rc=True):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #356 

See https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/loader.py#L834

PluginLoader gets the required base class by name, and imports it from the ansible package, and checks if the found plugin is a subclass of that class. Our shiny new base plugins aren't, so the check fails and the plugin is skipped.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugin_utils/terminal_base.py