### PR TITLE
cast AnsibleUnsafeText to str for CSafeLoader

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   - repo: https://github.com/ansible-network/collection_prep
     rev: 1.1.0
     hooks:
-      - id: autoversion
+      # - id: autoversion
       - id: update-docs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/changelogs/fragments/loader.yaml
+++ b/changelogs/fragments/loader.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Cast AnsibleUnsafeText to str in convert_doc_to_ansible_module_kwargs() to keep CSafeLoader happy.

--- a/changelogs/fragments/loader.yaml
+++ b/changelogs/fragments/loader.yaml
@@ -1,3 +1,4 @@
 ---
-trivial:
+bugfixes:
   - Cast AnsibleUnsafeText to str in convert_doc_to_ansible_module_kwargs() to keep CSafeLoader happy.
+    This fixes issues with content scaffolding tools.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,4 +13,4 @@ readme: README.md
 repository: https://github.com/ansible-collections/ansible.netcommon
 issues: https://github.com/ansible-collections/ansible.netcommon/issues
 tags: [networking, security, cloud, network_cli, netconf, httpapi, grpc]
-version: 5.0.0
+version: 5.0.0-dev

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,4 +13,4 @@ readme: README.md
 repository: https://github.com/ansible-collections/ansible.netcommon
 issues: https://github.com/ansible-collections/ansible.netcommon/issues
 tags: [networking, security, cloud, network_cli, netconf, httpapi, grpc]
-version: 5.0.0-dev
+version: 5.0.0

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -745,7 +745,7 @@ def extract_argspec(doc_obj, argpsec):
 
 # TODO: Support extends_documentation_fragment
 def convert_doc_to_ansible_module_kwargs(doc):
-    doc_obj = yaml.load(doc, SafeLoader)
+    doc_obj = yaml.load(str(doc), SafeLoader)
     argspec = {}
     spec = {}
     extract_argspec(doc_obj, argspec)


### PR DESCRIPTION
##### SUMMARY
- Fixes https://github.com/ansible-network/cli_rm_builder/issues/25
- Starting from ansible-core 2.12.6, "looked-up" file contents seem to be of type AnsibleUnsafeText, and not str like in the previous versions.
- The content building tools load a YAML docstring from a file and pass it to the convert_doc_to_ansible_module_kwargs() method that converts it to an argspec. While doing that, CSafeLoader is preferred (when available) over SafeLoader. AnsibleUnsafeText doesn't seem to work with CSafeLoader and throws the following error: 
```
"Unexpected templating type error occurred on ( {{ (rm_documentation|ansible_network.cli_rm_builder.to_argspec)['argument_spec'] }}): a string or stream input is required. a string or stream input is required"}
```
- The fix here is to cast the doc object to str.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request