### PR TITLE
Support for explicit proxy using ansible variable instead of environment variable

### DIFF
--- a/changelogs/fragments/556-ansible_httpapi_explicit_proxy.yml
+++ b/changelogs/fragments/556-ansible_httpapi_explicit_proxy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - httpapi - New ansible_explicit_proxy variable for setting HTTP/HTTPS proxy with ansible variable instead of environment variable

--- a/docs/ansible.netcommon.httpapi_connection.rst
+++ b/docs/ansible.netcommon.httpapi_connection.rst
@@ -108,6 +108,24 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>explicit_proxy</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                                <div>var: ansible_httpapi_explicit_proxy</div>
+                    </td>
+                <td>
+                        <div>Define an explicit proxy for the connection. Will reset HTTPS_PROXY and HTTP_PROXY env variable</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -293,8 +293,8 @@ class Connection(NetworkConnectionBase):
 
         explicit_proxy = self.get_option("explicit_proxy")
         if explicit_proxy and explicit_proxy != "":
-            environ['HTTPS_PROXY'] = explicit_proxy
-            environ['HTTP_PROXY']  = explicit_proxy
+            environ["HTTPS_PROXY"] = explicit_proxy
+            environ["HTTP_PROXY"] = explicit_proxy
 
         ciphers = self.get_option("ciphers")
         if ciphers:

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -101,6 +101,12 @@ options:
     default: true
     vars:
     - name: ansible_httpapi_use_proxy
+  explicit_proxy:
+    type: string
+    description:
+    - Define an explicit proxy for the connection. Will reset HTTPS_PROXY and HTTP_PROXY env variable
+    vars:
+    - name: ansible_httpapi_explicit_proxy
   ciphers:
     description:
       - SSL/TLS Ciphers to use for requests
@@ -156,6 +162,7 @@ options:
 """
 
 from io import BytesIO
+from os import environ
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_bytes
@@ -283,6 +290,11 @@ class Connection(NetworkConnectionBase):
             headers={},
         )
         url_kwargs.update(kwargs)
+
+        explicit_proxy = self.get_option("explicit_proxy")
+        if explicit_proxy and explicit_proxy != "":
+            environ['HTTPS_PROXY'] = explicit_proxy
+            environ['HTTP_PROXY']  = explicit_proxy
 
         ciphers = self.get_option("ciphers")
         if ciphers:


### PR DESCRIPTION
##### SUMMARY
Following issue : 
https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection/issues/240

The only way to use a proxy is to set the HTTP(S)_PROXY environment variables which are set globally for the ansible process. Unfortunatelly it does not permit to set a different proxy for different host or host_groups

Adding this option will allow to dynamically set an httpapi ansible variable "ansible_httpapi_explicit_proxy" based on host/hostgroup or any variable.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
httpapi

##### ADDITIONAL INFORMATION
In the send() fonction, os.environ variable HTTPS_PROXY and HTTP_PROXY are reset with the value provided.

This adds a new dependency with os python library. It may be improved or written differently i guess.

Usage:
```yaml
- name: xxx
  hosts:
    - xxx
  gather_facts: True
  collections:
    - fortinet.fortios
  vars:
    ansible_httpapi_port: 443
    ansible_httpapi_use_ssl: True
    ansible_httpapi_validate_certs: False
    ansible_httpapi_use_proxy: True
    ansible_network_os: fortinet.fortios.fortios
    ansible_network_import_modules: False
    ansible_httpapi_explicit_proxy: "{{ ps }}"     # <<<<<< 
  connection: httpapi
[...]
```
