### PR TITLE
Added network_cli option to send a newline upon successful connection…

### DIFF
--- a/docs/ansible.netcommon.network_cli_connection.rst
+++ b/docs/ansible.netcommon.network_cli_connection.rst
@@ -114,6 +114,25 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>coax_prompt</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"no"</div>
+                </td>
+                    <td>
+                                <div>var: ansible_coax_prompt</div>
+                    </td>
+                <td>
+                        <div>When connecting to a device that does not provide any terminal response on login, usually a console server, this option will wait 2 seconds then send a newline to coax the device into sending a response</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -212,6 +212,15 @@ options:
       matched.
     vars:
     - name: ansible_terminal_initial_answer
+  coax_prompt:
+    type: boolean
+    description:
+    - When connecting to a device that does not provide any terminal response on login,
+      usually a console server, this option will wait 2 seconds then send a newline to
+      coax the device into sending a response
+    default: false
+    vars:
+    - name: ansible_coax_prompt
   terminal_initial_prompt_checkall:
     type: boolean
     description:
@@ -689,6 +698,14 @@ class Connection(NetworkConnectionBase):
             check_all = (
                 self.get_option("terminal_initial_prompt_checkall") or False
             )
+            if self.get_option("coax_prompt"):
+                self.queue_message(
+                    "vvvv",
+                    "coaxing prompt by waiting and sending a newline"
+                )
+                from time import sleep
+                sleep(2)
+                self._ssh_shell.sendall(b"\r")
 
             self.receive(
                 prompts=terminal_initial_prompt,

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -700,10 +700,10 @@ class Connection(NetworkConnectionBase):
             )
             if self.get_option("coax_prompt"):
                 self.queue_message(
-                    "vvvv",
-                    "coaxing prompt by waiting and sending a newline"
+                    "vvvv", "coaxing prompt by waiting and sending a newline"
                 )
                 from time import sleep
+
                 sleep(2)
                 self._ssh_shell.sendall(b"\r")
 


### PR DESCRIPTION
… to resolve issues with console based logins

##### SUMMARY
Workaround for #381 allowing the user to manually request a newline be sent upon successful connection. This allows connections to a device via serial console that otherwise would never expose an initial prompt.

##### ISSUE TYPE
- Bugfix Pull Request