### PR TITLE
Ignore ansible-lint's sanity[cannot-ignore] rule

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,4 @@
+---
+skip_list:
+  # ansible-lint does not like the `import-3.11` ignore in tests/sanity/ignore-*.txt
+  - sanity[cannot-ignore]

--- a/changelogs/fragments/550-ansible-lint.yml
+++ b/changelogs/fragments/550-ansible-lint.yml
@@ -1,0 +1,2 @@
+trivial:
+  - "Ignore ``sanity[cannot-ignore]`` ansible-lint rule (https://github.com/ansible-collections/ansible.netcommon/pull/550)."


### PR DESCRIPTION
##### SUMMARY
Should fix CI on `main`.

Ref: #549

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
