### PR TITLE
Add new options to httpapi connection

### DIFF
--- a/changelogs/fragments/httpapi_options.yaml
+++ b/changelogs/fragments/httpapi_options.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - httpapi - Add additional option ``ca_path``, ``client_cert``, ``client_key``, and
+    ``http_agent`` that are available in open_url but not to httpapi.
+    (https://github.com/ansible-collections/ansible.netcommon/issues/528)

--- a/docs/ansible.netcommon.httpapi_connection.rst
+++ b/docs/ansible.netcommon.httpapi_connection.rst
@@ -84,6 +84,25 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ca_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 5.2.0</div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                                <div>var: ansible_httpapi_ca_path</div>
+                    </td>
+                <td>
+                        <div>Path to CA cert bundle to use.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>ciphers</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -108,6 +127,44 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>client_cert</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 5.2.0</div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                                <div>var: ansible_httpapi_client_cert</div>
+                    </td>
+                <td>
+                        <div>PEM formatted certificate chain file to be used for SSL client authentication. This file can also include the key as well, and if the key is included, <em>client_key</em> is not required</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>client_key</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 5.2.0</div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                                <div>var: ansible_httpapi_client_key</div>
+                    </td>
+                <td>
+                        <div>PEM formatted file that contains the private key to be used for SSL client authentication. If <em>client_cert</em> contains both the certificate and key, this option is not required.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -123,6 +180,25 @@ Parameters
                     </td>
                 <td>
                         <div>Specifies the remote device FQDN or IP address to establish the HTTP(S) connection to.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>http_agent</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 5.2.0</div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                                <div>var: ansible_httpapi_http_agent</div>
+                    </td>
+                <td>
+                        <div>User-Agent to use in the request.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -81,6 +81,34 @@ options:
     - When specified, I(password) is ignored.
     vars:
     - name: ansible_httpapi_session_key
+  ca_path:
+    description:
+      - Path to CA cert bundle to use.
+    type: path
+    version_added: 5.2.0
+    vars:
+      - name: ansible_httpapi_ca_path
+  client_cert:
+    description:
+      - PEM formatted certificate chain file to be used for SSL client
+        authentication. This file can also include the key as well, and if the key
+        is included, I(client_key) is not required
+    version_added: 5.2.0
+    vars:
+      - name: ansible_httpapi_client_cert
+  client_key:
+    description:
+      - PEM formatted file that contains the private key to be used for SSL client
+        authentication. If I(client_cert) contains both the certificate and key,
+        this option is not required.
+    version_added: 5.2.0
+    vars:
+      - name: ansible_httpapi_client_key
+  http_agent:
+    description: User-Agent to use in the request.
+    version_added: 5.2.0
+    vars:
+      - name: ansible_httpapi_http_agent
   use_ssl:
     type: boolean
     description:
@@ -279,10 +307,14 @@ class Connection(NetworkConnectionBase):
         Sends the command to the device over api
         """
         url_kwargs = dict(
+            headers={},
+            use_proxy=self.get_option("use_proxy"),
             timeout=self.get_option("persistent_command_timeout"),
             validate_certs=self.get_option("validate_certs"),
-            use_proxy=self.get_option("use_proxy"),
-            headers={},
+            http_agent=self.get_option("http_agent"),
+            client_cert=self.get_option("client_cert"),
+            client_key=self.get_option("client_key"),
+            ca_path=self.get_option("ca_path"),
         )
         url_kwargs.update(kwargs)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible-collections/ansible.netcommon/issues/528

Adds four new options to the httpapi conenction: `ca_path`, `client_cert`, `client_key`, and `http_agent`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
httpapi