### PR TITLE
Address inactive but legacy print calls found with code checking

### DIFF
--- a/changelogs/fragments/454-legacy_cleanup.yaml
+++ b/changelogs/fragments/454-legacy_cleanup.yaml
@@ -1,3 +1,3 @@
 ---
-bugfixes:
+trivial:
   - Address inactive but legacy print calls found with code checking

--- a/changelogs/fragments/454-legacy_cleanup.yaml
+++ b/changelogs/fragments/454-legacy_cleanup.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Address inactive but legacy print calls found with code checking

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -179,7 +179,7 @@ class Entity(object):
         transform = Entity(module, argument_spec)
         value = dict(command='foo')
         result = transform(value)
-        print result
+        print(result)
         {'command': 'foo', 'display': 'text', 'validate': None}
 
     Supported argument spec:


### PR DESCRIPTION
##### SUMMARY
Change legacy usage of print in comments to work with modern Python. Found during code checking.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
common

##### ADDITIONAL INFORMATION

Usage of `print result` should be `print(result)`

Would be found if the commented out troubleshooting usage was uncommented to validate something.

