### PR TITLE
Allow processing of a specific configuration file for libssh

### DIFF
--- a/changelogs/fragments/libssh_config_file.yaml
+++ b/changelogs/fragments/libssh_config_file.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - libssh - Hand over configuration files for libssh to solve connection problems
+  - libssh - add ``config_file`` option to specify an alternate SSH config file to use.

--- a/changelogs/fragments/libssh_config_file.yaml
+++ b/changelogs/fragments/libssh_config_file.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - libssh - Hand over configuration files for libssh to solve connection problems

--- a/docs/ansible.netcommon.libssh_connection.rst
+++ b/docs/ansible.netcommon.libssh_connection.rst
@@ -39,6 +39,28 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config_file</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[libssh_connection]<br>config_file = VALUE</p>
+                            </div>
+                                <div>env:ANSIBLE_LIBSSH_CONFIG_FILE</div>
+                                <div>var: ansible_libssh_config_file</div>
+                    </td>
+                <td>
+                        <div>Settings for libssh</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host_key_auto_add</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/docs/ansible.netcommon.libssh_connection.rst
+++ b/docs/ansible.netcommon.libssh_connection.rst
@@ -44,6 +44,7 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">path</span>
                     </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 5.1.0</div>
                 </td>
                 <td>
                 </td>
@@ -55,7 +56,7 @@ Parameters
                                 <div>var: ansible_libssh_config_file</div>
                     </td>
                 <td>
-                        <div>Settings for libssh</div>
+                        <div>Alternate SSH config file location</div>
                 </td>
             </tr>
             <tr>

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,4 +13,4 @@ readme: README.md
 repository: https://github.com/ansible-collections/ansible.netcommon
 issues: https://github.com/ansible-collections/ansible.netcommon/issues
 tags: [networking, security, cloud, network_cli, netconf, httpapi, grpc]
-version: 5.0.1-dev
+version: 5.1.0-dev

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -166,7 +166,8 @@ DOCUMENTATION = """
           cli:
             - name: ssh_extra_args
       config_file:
-        description: 'Settings for libssh'
+        version_added: 5.1.0
+        description: Alternate SSH config file location
         type: path
         env:
           - name: ANSIBLE_LIBSSH_CONFIG_FILE

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -165,6 +165,16 @@ DOCUMENTATION = """
               section: ssh_connection
           cli:
             - name: ssh_extra_args
+      config_file:
+        description: 'Settings for libssh'
+        type: path
+        env:
+          - name: ANSIBLE_LIBSSH_CONFIG_FILE
+        ini:
+          - section: libssh_connection
+            key: config_file
+        vars:
+          - name: ansible_libssh_config_file
 # TODO:
 #timeout=self._play_context.timeout,
 """
@@ -379,6 +389,11 @@ class Connection(ConnectionBase):
 
             if proxy_command:
                 ssh_connect_kwargs["proxycommand"] = proxy_command
+
+            if self.get_option("config_file"):
+                ssh_connect_kwargs["config_file"] = self.get_option(
+                    "config_file"
+                )
 
             if self.get_option("password_prompt") and (
                 Version(PYLIBSSH_VERSION) < "1.0.0"


### PR DESCRIPTION
##### SUMMARY

Depending on the destination, libssh might need to be configured in a way, that the algorithms and methods need to be adjusted. Instead of adding each possible configuration option into the wrapper, including a config file (as it exists for ordinary OpenSSH) is much easier. This allows ansible to connect to devices with less well supported algorithms.

This is a required step to fix connection issues with ansible.netcommon.libssh. The called ansible-pylibssh need to process the new optional argument config_file. But this is a separate patch, which needs to be applied there.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.netcommon.libssh

##### ADDITIONAL INFORMATION
Solve open connections issues with older devices, i.e.: #430 