### PR TITLE
Limit concurrency for github actions for a single PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,10 @@
 ---
 name: Test collection
+
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: [main]

--- a/changelogs/fragments/432.yaml
+++ b/changelogs/fragments/432.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Enable concurrency check for PRs & GHA


### PR DESCRIPTION
##### SUMMARY
- Limit the number of concurrent action runs for a single PR
- When a new push to an existing PR is made, previous actions will be canceled
- This is common for changelog additions and pre-commit changes

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Github actions

##### ADDITIONAL INFORMATION
```
