### PR TITLE
telnet: Timeout if prompt not found

### DIFF
--- a/changelogs/fragments/telnet-refactoring.yml
+++ b/changelogs/fragments/telnet-refactoring.yml
@@ -1,6 +1,5 @@
 ---
 minor_changes:
-  - Introduce timeouts for blocking commands and output corresponding errors.
-  - Allow regex prompts for login_prompt and password_prompt.
-  - Provides stdout and stdout_lines similar to other modules.
-  - Refactored prompt handling.
+  - telnet - apply ``timeout`` to command prompts.
+  - telnet - add support for regexes to ``login_prompt`` and ``password_prompt``.
+  - telnet - add ``stdout`` and ``stdout_lines`` to module output.

--- a/changelogs/fragments/telnet-refactoring.yml
+++ b/changelogs/fragments/telnet-refactoring.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - Introduce timeouts for blocking commands and output corresponding errors.
+  - Allow regex prompts for login_prompt and password_prompt.
+  - Provides stdout and stdout_lines similar to other modules.
+  - Refactored prompt handling.

--- a/plugins/action/telnet.py
+++ b/plugins/action/telnet.py
@@ -84,14 +84,15 @@ class ActionModule(ActionBase):
                         self.await_prompts([password_prompt], timeout)
                         self.tn.write(to_bytes(password + "\n"))
 
+                    self.await_prompts(prompts, timeout)
+
                     for cmd in commands:
                         display.vvvvv(">>> %s" % cmd)
-                        self.await_prompts(prompts, timeout)
                         self.tn.write(to_bytes(cmd + "\n"))
+                        self.await_prompts(prompts, timeout)
                         display.vvvvv("<<< %s" % cmd)
                         sleep(pause)
 
-                    self.await_prompts(prompts, timeout)
                     self.tn.write(b"exit\n")
 
                 except EOFError as e:
@@ -106,8 +107,8 @@ class ActionModule(ActionBase):
                 finally:
                     if self.tn:
                         self.tn.close()
-                    result["output"] = to_text(self.output)
-                    result["output_lines"] = result["output"].splitlines(True)
+                    result["stdout"] = to_text(self.output)
+                    result["stdout_lines"] = self.output.splitlines(True)
             else:
                 result["failed"] = True
                 result["msg"] = "Telnet requires a command to execute"


### PR DESCRIPTION
##### SUMMARY
- Introduce timeouts for blocking commands + error output.
- Allow regex prompts for `login_prompt` and `password_prompt`.
- Better output : Module now provides `stdout` and `stdout_lines` similar to other modules.
- Refactored prompt handling.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
telnet

##### ADDITIONAL INFORMATION
As it is, the module is not dying when not finding the prompt and hangs.
This PR let the module timeout when it doesn't find prompts and outputs a proper error.
Side effect of the use of `expect` instead of `read_until` is allowing regex in those prompts, but why not ? Could also allow flexible Login/Password prompt for devices with same commands but different firmwares.
Module now provides `output` and `output_lines` similar to other modules, making it more consistent if you ever need to search for text in the output.
Prompt handling is now done in a separated function that generate proper output and better exception handling.
```paste below
Tested on AWX + Ansible 2.14.3 + Python 3.9.16
```

Note that the version in `galaxy.yml` is breaking AWX because of `-dev` (`5.0.1`**`-dev`**). You might not want to break the versioning syntax (or create an issue in ansible-galaxy).
