### PR TITLE
Add optional netcommon_httpapi_ciphers for httpapi connection plugins to allow overriding default SSL/TLS ciphers

### DIFF
--- a/changelogs/fragments/netcommon_httpapi_ciphers.yaml
+++ b/changelogs/fragments/netcommon_httpapi_ciphers.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add optional netcommon_httpapi_ciphers for httpapi connection plugins to allow overriding default SSL/TLS ciphers.

--- a/changelogs/fragments/netcommon_httpapi_ciphers.yaml
+++ b/changelogs/fragments/netcommon_httpapi_ciphers.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - Add optional netcommon_httpapi_ciphers for httpapi connection plugins to allow overriding default SSL/TLS ciphers.
+  - httpapi - Add option netcommon_httpapi_ciphers to allow overriding default SSL/TLS ciphers. (https://github.com/ansible-collections/ansible.netcommon/pull/494)

--- a/docs/ansible.netcommon.httpapi_connection.rst
+++ b/docs/ansible.netcommon.httpapi_connection.rst
@@ -90,7 +90,7 @@ Parameters
                         <span style="color: purple">list</span>
                          / <span style="color: purple">elements=string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 5.0.0 - See the L(OpenSSL Cipher List Format,https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html#CIPHER-LIST-FORMAT) for more details. - The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions. - This option will have no effect on ansible-core<2.14 but a warning will be emitted.</div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 5.0.0</div>
                 </td>
                 <td>
                 </td>
@@ -100,6 +100,9 @@ Parameters
                 <td>
                         <div>SSL/TLS Ciphers to use for requests</div>
                         <div>When a list is provided, all ciphers are joined in order with <code>:</code></div>
+                        <div>See the <a href='https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html#CIPHER-LIST-FORMAT'>OpenSSL Cipher List Format</a> for more details.</div>
+                        <div>The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions.</div>
+                        <div>This option will have no effect on ansible-core&lt;2.14 but a warning will be emitted.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/ansible.netcommon.httpapi_connection.rst
+++ b/docs/ansible.netcommon.httpapi_connection.rst
@@ -100,7 +100,8 @@ Parameters
                         <div>SSL/TLS Ciphers to use for requests</div>
                         <div>When a list is provided, all ciphers are joined in order with <code>:</code></div>
                         <div>See the <a href='https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html#CIPHER-LIST-FORMAT'>OpenSSL Cipher List Format</a> for more details.</div>
-                        <div>The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions</div>
+                        <div>The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions.</div>
+                        <div>This option will have no effect on ansible-core&lt;2.14.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/ansible.netcommon.httpapi_connection.rst
+++ b/docs/ansible.netcommon.httpapi_connection.rst
@@ -101,7 +101,7 @@ Parameters
                         <div>When a list is provided, all ciphers are joined in order with <code>:</code></div>
                         <div>See the <a href='https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html#CIPHER-LIST-FORMAT'>OpenSSL Cipher List Format</a> for more details.</div>
                         <div>The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions.</div>
-                        <div>This option will have no effect on ansible-core&lt;2.14.</div>
+                        <div>This option will have no effect on ansible-core&lt;2.14 but a warning will be emitted.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/ansible.netcommon.httpapi_connection.rst
+++ b/docs/ansible.netcommon.httpapi_connection.rst
@@ -90,6 +90,7 @@ Parameters
                         <span style="color: purple">list</span>
                          / <span style="color: purple">elements=string</span>
                     </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 5.0.0 - See the L(OpenSSL Cipher List Format,https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html#CIPHER-LIST-FORMAT) for more details. - The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions. - This option will have no effect on ansible-core<2.14 but a warning will be emitted.</div>
                 </td>
                 <td>
                 </td>
@@ -99,9 +100,6 @@ Parameters
                 <td>
                         <div>SSL/TLS Ciphers to use for requests</div>
                         <div>When a list is provided, all ciphers are joined in order with <code>:</code></div>
-                        <div>See the <a href='https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html#CIPHER-LIST-FORMAT'>OpenSSL Cipher List Format</a> for more details.</div>
-                        <div>The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions.</div>
-                        <div>This option will have no effect on ansible-core&lt;2.14 but a warning will be emitted.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/ansible.netcommon.httpapi_connection.rst
+++ b/docs/ansible.netcommon.httpapi_connection.rst
@@ -84,6 +84,29 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ciphers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 2.15</div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                                <div>var: ansible_httpapi_ciphers</div>
+                    </td>
+                <td>
+                        <div>SSL/TLS Ciphers to use for requests</div>
+                        <div>When a list is provided, all ciphers are joined in order with <code>:</code></div>
+                        <div>See the <a href='https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html#CIPHER-LIST-FORMAT'>OpenSSL Cipher List Format</a> for more details.</div>
+                        <div>The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/docs/ansible.netcommon.httpapi_connection.rst
+++ b/docs/ansible.netcommon.httpapi_connection.rst
@@ -90,7 +90,6 @@ Parameters
                         <span style="color: purple">list</span>
                          / <span style="color: purple">elements=string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 2.15</div>
                 </td>
                 <td>
                 </td>

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,4 +13,4 @@ readme: README.md
 repository: https://github.com/ansible-collections/ansible.netcommon
 issues: https://github.com/ansible-collections/ansible.netcommon/issues
 tags: [networking, security, cloud, network_cli, netconf, httpapi, grpc]
-version: 4.1.1-dev
+version: 4.2.0-dev

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -163,7 +163,9 @@ from ansible.release import __version__ as ANSIBLE_CORE_VERSION
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.connection_base import (
     NetworkConnectionBase,
 )
-from ansible_collections.ansible.netcommon.plugins.plugin_utils.version import Version
+from ansible_collections.ansible.netcommon.plugins.plugin_utils.version import (
+    Version,
+)
 
 
 class Connection(NetworkConnectionBase):

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -101,11 +101,11 @@ options:
     description:
       - SSL/TLS Ciphers to use for requests
       - 'When a list is provided, all ciphers are joined in order with C(:)'
-    version_added: 5.0.0
       - See the L(OpenSSL Cipher List Format,https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html#CIPHER-LIST-FORMAT)
         for more details.
       - The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions.
       - This option will have no effect on ansible-core<2.14 but a warning will be emitted.
+    version_added: 5.0.0
     type: list
     elements: string
     vars:

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -284,7 +284,7 @@ class Connection(NetworkConnectionBase):
         )
         ciphers = self.get_option("ciphers")
         if ciphers:
-            if Version(ANSIBLE_CORE_VERSION) < Version("2.14.0"):
+            if Version(ANSIBLE_CORE_VERSION) >= Version("2.14.0"):
                 # Only insert "ciphers" kwarg for ansible-core versions >= 2.14.0.
                 url_kwargs["ciphers"] = ciphers
             else:

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -106,7 +106,6 @@ options:
       - The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions
     type: list
     elements: string
-    version_added: '2.15'
     vars:
     - name: ansible_httpapi_ciphers
   become:

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -149,6 +149,7 @@ options:
 """
 
 from io import BytesIO
+
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.compat.version import StrictVersion

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -97,6 +97,18 @@ options:
     default: true
     vars:
     - name: ansible_httpapi_use_proxy
+  ciphers:
+    description:
+      - SSL/TLS Ciphers to use for requests
+      - 'When a list is provided, all ciphers are joined in order with C(:)'
+      - See the L(OpenSSL Cipher List Format,https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html#CIPHER-LIST-FORMAT)
+        for more details.
+      - The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions
+    type: list
+    elements: string
+    version_added: '2.15'
+    vars:
+    - name: ansible_httpapi_ciphers
   become:
     type: boolean
     description:
@@ -264,6 +276,7 @@ class Connection(NetworkConnectionBase):
             timeout=self.get_option("persistent_command_timeout"),
             validate_certs=self.get_option("validate_certs"),
             use_proxy=self.get_option("use_proxy"),
+            ciphers=self.get_option("ciphers"),
             headers={},
         )
         url_kwargs.update(kwargs)

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -101,6 +101,7 @@ options:
     description:
       - SSL/TLS Ciphers to use for requests
       - 'When a list is provided, all ciphers are joined in order with C(:)'
+    version_added: 5.0.0
       - See the L(OpenSSL Cipher List Format,https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html#CIPHER-LIST-FORMAT)
         for more details.
       - The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add a new option `netcommon_httpapi_ciphers` for `httpapi` connection plugins to allow overriding default SSL/TLS ciphers

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netcommon.httpapi

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

With Python 3.10 the default SSL/TLS ciphers have been reduced. This leads to Ansible not being able to connect to devices not supporting the newer ciphers. This option allows users to override the SSL/TLS ciphers per device by configuring `netcommon_httpapi_ciphers`

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
  ciphers:
    description:
      - SSL/TLS Ciphers to use for requests
      - 'When a list is provided, all ciphers are joined in order with C(:)'
      - See the L(OpenSSL Cipher List Format,https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html#CIPHER-LIST-FORMAT)
        for more details.
      - The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions
    type: list
    elements: string
    vars:
    - name: ansible_httpapi_ciphers
```
