### PR TITLE
Fix inventory_hostname being returned when looking for the remote hostname

### DIFF
--- a/changelogs/fragments/remote_addr.yaml
+++ b/changelogs/fragments/remote_addr.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - libssh - Fix for improperly set hostname in url
+  - httpapi - Fix for improperly set hostname in connect

--- a/docs/ansible.netcommon.httpapi_connection.rst
+++ b/docs/ansible.netcommon.httpapi_connection.rst
@@ -94,6 +94,7 @@ Parameters
                         <b>Default:</b><br/><div style="color: blue">"inventory_hostname"</div>
                 </td>
                     <td>
+                                <div>var: inventory_hostname</div>
                                 <div>var: ansible_host</div>
                     </td>
                 <td>

--- a/docs/ansible.netcommon.libssh_connection.rst
+++ b/docs/ansible.netcommon.libssh_connection.rst
@@ -190,6 +190,7 @@ Parameters
                         <b>Default:</b><br/><div style="color: blue">"inventory_hostname"</div>
                 </td>
                     <td>
+                                <div>var: inventory_hostname</div>
                                 <div>var: ansible_host</div>
                                 <div>var: ansible_ssh_host</div>
                                 <div>var: ansible_libssh_host</div>

--- a/docs/ansible.netcommon.napalm_connection.rst
+++ b/docs/ansible.netcommon.napalm_connection.rst
@@ -60,6 +60,7 @@ Parameters
                         <b>Default:</b><br/><div style="color: blue">"inventory_hostname"</div>
                 </td>
                     <td>
+                                <div>var: inventory_hostname</div>
                                 <div>var: ansible_host</div>
                     </td>
                 <td>

--- a/docs/ansible.netcommon.netconf_connection.rst
+++ b/docs/ansible.netcommon.netconf_connection.rst
@@ -54,6 +54,7 @@ Parameters
                         <b>Default:</b><br/><div style="color: blue">"inventory_hostname"</div>
                 </td>
                     <td>
+                                <div>var: inventory_hostname</div>
                                 <div>var: ansible_host</div>
                     </td>
                 <td>

--- a/docs/ansible.netcommon.network_cli_connection.rst
+++ b/docs/ansible.netcommon.network_cli_connection.rst
@@ -124,6 +124,7 @@ Parameters
                         <b>Default:</b><br/><div style="color: blue">"inventory_hostname"</div>
                 </td>
                     <td>
+                                <div>var: inventory_hostname</div>
                                 <div>var: ansible_host</div>
                     </td>
                 <td>

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -23,6 +23,7 @@ options:
       to.
     default: inventory_hostname
     vars:
+    - name: inventory_hostname
     - name: ansible_host
   port:
     type: int

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -20,6 +20,7 @@ DOCUMENTATION = """
             - Address of the remote target
         default: inventory_hostname
         vars:
+            - name: inventory_hostname
             - name: ansible_host
             - name: ansible_ssh_host
             - name: ansible_libssh_host

--- a/plugins/connection/napalm.py
+++ b/plugins/connection/napalm.py
@@ -31,6 +31,7 @@ options:
       to.
     default: inventory_hostname
     vars:
+    - name: inventory_hostname
     - name: ansible_host
   port:
     type: int

--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -29,6 +29,7 @@ options:
       to.
     default: inventory_hostname
     vars:
+    - name: inventory_hostname
     - name: ansible_host
   port:
     type: int

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -27,6 +27,7 @@ options:
       to.
     default: inventory_hostname
     vars:
+    - name: inventory_hostname
     - name: ansible_host
   port:
     type: int


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
I don't think network_cli needs this (or any?) value defined for host, but it is included for completeness and documentation

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
httpapi
libssh
napalm, probably
netconf