### PR TITLE
[network_cli] handle terminal errors

### DIFF
--- a/changelogs/fragments/terminal_errors.yaml
+++ b/changelogs/fragments/terminal_errors.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Adds a new option `terminal_errors` in network_cli, that determines how terminal setting failures are handled."

--- a/docs/ansible.netcommon.network_cli_connection.rst
+++ b/docs/ansible.netcommon.network_cli_connection.rst
@@ -480,6 +480,30 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>terminal_errors</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>ignore</li>
+                                    <li>warn</li>
+                                    <li><div style="color: blue"><b>fail</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                    <td>
+                                <div>var: ansible_network_terminal_errors</div>
+                    </td>
+                <td>
+                        <div>This option determines how failures while setting terminal parameters are handled.</div>
+                        <div>When set to <code>ignore</code>, the errors are silently ignored. When set to <code>warn</code>, a warning message is displayed. The default option <code>fail</code>, triggers a failure and halts execution.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>terminal_inital_prompt_newline</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/docs/ansible.netcommon.network_cli_connection.rst
+++ b/docs/ansible.netcommon.network_cli_connection.rst
@@ -485,6 +485,7 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
                 </td>
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -122,6 +122,7 @@ options:
     - name: ansible_network_terminal_errors
     default: fail
     choices: ["ignore", "warn", "fail"]
+    version_added: 3.1.0
   become_method:
     description:
     - This option allows the become method to be specified in for handling privilege

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -113,8 +113,8 @@ options:
   terminal_errors:
     type: str
     description:
-    - This option determines how failures while setting terminal parameters 
-      are handled.    
+    - This option determines how failures while setting terminal parameters
+      are handled.
     - When set to C(ignore), the errors are silently ignored.
       When set to C(warn), a warning message is displayed.
       The default option C(fail), triggers a failure and halts execution.
@@ -717,7 +717,7 @@ class Connection(NetworkConnectionBase):
                 )
             else:
                 raise
-    
+
     def _on_open_shell(self):
         """
         Wraps terminal.on_open_shell() to handle
@@ -731,7 +731,8 @@ class Connection(NetworkConnectionBase):
                 pass
             elif on_terminal_error == "warn":
                 self.queue_message(
-                    "warning", "on_open_shell: failed to set terminal parameters"
+                    "warning",
+                    "on_open_shell: failed to set terminal parameters",
                 )
             else:
                 raise


### PR DESCRIPTION
##### SUMMARY
- This change adds a new option to network_cli that determines what happens when there's a failure while setting parameters.
- Fixes https://github.com/ansible-collections/cisco.nxos/issues/540

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
network_cli.py
