### PR TITLE
[network_resource] fix modules list generation

### DIFF
--- a/changelogs/fragments/resource_manager.yaml
+++ b/changelogs/fragments/resource_manager.yaml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - "network_resource - do not append network_os to module names when building supported resources list. 
-     This fix is only valid for cases where FACTS_RESOURCE_SUBSETS is undefined."
+  - "network_resource - do not append network_os to module names when building supported resources list.
+    This fix is only valid for cases where FACTS_RESOURCE_SUBSETS is undefined."

--- a/changelogs/fragments/resource_manager.yaml
+++ b/changelogs/fragments/resource_manager.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "network_resource - do not append network_os to module names when building supported resources list. 
+     This fix is only valid for cases where FACTS_RESOURCE_SUBSETS is undefined."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,4 +13,4 @@ readme: README.md
 repository: https://github.com/ansible-collections/ansible.netcommon
 issues: https://github.com/ansible-collections/ansible.netcommon/issues
 tags: [networking, security, cloud, network_cli, netconf, httpapi, grpc]
-version: 5.1.0
+version: 5.1.1-dev

--- a/plugins/action/network_resource.py
+++ b/plugins/action/network_resource.py
@@ -251,13 +251,13 @@ class ActionModule(ActionNetworkModule):
                     display.vvvv("'%s' is not defined" % (fact_modulelib))
                 except AttributeError:
                     display.vvvv(
-                        "'FACT_RESOURCE_SUBSETS is not defined in '%s'"
+                        "'DOCUMENTATION is not defined in '%s'"
                         % (fact_modulelib)
                     )
 
                 if docs:
                     if self._is_resource_module(docs):
-                        resource_modules.append(module_name)
+                        resource_modules.append(module_name.split("_", 1)[1])
                     else:
                         display.vvvvv(
                             "module in path '%s' is not a resource module"


### PR DESCRIPTION
##### SUMMARY
- When using module documentation to determine if a module is a resource module, the final list of supported resource modules would have the `network_os` prepended. This deviates from how the resources are listed if FACTS_RESOURCES_SUBSETS is defined.
- cisco.nxos doesn't have the above mentioned key now for a variety of reasons and hence, it was falling back to the DOCUMENTATION search, which is how I encountered this problem.
- Tests did not catch this because the assertion [here](https://github.com/ansible-collections/cisco.nxos/pull/280/files#diff-bb5ebe6a528bc171e759d66903c1f83f42fb776d3e18d1c88cd62fdb53bfb3f4R34) will always pass since neither L.H.S or R.H.S is hard coded and is generated by the same piece of code.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
network_resource.py
