### PR TITLE
Add password_prompt option to libssh

### DIFF
--- a/changelogs/fragments/libssh-password-prompt.yaml
+++ b/changelogs/fragments/libssh-password-prompt.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - libssh - Added `password_prompt` option to override default "password:" prompt used by pylibssh

--- a/docs/ansible.netcommon.libssh_connection.rst
+++ b/docs/ansible.netcommon.libssh_connection.rst
@@ -133,6 +133,26 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password_prompt</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                                <div>var: ansible_libssh_password_prompt</div>
+                    </td>
+                <td>
+                        <div>Text to match when using keyboard-interactive authentication to determine if the prompt is for the password.</div>
+                        <div>Requires ansible-pylibssh version &gt;= 1.0.0</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>proxy_command</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -50,6 +50,14 @@ DOCUMENTATION = """
             - name: ansible_ssh_password
             - name: ansible_libssh_pass
             - name: ansible_libssh_password
+      password_prompt:
+        description:
+          - Text to match when using keyboard-interactive authentication to determine if the prompt is
+            for the password.
+          - Requires ansible-pylibssh version >= 1.0.0
+        vars:
+          - name: ansible_libssh_password_prompt
+        version_added: 3.1.0
       host_key_auto_add:
         description: 'TODO: write it'
         env: [{name: ANSIBLE_LIBSSH_HOST_KEY_AUTO_ADD}]
@@ -329,6 +337,7 @@ class Connection(ConnectionBase):
                 look_for_keys=self.get_option("look_for_keys"),
                 host_key_checking=self.get_option("host_key_checking"),
                 password=self.get_option("password"),
+                password_prompt=self.get_option("password_prompt"),
                 private_key=private_key,
                 timeout=self._play_context.timeout,
                 port=port,

--- a/tests/unit/plugins/connection/test_libssh.py
+++ b/tests/unit/plugins/connection/test_libssh.py
@@ -52,6 +52,7 @@ def test_libssh_connect(conn, monkeypatch):
         host_key_checking=False,
         look_for_keys=True,
         password="test",
+        password_prompt=None,
         port=8080,
         timeout=60,
         user="user1",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
See https://github.com/ansible/pylibssh/pull/331

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
libssh