### PR TITLE
[network_cli] Add toggle for matched prompt stripping

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ This includes  connection plugins, such as ``network_cli``, ``httpapi``, and ``n
 
 This collection has been tested against following Ansible versions: **>=2.9.10**.
 
-For collections that support Ansible 2.9, please ensure you update your `network_os` to use the
-fully qualified collection name (for example, `cisco.ios.ios`).
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.
 PEP440 is the schema used to describe the versions of Ansible.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This includes  connection plugins, such as ``network_cli``, ``httpapi``, and ``n
 
 This collection has been tested against following Ansible versions: **>=2.9.10**.
 
+For collections that support Ansible 2.9, please ensure you update your `network_os` to use the
+fully qualified collection name (for example, `cisco.ios.ios`).
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.
 PEP440 is the schema used to describe the versions of Ansible.

--- a/changelogs/fragments/add_remove_prompt.yaml
+++ b/changelogs/fragments/add_remove_prompt.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Add an option that determines whether network_cli strips matched prompts from returned responses or not.

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -1130,12 +1130,12 @@ class Connection(NetworkConnectionBase):
             if command and line.strip() == command.strip():
                 continue
 
-            if strip_prompt:
-                for prompt in self._matched_prompt.strip().splitlines():
-                    if prompt.strip() in line:
-                        break
+            for prompt in self._matched_prompt.strip().splitlines():
+                if prompt.strip() in line and strip_prompt:
+                    break
             else:
                 cleaned.append(line)
+
         return b"\n".join(cleaned).strip()
 
     def _find_error(self, response):

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -720,7 +720,7 @@ class Connection(NetworkConnectionBase):
         newline=True,
         prompt_retry_check=False,
         check_all=False,
-        remove_prompt=True,
+        strip_prompt=True,
     ):
 
         recv = BytesIO()
@@ -811,7 +811,7 @@ class Connection(NetworkConnectionBase):
                 self._last_response = recv.getvalue()
                 resp = self._strip(self._last_response)
                 self._command_response = self._sanitize(
-                    resp, command, remove_prompt
+                    resp, command, strip_prompt
                 )
                 if self._buffer_read_timeout == 0.0:
                     # reset socket timeout to global timeout
@@ -828,7 +828,7 @@ class Connection(NetworkConnectionBase):
         newline=True,
         prompt_retry_check=False,
         check_all=False,
-        remove_prompt=True,
+        strip_prompt=True,
     ):
         self._command_response = resp = b""
         command_prompt_matched = False
@@ -896,7 +896,7 @@ class Connection(NetworkConnectionBase):
                     raise AnsibleConnectionFailure(errored_response)
                 self._last_response = data
                 self._command_response += self._sanitize(
-                    resp, command, remove_prompt
+                    resp, command, strip_prompt
                 )
                 command_prompt_matched = True
 
@@ -908,7 +908,7 @@ class Connection(NetworkConnectionBase):
         newline=True,
         prompt_retry_check=False,
         check_all=False,
-        remove_prompt=True,
+        strip_prompt=True,
     ):
         """
         Handles receiving of output from command
@@ -947,7 +947,7 @@ class Connection(NetworkConnectionBase):
                 newline,
                 prompt_retry_check,
                 check_all,
-                remove_prompt,
+                strip_prompt,
             )
         else:
             response = self.receive_paramiko(
@@ -957,7 +957,7 @@ class Connection(NetworkConnectionBase):
                 newline,
                 prompt_retry_check,
                 check_all,
-                remove_prompt,
+                strip_prompt,
             )
 
         return response
@@ -972,7 +972,7 @@ class Connection(NetworkConnectionBase):
         sendonly=False,
         prompt_retry_check=False,
         check_all=False,
-        remove_prompt=True,
+        strip_prompt=True,
     ):
         """
         Sends the command to the device in the opened shell
@@ -1008,7 +1008,7 @@ class Connection(NetworkConnectionBase):
                 newline,
                 prompt_retry_check,
                 check_all,
-                remove_prompt,
+                strip_prompt,
             )
             response = to_text(response, errors="surrogate_then_replace")
 
@@ -1121,7 +1121,7 @@ class Connection(NetworkConnectionBase):
                 return True
         return False
 
-    def _sanitize(self, resp, command=None, remove_prompt=True):
+    def _sanitize(self, resp, command=None, strip_prompt=True):
         """
         Removes elements from the response before returning to the caller
         """
@@ -1130,7 +1130,7 @@ class Connection(NetworkConnectionBase):
             if command and line.strip() == command.strip():
                 continue
 
-            if remove_prompt:
+            if strip_prompt:
                 for prompt in self._matched_prompt.strip().splitlines():
                     if prompt.strip() in line:
                         break

--- a/plugins/plugin_utils/cliconf_base.py
+++ b/plugins/plugin_utils/cliconf_base.py
@@ -117,6 +117,7 @@ class CliconfBase(CliconfBaseBase):
         newline=True,
         prompt_retry_check=False,
         check_all=False,
+        strip_prompt=True,
     ):
         """Executes a command over the device connection
 
@@ -132,6 +133,7 @@ class CliconfBase(CliconfBaseBase):
         :param prompt_retry_check: Bool value for trying to detect more prompts
         :param check_all: Bool value to indicate if all the values in prompt sequence should be matched or any one of
                           given prompt.
+        :param strip_prompt: Bool value to indicate if the matched prompt is removed from the returned response or not.
         :returns: The output from the device after executing the command
         """
         kwargs = {
@@ -140,6 +142,7 @@ class CliconfBase(CliconfBaseBase):
             "newline": newline,
             "prompt_retry_check": prompt_retry_check,
             "check_all": check_all,
+            "strip_prompt": strip_prompt,
         }
 
         if prompt is not None:


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

Depends-On: https://github.com/ansible-collections/ansible.netcommon/pull/370

##### SUMMARY
- Add an option that determines if _sanitize() removes matched prompts from received responses.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
network_cli.py
