### PR TITLE
Add 'type: string' to connection options to make sure they are actually strings

### DIFF
--- a/changelogs/fragments/549-connection-strings.yml
+++ b/changelogs/fragments/549-connection-strings.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Ensure that all connection plugin options that should be strings are actually strings (https://github.com/ansible-collections/ansible.netcommon/pull/549)."

--- a/docs/ansible.netcommon.grpc_connection.rst
+++ b/docs/ansible.netcommon.grpc_connection.rst
@@ -48,7 +48,7 @@ Parameters
                     <b>certificate_chain_file</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -93,7 +93,7 @@ Parameters
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -135,7 +135,7 @@ Parameters
                     <b>network_os</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -153,7 +153,7 @@ Parameters
                     <b>password</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -264,7 +264,7 @@ Parameters
                     <b>private_key_file</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -286,7 +286,7 @@ Parameters
                     <b>remote_user</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -309,7 +309,7 @@ Parameters
                     <b>root_certificates_file</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -331,7 +331,7 @@ Parameters
                     <b>ssl_target_name_override</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>

--- a/docs/ansible.netcommon.httpapi_connection.rst
+++ b/docs/ansible.netcommon.httpapi_connection.rst
@@ -64,7 +64,7 @@ Parameters
                     <b>become_method</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -111,7 +111,7 @@ Parameters
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -154,7 +154,7 @@ Parameters
                     <b>network_os</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -172,7 +172,7 @@ Parameters
                     <b>password</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -262,7 +262,7 @@ Parameters
                     <b>platform_type</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -304,7 +304,7 @@ Parameters
                     <b>remote_user</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>

--- a/docs/ansible.netcommon.libssh_connection.rst
+++ b/docs/ansible.netcommon.libssh_connection.rst
@@ -136,7 +136,7 @@ Parameters
                     <b>password</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -159,7 +159,7 @@ Parameters
                     <b>password_prompt</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                     <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
                 </td>
@@ -179,7 +179,7 @@ Parameters
                     <b>proxy_command</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -226,7 +226,7 @@ Parameters
                     <b>remote_addr</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -248,7 +248,7 @@ Parameters
                     <b>remote_user</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -275,7 +275,7 @@ Parameters
                     <b>ssh_args</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                     <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.2.0</div>
                 </td>
@@ -300,7 +300,7 @@ Parameters
                     <b>ssh_common_args</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                     <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.2.0</div>
                 </td>
@@ -325,7 +325,7 @@ Parameters
                     <b>ssh_extra_args</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                     <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.2.0</div>
                 </td>

--- a/docs/ansible.netcommon.netconf_connection.rst
+++ b/docs/ansible.netcommon.netconf_connection.rst
@@ -47,7 +47,7 @@ Parameters
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -140,7 +140,7 @@ Parameters
                     <b>netconf_ssh_config</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -162,7 +162,7 @@ Parameters
                     <b>network_os</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -180,7 +180,7 @@ Parameters
                     <b>password</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -294,7 +294,7 @@ Parameters
                     <b>private_key_file</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -316,7 +316,7 @@ Parameters
                     <b>proxy_command</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -341,7 +341,7 @@ Parameters
                     <b>remote_user</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>

--- a/docs/ansible.netcommon.network_cli_connection.rst
+++ b/docs/ansible.netcommon.network_cli_connection.rst
@@ -94,7 +94,7 @@ Parameters
                     <b>become_method</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -117,7 +117,7 @@ Parameters
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -232,7 +232,7 @@ Parameters
                     <b>network_os</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -250,7 +250,7 @@ Parameters
                     <b>password</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -386,7 +386,7 @@ Parameters
                     <b>private_key_file</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -408,7 +408,7 @@ Parameters
                     <b>remote_user</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -453,7 +453,7 @@ Parameters
                     <b>ssh_type</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>

--- a/plugins/connection/grpc.py
+++ b/plugins/connection/grpc.py
@@ -29,6 +29,7 @@ options:
       - Specifies the remote device FQDN or IP address to establish the gRPC
         connection to.
     default: inventory_hostname
+    type: string
     vars:
       - name: ansible_host
   port:
@@ -49,6 +50,7 @@ options:
       - Configures the device platform network operating system. This value is
         used to load a device specific grpc plugin to communicate with the remote
         device.
+    type: string
     vars:
       - name: ansible_network_os
   remote_user:
@@ -57,6 +59,7 @@ options:
         connection is first established.  If the remote_user is not specified,
         the connection will use the username of the logged in user.
       - Can be configured from the CLI via the C(--user) or C(-u) options.
+    type: string
     ini:
       - section: defaults
         key: remote_user
@@ -68,6 +71,7 @@ options:
     description:
       - Configures the user password used to authenticate to the remote device
         when first establishing the gRPC connection.
+    type: string
     vars:
       - name: ansible_password
       - name: ansible_ssh_pass
@@ -75,6 +79,7 @@ options:
     description:
       - The PEM encoded private key file used to authenticate to the
         remote device when first establishing the grpc connection.
+    type: string
     ini:
       - section: grpc_connection
         key: private_key_file
@@ -87,6 +92,7 @@ options:
       - The PEM encoded root certificate file used to create a SSL-enabled
         channel, if the value is None it reads the root certificates from
         a default location chosen by gRPC at runtime.
+    type: string
     ini:
       - section: grpc_connection
         key: root_certificates_file
@@ -98,6 +104,7 @@ options:
     description:
       - The PEM encoded certificate chain file used to create a SSL-enabled
         channel. If the value is None, no certificate chain is used.
+    type: string
     ini:
       - section: grpc_connection
         key: certificate_chain_file
@@ -111,6 +118,7 @@ options:
         The name used for SSL host name checking will be the target parameter
         (assuming that the secure channel is an SSL channel). If this parameter is
         specified and the underlying is not an SSL channel, it will just be ignored.
+    type: string
     ini:
       - section: grpc_connection
         key: ssl_target_name_override

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -23,6 +23,7 @@ options:
     - Specifies the remote device FQDN or IP address to establish the HTTP(S) connection
       to.
     default: inventory_hostname
+    type: string
     vars:
     - name: inventory_hostname
     - name: ansible_host
@@ -43,6 +44,7 @@ options:
     description:
     - Configures the device platform network operating system.  This value is used
       to load the correct httpapi plugin to communicate with the remote device
+    type: string
     vars:
     - name: ansible_network_os
   remote_user:
@@ -51,6 +53,7 @@ options:
       is first established.  If the remote_user is not specified, the connection will
       use the username of the logged in user.
     - Can be configured from the CLI via the C(--user) or C(-u) options.
+    type: string
     ini:
     - section: defaults
       key: remote_user
@@ -62,6 +65,7 @@ options:
     description:
     - Configures the user password used to authenticate to the remote device when
       needed for the device API.
+    type: string
     vars:
     - name: ansible_password
     - name: ansible_httpapi_pass
@@ -133,6 +137,7 @@ options:
       escalation.  Typically the become_method value is set to C(enable) but could
       be defined as other values.
     default: sudo
+    type: string
     ini:
     - section: privilege_escalation
       key: become_method
@@ -143,6 +148,7 @@ options:
   platform_type:
     description:
     - Set type of platform.
+    type: string
     env:
     - name: ANSIBLE_PLATFORM_TYPE
     vars:

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -20,6 +20,7 @@ DOCUMENTATION = """
       remote_addr:
         description:
             - Address of the remote target
+        type: string
         default: inventory_hostname
         vars:
             - name: inventory_hostname
@@ -30,6 +31,7 @@ DOCUMENTATION = """
         description:
             - User to login/authenticate as
             - Can be set from the CLI via the C(--user) or C(-u) options.
+        type: string
         vars:
             - name: ansible_user
             - name: ansible_ssh_user
@@ -46,6 +48,7 @@ DOCUMENTATION = """
         description:
           - Secret used to either login the ssh server or as a passphrase for ssh keys that require it
           - Can be set from the CLI via the C(--ask-pass) option.
+        type: string
         vars:
             - name: ansible_password
             - name: ansible_ssh_pass
@@ -57,6 +60,7 @@ DOCUMENTATION = """
           - Text to match when using keyboard-interactive authentication to determine if the prompt is
             for the password.
           - Requires ansible-pylibssh version >= 1.0.0
+        type: string
         vars:
           - name: ansible_libssh_password_prompt
         version_added: 3.1.0
@@ -78,6 +82,7 @@ DOCUMENTATION = """
         description:
             - Proxy information for running the connection via a jumphost.
             - Also this plugin will scan 'ssh_args', 'ssh_extra_args' and 'ssh_common_args' from the 'ssh' plugin settings for proxy information if set.
+        type: string
         env:
           - name: ANSIBLE_LIBSSH_PROXY_COMMAND
         ini:
@@ -126,6 +131,7 @@ DOCUMENTATION = """
            - Arguments to pass to all ssh CLI tools.
            - ProxyCommand is the only supported argument.
            - This option is deprecated in favor of I(proxy_command).
+          type: string
           ini:
               - section: 'ssh_connection'
                 key: 'ssh_args'
@@ -141,6 +147,7 @@ DOCUMENTATION = """
            - Common extra arguments for all ssh CLI tools.
            - ProxyCommand is the only supported argument.
            - This option is deprecated in favor of I(proxy_command).
+          type: string
           ini:
               - section: 'ssh_connection'
                 key: 'ssh_common_args'
@@ -156,6 +163,7 @@ DOCUMENTATION = """
            - Extra arguments exclusive to the 'ssh' CLI tool.
            - ProxyCommand is the only supported argument.
            - This option is deprecated in favor of I(proxy_command).
+          type: string
           vars:
               - name: ansible_ssh_extra_args
           env:

--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -29,6 +29,7 @@ options:
     - Specifies the remote device FQDN or IP address to establish the SSH connection
       to.
     default: inventory_hostname
+    type: string
     vars:
     - name: inventory_hostname
     - name: ansible_host
@@ -51,6 +52,7 @@ options:
       to load a device specific netconf plugin.  If this option is not configured
       (or set to C(auto)), then Ansible will attempt to guess the correct network_os
       to use. If it can not guess a network_os correctly it will use C(default).
+    type: string
     vars:
     - name: ansible_network_os
   remote_user:
@@ -59,6 +61,7 @@ options:
       is first established.  If the remote_user is not specified, the connection will
       use the username of the logged in user.
     - Can be configured from the CLI via the C(--user) or C(-u) options.
+    type: string
     ini:
     - section: defaults
       key: remote_user
@@ -70,6 +73,7 @@ options:
     description:
     - Configures the user password used to authenticate to the remote device when
       first establishing the SSH connection.
+    type: string
     vars:
     - name: ansible_password
     - name: ansible_ssh_pass
@@ -79,6 +83,7 @@ options:
     description:
     - The private SSH key or certificate file used to authenticate to the remote device
       when first establishing the SSH connection.
+    type: string
     ini:
     - section: defaults
       key: private_key_file
@@ -119,6 +124,7 @@ options:
     description:
       - Proxy information for running the connection via a jumphost.
       - This requires ncclient >= 0.6.10 to be installed on the controller.
+    type: string
     env:
       - name: ANSIBLE_NETCONF_PROXY_COMMAND
     ini:
@@ -132,6 +138,7 @@ options:
       set to True the bastion/jump host ssh settings should be present in ~/.ssh/config
       file, alternatively it can be set to custom ssh configuration file path to read
       the bastion/jump host settings.
+    type: string
     ini:
     - section: netconf_connection
       key: ssh_config

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -27,6 +27,7 @@ options:
     - Specifies the remote device FQDN or IP address to establish the SSH connection
       to.
     default: inventory_hostname
+    type: string
     vars:
     - name: inventory_hostname
     - name: ansible_host
@@ -48,6 +49,7 @@ options:
     - Configures the device platform network operating system.  This value is used
       to load the correct terminal and cliconf plugins to communicate with the remote
       device.
+    type: string
     vars:
     - name: ansible_network_os
   remote_user:
@@ -56,6 +58,7 @@ options:
       is first established.  If the remote_user is not specified, the connection will
       use the username of the logged in user.
     - Can be configured from the CLI via the C(--user) or C(-u) options.
+    type: string
     ini:
     - section: defaults
       key: remote_user
@@ -67,6 +70,7 @@ options:
     description:
     - Configures the user password used to authenticate to the remote device when
       first establishing the SSH connection.
+    type: string
     vars:
     - name: ansible_password
     - name: ansible_ssh_pass
@@ -75,6 +79,7 @@ options:
     description:
     - The private SSH key or certificate file used to authenticate to the remote device
       when first establishing the SSH connection.
+    type: string
     ini:
     - section: defaults
       key: private_key_file
@@ -130,6 +135,7 @@ options:
       escalation.  Typically the become_method value is set to C(enable) but could
       be defined as other values.
     default: sudo
+    type: string
     ini:
     - section: privilege_escalation
       key: become_method
@@ -254,6 +260,7 @@ options:
       - I(auto) will use ansible-pylibssh if that package is installed, otherwise will fallback to paramiko.
     default: auto
     choices: ["libssh", "paramiko", "auto"]
+    type: string
     env:
         - name: ANSIBLE_NETWORK_CLI_SSH_TYPE
     ini:


### PR DESCRIPTION
##### SUMMARY
As opposed to modules, the plugin config system uses `type: raw` as a default for `type`, and not `type: str`. Therefore options that do not specify `type` can end up as non-strings.

This caused a problem in https://github.com/ansible-collections/community.routeros/issues/175 when users had passwords that could be interpreted as integers. Specifying `ansible_ssh_pass=1234567890` in the inventory caused strange errors in the bowels of network_cli (i.e. without stack traces since the errors happened on the other side of the JSON RPC connection). Once @BSMaximN figured out this is caused by passwords that look like integers, I was able to reproduce this with network_cli via libssh. (I have some trouble getting paramiko to work so I cannot reproduce it there.)

The problem seems to boil down to Ansible's plugin config manager having a different default for `type` than the module argument spec: if you omit `type`, then the values are kept as-is (for modules, they are converted to strings).

Therefore the password ended up being an integer and not a string, which trips up both paramiko and libssh.

I've added `type: string` to all options which do not have other types for the connection plugins; adding `type: string` to libssh's `password` field solved the problem for me, and I guess there are many similar problems where other values are assumed to be strings that potentially aren't. (There are also a lot of `to_native()`s everywhere, so some of them got converted to strings already before.)

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
connection plugins
