### PR TITLE
Added crlf/lf option to telnet

### DIFF
--- a/changelogs/fragments/440-telnet-add-crlf-option.yml
+++ b/changelogs/fragments/440-telnet-add-crlf-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - telnet - add crlf option to send CRLF instead of just LF (https://github.com/ansible-collections/ansible.netcommon/pull/440).

--- a/docs/ansible.netcommon.telnet_module.rst
+++ b/docs/ansible.netcommon.telnet_module.rst
@@ -55,6 +55,25 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>crlf</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Sends a CRLF (Carrage Return) instead of just a LF (Line Feed).</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/modules/telnet.py
+++ b/plugins/modules/telnet.py
@@ -84,6 +84,12 @@ options:
     required: false
     type: bool
     default: false
+  crlf:
+    description:
+    - Sends a CRLF (Carrage Return) instead of just a LF (Line Feed).
+    required: false
+    type: bool
+    default: false
 notes:
 - The C(environment) keyword does not work with this task
 author:


### PR DESCRIPTION
##### SUMMARY
Adds option to send a CLRF instead of a LF when talking to a device via telnet.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
telnet

##### ADDITIONAL INFORMATION
When attempting to use this plugin to send commands to a service that uses telnet I noticed that it required CLRF to "submit" the input (in this case being the username prompt). After just changing the strings to be CLRF I decided to add the functionality just incase someone else tries to use it in the future and hits this issue.
I've tested the code with the play that I was attempting to use it with success and original functionality should stay the same to not break existing plays.

Please let me know if you'd like me to make any changes. Thanks.