### PR TITLE
Gather options from sub-plugins when gathering all options

### DIFF
--- a/docs/ansible.netcommon.libssh_connection.rst
+++ b/docs/ansible.netcommon.libssh_connection.rst
@@ -229,6 +229,75 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_args</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[ssh_connection]<br>ssh_args = VALUE</p>
+                            </div>
+                                <div>env:ANSIBLE_SSH_ARGS</div>
+                                <div>var: ansible_ssh_args</div>
+                    </td>
+                <td>
+                        <div>Arguments to pass to all ssh cli tools</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_common_args</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[ssh_connection]<br>ssh_common_args = VALUE</p>
+                            </div>
+                                <div>env:ANSIBLE_SSH_COMMON_ARGS</div>
+                                <div>var: ansible_ssh_common_args</div>
+                    </td>
+                <td>
+                        <div>Common extra args for all ssh CLI tools</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_extra_args</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[ssh_connection]<br>ssh_extra_args = VALUE</p>
+                            </div>
+                                <div>env:ANSIBLE_SSH_EXTRA_ARGS</div>
+                                <div>var: ansible_ssh_extra_args</div>
+                    </td>
+                <td>
+                        <div>Extra exclusive to the &#x27;ssh&#x27; CLI</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>use_persistent_connections</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/docs/ansible.netcommon.libssh_connection.rst
+++ b/docs/ansible.netcommon.libssh_connection.rst
@@ -246,7 +246,9 @@ Parameters
                                 <div>var: ansible_ssh_args</div>
                     </td>
                 <td>
-                        <div>Arguments to pass to all ssh cli tools</div>
+                        <div>Arguments to pass to all ssh CLI tools.</div>
+                        <div>ProxyCommand is the only supported argument.</div>
+                        <div>This option is deprecated in favor of <em>proxy_command</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -269,7 +271,9 @@ Parameters
                                 <div>var: ansible_ssh_common_args</div>
                     </td>
                 <td>
-                        <div>Common extra args for all ssh CLI tools</div>
+                        <div>Common extra arguments for all ssh CLI tools.</div>
+                        <div>ProxyCommand is the only supported argument.</div>
+                        <div>This option is deprecated in favor of <em>proxy_command</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -292,7 +296,9 @@ Parameters
                                 <div>var: ansible_ssh_extra_args</div>
                     </td>
                 <td>
-                        <div>Extra exclusive to the &#x27;ssh&#x27; CLI</div>
+                        <div>Extra arguments exclusive to the &#x27;ssh&#x27; CLI tool.</div>
+                        <div>ProxyCommand is the only supported argument.</div>
+                        <div>This option is deprecated in favor of <em>proxy_command</em>.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -112,7 +112,10 @@ DOCUMENTATION = """
             key: use_persistent_connections
       ssh_args:
           version_added: 3.1.0
-          description: Arguments to pass to all ssh cli tools
+          description:
+           - Arguments to pass to all ssh CLI tools.
+           - ProxyCommand is the only supported argument.
+           - This option is deprecated in favor of I(proxy_command).
           ini:
               - section: 'ssh_connection'
                 key: 'ssh_args'
@@ -124,7 +127,10 @@ DOCUMENTATION = """
               - name: ssh_args
       ssh_common_args:
           version_added: 3.1.0
-          description: Common extra args for all ssh CLI tools
+          description:
+           - Common extra arguments for all ssh CLI tools.
+           - ProxyCommand is the only supported argument.
+           - This option is deprecated in favor of I(proxy_command).
           ini:
               - section: 'ssh_connection'
                 key: 'ssh_common_args'
@@ -136,7 +142,10 @@ DOCUMENTATION = """
               - name: ssh_common_args
       ssh_extra_args:
           version_added: 3.1.0
-          description: Extra exclusive to the 'ssh' CLI
+          description:
+           - Extra arguments exclusive to the 'ssh' CLI tool.
+           - ProxyCommand is the only supported argument.
+           - This option is deprecated in favor of I(proxy_command).
           vars:
               - name: ansible_ssh_extra_args
           env:

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -110,6 +110,42 @@ DOCUMENTATION = """
         ini:
           - section: defaults
             key: use_persistent_connections
+      ssh_args:
+          version_added: 3.1.0
+          description: Arguments to pass to all ssh cli tools
+          ini:
+              - section: 'ssh_connection'
+                key: 'ssh_args'
+          env:
+              - name: ANSIBLE_SSH_ARGS
+          vars:
+              - name: ansible_ssh_args
+          cli:
+              - name: ssh_args
+      ssh_common_args:
+          version_added: 3.1.0
+          description: Common extra args for all ssh CLI tools
+          ini:
+              - section: 'ssh_connection'
+                key: 'ssh_common_args'
+          env:
+              - name: ANSIBLE_SSH_COMMON_ARGS
+          vars:
+              - name: ansible_ssh_common_args
+          cli:
+              - name: ssh_common_args
+      ssh_extra_args:
+          version_added: 3.1.0
+          description: Extra exclusive to the 'ssh' CLI
+          vars:
+              - name: ansible_ssh_extra_args
+          env:
+            - name: ANSIBLE_SSH_EXTRA_ARGS
+          ini:
+            - key: ssh_extra_args
+              section: ssh_connection
+          cli:
+            - name: ssh_extra_args
 # TODO:
 #timeout=self._play_context.timeout,
 """
@@ -245,12 +281,12 @@ class Connection(ConnectionBase):
         proxy_command = None
         # Parse ansible_ssh_common_args, specifically looking for ProxyCommand
         ssh_args = [
-            getattr(self._play_context, "ssh_extra_args", "") or "",
-            getattr(self._play_context, "ssh_common_args", "") or "",
-            getattr(self._play_context, "ssh_args", "") or "",
+            self.get_option("ssh_extra_args") or "",
+            self.get_option("ssh_common_args") or "",
+            self.get_option("ssh_args") or "",
         ]
 
-        if ssh_args is not None:
+        if any(ssh_args):
             args = self._split_ssh_args(" ".join(ssh_args))
             for i, arg in enumerate(args):
                 if arg.lower() == "proxycommand":

--- a/plugins/plugin_utils/connection_base.py
+++ b/plugins/plugin_utils/connection_base.py
@@ -108,6 +108,24 @@ class NetworkConnectionBase(ConnectionBase):
         if self._connected:
             self._connected = False
 
+    def get_options(self, hostvars=None):
+        options = super(NetworkConnectionBase, self).get_options(
+            hostvars=hostvars
+        )
+
+        if (
+            self._sub_plugin.get("obj")
+            and self._sub_plugin.get("type") != "external"
+        ):
+            try:
+                options.update(
+                    self._sub_plugin["obj"].get_options(hostvars=hostvars)
+                )
+            except AttributeError:
+                pass
+
+        return options
+
     def set_options(self, task_keys=None, var_options=None, direct=None):
         super(NetworkConnectionBase, self).set_options(
             task_keys=task_keys, var_options=var_options, direct=direct


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This was proposed for ansible-core, but the base plugin changes are now here.

~~Adding ssh_args options to libssh fixes the `--ssh-common-args='-o ProxyCommand="blablabla"'` use case, but seems misleading to use without changing the description to reflect that only ProxyCommand is supported.~~
The descriptions have been updated

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
network_cli