### PR TITLE
restconf_get: Fix wrong direction of XML deserialization.

### DIFF
--- a/changelogs/fragments/fix_wrong_xml_direction.yaml
+++ b/changelogs/fragments/fix_wrong_xml_direction.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - restconf_get - fix direction of XML deserialization when ``output == 'xml'``

--- a/plugins/modules/restconf_get.py
+++ b/plugins/modules/restconf_get.py
@@ -88,9 +88,8 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.restconf
     restconf,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.utils.data import (
-    dict_to_xml,
+    xml_to_dict,
 )
-
 
 def main():
     """entry point for module execution"""
@@ -113,7 +112,10 @@ def main():
 
     if module.params["output"] == "xml":
         try:
-            response = dict_to_xml(response)
+            if response == "":
+                response = {}
+            else:
+                response = xml_to_dict(response)
         except Exception as exc:
             module.fail_json(msg=to_text(exc))
 

--- a/plugins/modules/restconf_get.py
+++ b/plugins/modules/restconf_get.py
@@ -91,6 +91,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.utils.data impor
     xml_to_dict,
 )
 
+
 def main():
     """entry point for module execution"""
     argument_spec = dict(

--- a/plugins/modules/restconf_get.py
+++ b/plugins/modules/restconf_get.py
@@ -113,10 +113,7 @@ def main():
 
     if module.params["output"] == "xml":
         try:
-            if response == "":
-                response = {}
-            else:
-                response = xml_to_dict(response)
+            response = xml_to_dict(response)
         except Exception as exc:
             module.fail_json(msg=to_text(exc))
 


### PR DESCRIPTION
Add empty string handling that would otherwise break the XML deserialization.

##### SUMMARY

Fixes wrong direction of module restconf_get's wrong direction of XML deserialization.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
restconf_get

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

The original implementation tried to serialize a string, not deserialize:

```
fatal: [XXXX]: FAILED! => changed=false 
  msg: |-
    'xmltodict' returned the following error when converting     <interfaces xmlns="http://openconfig.net/yang/interfaces">
...
...
        </interfaces>
     to xml. 'str' object has no attribute 'items'
```
In fact the code is calling `dict_to_xml()`, not `xml_to_dict()` as expected.

Tested the bugfix with a Nexus 9300v NXOS v9.3.10 device.