### PR TITLE
DNM Github action for running `ansible-test sanity` and `ansible-test units`

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,0 +1,11 @@
+name: Sanity
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  sanity:
+    uses: ansible-network/github_actions/.github/workflows/sanity.yml@main

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,11 @@
+name: Units
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  unit:
+    uses: ansible-network/github_actions/.github/workflows/unit.yml@main

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -9,5 +9,3 @@ on:
 jobs:
   unit:
     uses: ansible-network/github_actions/.github/workflows/unit.yml@main
-    with:
-      system_packages: libssh-dev

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -9,3 +9,5 @@ on:
 jobs:
   unit:
     uses: ansible-network/github_actions/.github/workflows/unit.yml@main
+    with:
+      system_packages: libssh-dev

--- a/bindep.txt
+++ b/bindep.txt
@@ -9,6 +9,7 @@ python3 [test platform:rpm]
 
 # ansible-pylibssh
 gcc [compile test platform:rpm]
+libssh-dev [compile test platform:dpkg]
 libssh-devel [compile test platform:rpm]
 python3-Cython [test platform:fedora-35 platform:rhel-9]
 # 3.9 Cython doesn't seem to be available on our centos-8 images

--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -158,7 +158,9 @@ from ansible.plugins.connection import ensure_connect
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.connection_base import (
     NetworkConnectionBase,
 )
-from distutils.version import LooseVersion
+from ansible_collections.ansible.netcommon.plugins.plugin_utils.version import (
+    Version,
+)
 
 try:
     from ncclient import __version__ as NCCLIENT_VERSION
@@ -282,7 +284,7 @@ class Connection(NetworkConnectionBase):
 
         sock = None
         if proxy_command:
-            if LooseVersion(NCCLIENT_VERSION) < LooseVersion("0.6.10"):
+            if Version(NCCLIENT_VERSION) < "0.6.10":
                 raise AnsibleError(
                     "Configuring jumphost settings through ProxyCommand is unsupported in ncclient version %s. "
                     "Please upgrade to ncclient 0.6.10 or newer."

--- a/plugins/plugin_utils/version.py
+++ b/plugins/plugin_utils/version.py
@@ -1,0 +1,43 @@
+# (c) 2022 Red Hat Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from functools import total_ordering
+
+
+@total_ordering
+class Version:
+    """Simple class to compare arbitrary versions"""
+
+    def __init__(self, version_string):
+        self.components = version_string.split(".")
+
+    def __eq__(self, other):
+        other = _coerce(other)
+        if not isinstance(other, Version):
+            return NotImplemented
+
+        return self.components == other.components
+
+    def __ne__(self, other):
+        other = _coerce(other)
+        if not isinstance(other, Version):
+            return NotImplemented
+
+        return self.components != other.components
+
+    def __lt__(self, other):
+        other = _coerce(other)
+        if not isinstance(other, Version):
+            return NotImplemented
+
+        return self.components < other.components
+
+
+def _coerce(other):
+    if isinstance(other, str):
+        other = Version(other)
+    return other

--- a/tests/unit/plugins/connection/test_libssh.py
+++ b/tests/unit/plugins/connection/test_libssh.py
@@ -23,7 +23,9 @@ pylibsshext = pytest.importorskip("pylibsshext")
 
 class TestConnectionClass(unittest.TestCase):
     @patch("pylibsshext.session.Session")
-    @patch("ansible_collections.ansible.netcommon.plugins.connection.libssh.Connection._connect")
+    @patch(
+        "ansible_collections.ansible.netcommon.plugins.connection.libssh.Connection._connect"
+    )
     def test_libssh_connect(self, mocked_super, mock_session):
         pc = PlayContext()
         pc.remote_addr = "localhost"

--- a/tests/unit/plugins/connection/test_libssh.py
+++ b/tests/unit/plugins/connection/test_libssh.py
@@ -46,7 +46,7 @@ def test_libssh_connect(monkeypatch):
         }
     )
 
-    call_args, call_kwargs = None, None
+    all_args = {"call_args": {}, "call_kwargs": {}}
 
     class Session(libssh.Session):
         """A session object used to patch libssh.Session"""
@@ -58,8 +58,8 @@ def test_libssh_connect(monkeypatch):
             :param kwargs: Keyword arguments
             :raises AnsibleConnectionFailure: Always
             """
-            nonlocal call_args, call_kwargs
-            call_args, call_kwargs = args, kwargs
+            all_args["call_args"] = args
+            all_args["call_kwargs"] = kwargs
             raise AnsibleConnectionFailure
 
     monkeypatch.setattr(libssh, "Session", Session)
@@ -67,7 +67,7 @@ def test_libssh_connect(monkeypatch):
     with pytest.raises(AnsibleConnectionFailure):
         conn._connect()
 
-    assert call_kwargs == {
+    assert all_args['call_kwargs'] == {
         "host": "localhost",
         "host_key_checking": False,
         "look_for_keys": True,
@@ -98,7 +98,7 @@ def test_libssh_fetch_file(monkeypatch):
 
     monkeypatch.setattr(libssh, "Session", Session)
 
-    call_args, call_kwargs = None, None
+    all_args = {"call_args": {}, "call_kwargs": {}}
 
     def fetch_file(*args, **kwargs):
         """Stores the arguments and keyword arguments for later use.
@@ -107,8 +107,8 @@ def test_libssh_fetch_file(monkeypatch):
         :param kwargs: Keyword arguments
         :raises AnsibleFileNotFound: Always
         """
-        nonlocal call_args, call_kwargs
-        call_args, call_kwargs = args, kwargs
+        all_args["call_args"] = args
+        all_args["call_kwargs"] = kwargs
         raise AnsibleFileNotFound
 
     file_path = "test_libssh.py"
@@ -117,7 +117,7 @@ def test_libssh_fetch_file(monkeypatch):
     with pytest.raises(AnsibleFileNotFound):
         conn.fetch_file(in_path=file_path, out_path=file_path)
 
-    assert call_kwargs == {"in_path": file_path, "out_path": file_path}
+    assert all_args["call_kwargs"] == {"in_path": file_path, "out_path": file_path}
 
 
 class TestConnectionClass(unittest.TestCase):

--- a/tests/unit/plugins/connection/test_libssh.py
+++ b/tests/unit/plugins/connection/test_libssh.py
@@ -23,7 +23,7 @@ pylibsshext = pytest.importorskip("pylibsshext")
 
 class TestConnectionClass(unittest.TestCase):
     @patch("pylibsshext.session.Session")
-    @patch("ansible.plugins.connection.ConnectionBase._connect")
+    @patch("ansible_collections.ansible.netcommon.plugins.connection.libssh.Connection._connect")
     def test_libssh_connect(self, mocked_super, mock_session):
         pc = PlayContext()
         pc.remote_addr = "localhost"

--- a/tests/unit/plugins/connection/test_libssh.py
+++ b/tests/unit/plugins/connection/test_libssh.py
@@ -27,11 +27,8 @@ from ansible_collections.ansible.netcommon.plugins.connection import libssh
 pylibsshext = pytest.importorskip("pylibsshext")
 
 
-def test_libssh_connect(monkeypatch):
-    """Test the libssh connection plugin.
-
-    :param monkeypatch: pytest fixture
-    """
+@pytest.fixture(name="conn")
+def plugin_fixture(monkeypatch):
     pc = PlayContext()
     pc.remote_addr = "localhost"
     pc.password = "test"
@@ -40,6 +37,14 @@ def test_libssh_connect(monkeypatch):
     pc.remote_user = "user1"
 
     conn = connection_loader.get("ansible.netcommon.libssh", pc, "/dev/null")
+    return conn
+
+
+def test_libssh_connect(conn, monkeypatch):
+    """Test the libssh connection plugin.
+
+    :param monkeypatch: pytest fixture
+    """
     conn.set_options(
         direct={
             "host_key_checking": False,
@@ -79,80 +84,59 @@ def test_libssh_connect(monkeypatch):
     }
 
 
-class TestConnectionClass(unittest.TestCase):
-    def test_libssh_close(self):
-        pc = PlayContext()
-        conn = connection_loader.get(
-            "ansible.netcommon.libssh", pc, "/dev/null"
-        )
-        conn.ssh = MagicMock()
-        conn.sftp = MagicMock()
-        conn.chan = MagicMock()
+def test_libssh_close(conn):
+    conn.ssh = MagicMock()
+    conn.sftp = MagicMock()
+    conn.chan = MagicMock()
 
-        conn.close()
+    conn.close()
 
-        conn.sftp.close.assert_called_with()
-        conn.chan.close.assert_called_with()
-        conn.sftp.close.assert_called_with()
-
-    @patch("ansible.plugins.connection.ConnectionBase.exec_command")
-    def test_libssh_exec_command(self, mocked_super):
-        pc = PlayContext()
-        conn = connection_loader.get(
-            "ansible.netcommon.libssh", pc, "/dev/null"
-        )
-        with self.assertRaises(AnsibleError):
-            conn.exec_command(cmd="ls", in_data=True)
-
-        mock_chan = MagicMock()
-        mock_chan.request_shell = MagicMock()
-        mock_chan.exec_command = MagicMock()
-        mock_chan.exec_command.return_value = MagicMock(
-            returncode=0, stdout="echo hello", stderr=""
-        )
-
-        attr = {"new_channel.return_value": mock_chan}
-        mock_ssh = MagicMock(**attr)
-        conn.ssh = mock_ssh
-
-        rc, out, err = conn.exec_command(cmd="echo hello")
-
-        self.assertEqual((rc, out, err), (0, "echo hello", ""))
-
-    @patch("ansible.plugins.connection.ConnectionBase.put_file")
-    def test_libssh_put_file_not_exist(self, mocked_super):
-        pc = PlayContext()
-        conn = connection_loader.get(
-            "ansible.netcommon.libssh", pc, "/dev/null"
-        )
-        with self.assertRaises(AnsibleFileNotFound):
-            conn.put_file(in_path="", out_path="")
-
-    @patch("os.path.exists")
-    @patch("ansible.plugins.connection.ConnectionBase.put_file")
-    def test_libssh_put_file(self, mocked_super, mock_exists):
-        pc = PlayContext()
-        conn = connection_loader.get(
-            "ansible.netcommon.libssh", pc, "/dev/null"
-        )
-
-        mock_sftp = MagicMock()
-        attr = {"sftp.return_value": mock_sftp}
-        mock_ssh = MagicMock(**attr)
-        conn.ssh = mock_ssh
-
-        file_path = "test_libssh.py"
-        conn.put_file(in_path=file_path, out_path=file_path)
-        mock_sftp.put.assert_called_with(
-            to_bytes(file_path), to_bytes(file_path)
-        )
+    conn.sftp.close.assert_called_with()
+    conn.chan.close.assert_called_with()
+    conn.sftp.close.assert_called_with()
 
 
-def test_libssh_fetch_file(monkeypatch):
-    pc = PlayContext()
-    pc.remote_addr = "localhost"
-    conn = connection_loader.get("ansible.netcommon.libssh", pc, "/dev/null")
+@patch("ansible.plugins.connection.ConnectionBase.exec_command")
+def test_libssh_exec_command(mocked_super, conn):
+    with pytest.raises(AnsibleError):
+        conn.exec_command(cmd="ls", in_data=True)
 
+    mock_chan = MagicMock()
+    mock_chan.request_shell = MagicMock()
+    mock_chan.exec_command = MagicMock()
+    mock_chan.exec_command.return_value = MagicMock(
+        returncode=0, stdout="echo hello", stderr=""
+    )
+
+    attr = {"new_channel.return_value": mock_chan}
+    mock_ssh = MagicMock(**attr)
+    conn.ssh = mock_ssh
+
+    rc, out, err = conn.exec_command(cmd="echo hello")
+
+    assert (rc, out, err) == (0, "echo hello", "")
+
+
+@patch("ansible.plugins.connection.ConnectionBase.put_file")
+def test_libssh_put_file_not_exist(mocked_super, conn):
+    with pytest.raises(AnsibleFileNotFound):
+        conn.put_file(in_path="", out_path="")
+
+
+@patch("os.path.exists")
+@patch("ansible.plugins.connection.ConnectionBase.put_file")
+def test_libssh_put_file(mocked_super, mock_exists, conn):
+    mock_sftp = MagicMock()
+    attr = {"sftp.return_value": mock_sftp}
+    mock_ssh = MagicMock(**attr)
+    conn.ssh = mock_ssh
+
+    file_path = "test_libssh.py"
+    conn.put_file(in_path=file_path, out_path=file_path)
+    mock_sftp.put.assert_called_with(to_bytes(file_path), to_bytes(file_path))
+
+
+def test_libssh_fetch_file(conn, monkeypatch):
     class Session(libssh.Session):
         """A session object used to patch libssh.Session"""
 

--- a/tests/unit/plugins/connection/test_libssh.py
+++ b/tests/unit/plugins/connection/test_libssh.py
@@ -67,7 +67,7 @@ def test_libssh_connect(monkeypatch):
     with pytest.raises(AnsibleConnectionFailure):
         conn._connect()
 
-    assert all_args['call_kwargs'] == {
+    assert all_args["call_kwargs"] == {
         "host": "localhost",
         "host_key_checking": False,
         "look_for_keys": True,
@@ -117,7 +117,10 @@ def test_libssh_fetch_file(monkeypatch):
     with pytest.raises(AnsibleFileNotFound):
         conn.fetch_file(in_path=file_path, out_path=file_path)
 
-    assert all_args["call_kwargs"] == {"in_path": file_path, "out_path": file_path}
+    assert all_args["call_kwargs"] == {
+        "in_path": file_path,
+        "out_path": file_path,
+    }
 
 
 class TestConnectionClass(unittest.TestCase):

--- a/tests/unit/plugins/connection/test_network_cli.py
+++ b/tests/unit/plugins/connection/test_network_cli.py
@@ -44,7 +44,7 @@ def plugin_fixture(monkeypatch):
     pc.network_os = "fakeos"
 
     def get(*args, **kwargs):
-        return True
+        return MagicMock()
 
     monkeypatch.setattr(terminal_loader, "get", get)
     conn = connection_loader.get(
@@ -197,9 +197,9 @@ def test_network_cli_send(conn, response, ssh_type):
     conn._ssh_shell = mock__shell
     conn._connected = True
 
-    if ssh_type == "paramiko":
+    if conn.ssh_type == "paramiko":
         mock__shell.recv.side_effect = [response, None]
-    else:
+    elif conn.ssh_type == "libssh":
         mock__shell.read_bulk_response.side_effect = [response, None]
     conn.send(b"command")
 

--- a/tests/unit/plugins/connection/test_network_cli.py
+++ b/tests/unit/plugins/connection/test_network_cli.py
@@ -43,6 +43,7 @@ def plugin_fixture(mocked_loader):
     conn = connection_loader.get(
         "ansible.netcommon.network_cli", pc, "/dev/null"
     )
+    assert conn is not None
     return conn
 
 

--- a/tests/unit/plugins/connection/test_network_cli.py
+++ b/tests/unit/plugins/connection/test_network_cli.py
@@ -35,11 +35,21 @@ import pytest
 
 
 @pytest.fixture(name="conn")
-@patch("ansible.plugins.loader.terminal_loader")
-def plugin_fixture(mocked_loader):
+def plugin_fixture(monkeypatch):
+
     pc = PlayContext()
     pc.network_os = "fakeos"
-    mocked_loader.get.return_value = MagicMock()
+
+    def get(*args, **kwargs):
+        return True
+
+    monkeypatch.setattr(
+        (
+            "ansible_collections.ansible.netcommon.plugins"
+            ".connection.network_cli.terminal_loader.get"
+        ),
+        get,
+    )
     conn = connection_loader.get(
         "ansible.netcommon.network_cli", pc, "/dev/null"
     )

--- a/tests/unit/plugins/connection/test_network_cli.py
+++ b/tests/unit/plugins/connection/test_network_cli.py
@@ -27,6 +27,9 @@ from unittest.mock import (
     MagicMock,
     patch,
 )
+from ansible_collections.ansible.netcommon.plugins.connection.network_cli import (
+    terminal_loader,
+)
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text
 from ansible.playbook.play_context import PlayContext
@@ -43,17 +46,10 @@ def plugin_fixture(monkeypatch):
     def get(*args, **kwargs):
         return True
 
-    monkeypatch.setattr(
-        (
-            "ansible_collections.ansible.netcommon.plugins"
-            ".connection.network_cli.terminal_loader.get"
-        ),
-        get,
-    )
+    monkeypatch.setattr(terminal_loader, "get", get)
     conn = connection_loader.get(
         "ansible.netcommon.network_cli", pc, "/dev/null"
     )
-    assert conn is not None
     return conn
 
 


### PR DESCRIPTION
This is a test of using GitHub actions for sanity and unit tests.

It should be broken into several PRs and not merged as is:

1) NCLIENT version change, removing dependency on distutils
2) Rewrite of the libssh tests
3) Rewrite of the network_cli test
3) the addition of the pyproject.toml file

Additionally, https://github.com/ansible-network/github_actions/blob/main/.github/actions/build_install_collection/action.yml#L53 should point to a released version of the pytest plugin. not main

and finally, this PR should include the .github files.
 
