### PR TITLE
network_cli libssh: prevent data to appear multiple times in output

### DIFF
--- a/changelogs/fragments/517-network_cli-libssh-receive.yml
+++ b/changelogs/fragments/517-network_cli-libssh-receive.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "network_cli connection plugin - when receiving longer responses from libssh, parts of the response were sometimes added multiple times (https://github.com/ansible-collections/ansible.netcommon/pull/517)."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,4 +13,4 @@ readme: README.md
 repository: https://github.com/ansible-collections/ansible.netcommon
 issues: https://github.com/ansible-collections/ansible.netcommon/issues
 tags: [networking, security, cloud, network_cli, netconf, httpapi, grpc]
-version: 5.0.0
+version: 5.0.1-dev

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -948,6 +948,7 @@ class Connection(NetworkConnectionBase):
                 self._command_response += self._sanitize(
                     resp, command, strip_prompt
                 )
+                resp = b""
                 command_prompt_matched = True
 
     def receive(


### PR DESCRIPTION
##### SUMMARY
Prevent the same data being added multiple times to `self._command_response`.

Right now `resp` is extended by newly read `data` every time, but `resp` is never truncated after sanitized `resp` is added to `self._command_response`. This causes the same data being added multiple times to `self._command_response` depending on how often the prompt is identified in the result. This happens for MikroTik RouterOS 7, see https://github.com/ansible-collections/community.routeros/issues/132.

Note that the paramiko receive method works differently, since it does `resp = self._strip(self._last_response)` before adding the sanitized `resp` to `self._command_response`. This is consistent with the report in https://github.com/ansible-collections/community.routeros/issues/132 that this problem does not appear with paramiko, but only with libssh.

Fixes https://github.com/ansible-collections/community.routeros/issues/132.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
network_cli
