### PR TITLE
Add default cliconf plugin good enough to use cli_command most of the time

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Name | Description
 --- | ---
 [ansible.netcommon.enable](https://github.com/ansible-collections/ansible.netcommon/blob/main/docs/ansible.netcommon.enable_become.rst)|Switch to elevated permissions on a network device
 
+### Cliconf plugins
+Name | Description
+--- | ---
+[ansible.netcommon.default](https://github.com/ansible-collections/ansible.netcommon/blob/main/docs/ansible.netcommon.default_cliconf.rst)|General purpose cliconf plugin for new platforms
+
 ### Connection plugins
 Name | Description
 --- | ---

--- a/changelogs/fragments/default-cliconf.yaml
+++ b/changelogs/fragments/default-cliconf.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Add a new cliconf plugin ``default`` that can be used when no cliconf
+    plugin is found for a given network_os. This plugin only supports ``get()``.
+    (https://github.com/ansible-collections/ansible.netcommon/pull/569)

--- a/docs/ansible.netcommon.default_cliconf.rst
+++ b/docs/ansible.netcommon.default_cliconf.rst
@@ -1,0 +1,43 @@
+.. _ansible.netcommon.default_cliconf:
+
+
+*************************
+ansible.netcommon.default
+*************************
+
+**General purpose cliconf plugin for new platforms**
+
+
+Version added: 5.2.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This plugin attemts to provide low level abstraction apis for sending and receiving CLI commands from arbitrary network devices.
+
+
+
+
+
+
+
+
+
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Ansible Networking Team (@ansible-network)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/plugins/cliconf/default.py
+++ b/plugins/cliconf/default.py
@@ -18,17 +18,10 @@ version_added: 5.2.0
 
 import json
 
-from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils.common._collections_compat import Mapping
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.cliconf_base import CliconfBase
 
 
 class Cliconf(CliconfBase):
-    __rpc__ = CliconfBase.__rpc__ + [
-        "run_commands",
-    ]
-
     def __init__(self, *args, **kwargs):
         super(Cliconf, self).__init__(*args, **kwargs)
         self._device_info = {}
@@ -41,52 +34,19 @@ class Cliconf(CliconfBase):
         return self._device_info
 
     def get_config(self, flags=None, format=None):
-        raise NotImplementedError
-
-    def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
-        raise NotImplementedError
-
-    def get(
-        self,
-        command=None,
-        prompt=None,
-        answer=None,
-        sendonly=False,
-        newline=True,
-        output=None,
-        check_all=False,
-    ):
-        if not command:
-            raise ValueError("must provide value of command to execute")
-
-        return self.send_command(
-            command=command,
-            prompt=prompt,
-            answer=answer,
-            sendonly=sendonly,
-            newline=newline,
-            check_all=check_all,
+        return self._connection.method_not_found(
+            "commit is not supported by network_os %s" % self._play_context.network_os
         )
 
-    def run_commands(self, commands=None, check_rc=True):
-        if commands is None:
-            raise ValueError("'commands' value is required")
+    def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
+        return self._connection.method_not_found(
+            "commit is not supported by network_os %s" % self._play_context.network_os
+        )
 
-        responses = list()
-        for cmd in to_list(commands):
-            if not isinstance(cmd, Mapping):
-                cmd = {"command": cmd}
-
-            try:
-                out = self.send_command(**cmd)
-            except AnsibleConnectionFailure as e:
-                if check_rc:
-                    raise
-                out = getattr(e, "err", e)
-
-            responses.append(out)
-
-        return responses
+    def get_capabilities(self):
+        result = super(Cliconf, self).get_capabilities()
+        result["device_operations"] = self.get_device_operations()
+        return json.dumps(result)
 
     def get_device_operations(self):
         return {
@@ -102,9 +62,3 @@ class Cliconf(CliconfBase):
             "supports_generate_diff": False,
             "supports_replace": False,
         }
-
-    def get_capabilities(self):
-        result = super(Cliconf, self).get_capabilities()
-        result["device_operations"] = self.get_device_operations()
-        result.update(self.get_option_values())
-        return json.dumps(result)

--- a/plugins/cliconf/default.py
+++ b/plugins/cliconf/default.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -18,6 +19,8 @@ version_added: 5.2.0
 
 import json
 
+from ansible.errors import AnsibleConnectionFailure
+
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.cliconf_base import CliconfBase
 
 
@@ -31,17 +34,17 @@ class Cliconf(CliconfBase):
             device_info = {}
 
             device_info["network_os"] = "default"
+            self._device_info = device_info
+
         return self._device_info
 
     def get_config(self, flags=None, format=None):
-        return self._connection.method_not_found(
-            "commit is not supported by network_os %s" % self._play_context.network_os
-        )
+        network_os = self.get_device_info()["network_os"]
+        raise AnsibleConnectionFailure("get_config is not supported by network_os %s" % network_os)
 
     def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
-        return self._connection.method_not_found(
-            "commit is not supported by network_os %s" % self._play_context.network_os
-        )
+        network_os = self.get_device_info()["network_os"]
+        raise AnsibleConnectionFailure("edit_config is not supported by network_os %s" % network_os)
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()

--- a/plugins/cliconf/default.py
+++ b/plugins/cliconf/default.py
@@ -1,0 +1,110 @@
+# (c) 2023 Red Hat Inc.
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+author: Ansible Networking Team (@ansible-network)
+name: default
+short_description: General purpose cliconf plugin for new platforms
+description:
+- This plugin attemts to provide low level abstraction apis for sending and receiving CLI
+  commands from arbitrary network devices.
+version_added: 5.2.0
+"""
+
+import json
+
+from ansible.errors import AnsibleConnectionFailure
+from ansible.module_utils.common._collections_compat import Mapping
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list
+from ansible_collections.ansible.netcommon.plugins.plugin_utils.cliconf_base import CliconfBase
+
+
+class Cliconf(CliconfBase):
+    __rpc__ = CliconfBase.__rpc__ + [
+        "run_commands",
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super(Cliconf, self).__init__(*args, **kwargs)
+        self._device_info = {}
+
+    def get_device_info(self):
+        if not self._device_info:
+            device_info = {}
+
+            device_info["network_os"] = "default"
+        return self._device_info
+
+    def get_config(self, flags=None, format=None):
+        raise NotImplementedError
+
+    def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
+        raise NotImplementedError
+
+    def get(
+        self,
+        command=None,
+        prompt=None,
+        answer=None,
+        sendonly=False,
+        newline=True,
+        output=None,
+        check_all=False,
+    ):
+        if not command:
+            raise ValueError("must provide value of command to execute")
+
+        return self.send_command(
+            command=command,
+            prompt=prompt,
+            answer=answer,
+            sendonly=sendonly,
+            newline=newline,
+            check_all=check_all,
+        )
+
+    def run_commands(self, commands=None, check_rc=True):
+        if commands is None:
+            raise ValueError("'commands' value is required")
+
+        responses = list()
+        for cmd in to_list(commands):
+            if not isinstance(cmd, Mapping):
+                cmd = {"command": cmd}
+
+            try:
+                out = self.send_command(**cmd)
+            except AnsibleConnectionFailure as e:
+                if check_rc:
+                    raise
+                out = getattr(e, "err", e)
+
+            responses.append(out)
+
+        return responses
+
+    def get_device_operations(self):
+        return {
+            "supports_diff_replace": False,
+            "supports_commit": False,
+            "supports_rollback": False,
+            "supports_defaults": False,
+            "supports_onbox_diff": False,
+            "supports_commit_comment": False,
+            "supports_multiline_delimiter": False,
+            "supports_diff_match": False,
+            "supports_diff_ignore_lines": False,
+            "supports_generate_diff": False,
+            "supports_replace": False,
+        }
+
+    def get_capabilities(self):
+        result = super(Cliconf, self).get_capabilities()
+        result["device_operations"] = self.get_device_operations()
+        result.update(self.get_option_values())
+        return json.dumps(result)

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -386,26 +386,30 @@ class Connection(NetworkConnectionBase):
                 raise AnsibleConnectionFailure("network os %s is not supported" % self._network_os)
 
             self.cliconf = cliconf_loader.get(self._network_os, self)
-            if self.cliconf:
-                self._sub_plugin = {
-                    "type": "cliconf",
-                    "name": self.cliconf._load_name,
-                    "obj": self.cliconf,
-                }
+            if not self.cliconf:
                 self.queue_message(
                     "vvvv",
-                    "loaded cliconf plugin %s from path %s for network_os %s"
-                    % (
-                        self.cliconf._load_name,
-                        self.cliconf._original_path,
-                        self._network_os,
-                    ),
+                    "unable to load cliconf for network_os %s. Falling back to default"
+                    % self._network_os,
                 )
-            else:
-                self.queue_message(
-                    "vvvv",
-                    "unable to load cliconf for network_os %s" % self._network_os,
-                )
+                self.cliconf = cliconf_loader.get("ansible.netcommon.default", self)
+                if not self.cliconf:
+                    raise AnsibleConnectionFailure("Couldn't load fallback cliconf plugin")
+
+            self._sub_plugin = {
+                "type": "cliconf",
+                "name": self.cliconf._load_name,
+                "obj": self.cliconf,
+            }
+            self.queue_message(
+                "vvvv",
+                "loaded cliconf plugin %s from path %s for network_os %s"
+                % (
+                    self.cliconf._load_name,
+                    self.cliconf._original_path,
+                    self._network_os,
+                ),
+            )
         else:
             raise AnsibleConnectionFailure(
                 "Unable to automatically determine host network os. Please "

--- a/plugins/plugin_utils/cliconf_base.py
+++ b/plugins/plugin_utils/cliconf_base.py
@@ -13,9 +13,11 @@ from functools import wraps
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
 from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common._collections_compat import Mapping
 
 # Needed to satisfy PluginLoader's required_base_class
 from ansible.plugins.cliconf import CliconfBase as CliconfBaseBase
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list
 
 
 try:
@@ -70,12 +72,13 @@ class CliconfBase(CliconfBaseBase):
     """
 
     __rpc__ = [
-        "get_config",
         "edit_config",
-        "get_capabilities",
-        "get",
         "enable_response_logging",
+        "get",
+        "get_capabilities",
+        "get_config",
         "disable_response_logging",
+        "run_commands",
     ]
 
     def __init__(self, connection):
@@ -241,7 +244,6 @@ class CliconfBase(CliconfBaseBase):
         """
         pass
 
-    @abstractmethod
     def get(
         self,
         command=None,
@@ -268,7 +270,17 @@ class CliconfBase(CliconfBaseBase):
                           given prompt.
         :return: The output from the device after executing the command
         """
-        pass
+        if not command:
+            raise ValueError("must provide value of command to execute")
+
+        return self.send_command(
+            command=command,
+            prompt=prompt,
+            answer=answer,
+            sendonly=sendonly,
+            newline=newline,
+            check_all=check_all,
+        )
 
     @abstractmethod
     def get_capabilities(self):
@@ -478,7 +490,24 @@ class CliconfBase(CliconfBaseBase):
                          value is True an exception is raised.
         :return: List of returned response
         """
-        pass
+        if commands is None:
+            raise ValueError("'commands' value is required")
+
+        responses = list()
+        for cmd in to_list(commands):
+            if not isinstance(cmd, Mapping):
+                cmd = {"command": cmd}
+
+            try:
+                out = self.send_command(**cmd)
+            except AnsibleConnectionFailure as e:
+                if check_rc:
+                    raise
+                out = getattr(e, "err", e)
+
+            responses.append(out)
+
+        return responses
 
     def check_edit_config_capability(
         self,

--- a/plugins/plugin_utils/cliconf_base.py
+++ b/plugins/plugin_utils/cliconf_base.py
@@ -17,6 +17,7 @@ from ansible.module_utils.common._collections_compat import Mapping
 
 # Needed to satisfy PluginLoader's required_base_class
 from ansible.plugins.cliconf import CliconfBase as CliconfBaseBase
+
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list
 
 
@@ -352,7 +353,7 @@ class CliconfBase(CliconfBaseBase):
 
         :return: None
         """
-        return self._connection.method_not_found(
+        raise AnsibleConnectionFailure(
             "commit is not supported by network_os %s" % self._play_context.network_os
         )
 
@@ -365,7 +366,7 @@ class CliconfBase(CliconfBaseBase):
 
         :returns: None
         """
-        return self._connection.method_not_found(
+        raise AnsibleConnectionFailure(
             "discard_changes is not supported by network_os %s" % self._play_context.network_os
         )
 

--- a/tests/unit/plugins/cliconf/test_default.py
+++ b/tests/unit/plugins/cliconf/test_default.py
@@ -73,14 +73,15 @@ def test_get_capabilities(cliconf):
     )
 
 
-def test_get_config(cliconf):
-    with pytest.raises(AnsibleConnectionFailure):
-        cliconf.get_config()
+@pytest.mark.parametrize("method", ["get_config", "edit_config", "commit", "discard_changes"])
+def test_unsupported_method(cliconf, method):
+    cliconf._play_context = MagicMock()
+    cliconf._play_context.network_os = "default"
 
-
-def test_edit_config(cliconf):
-    with pytest.raises(AnsibleConnectionFailure):
-        cliconf.edit_config()
+    with pytest.raises(
+        AnsibleConnectionFailure, match=f"{method} is not supported by network_os default"
+    ):
+        getattr(cliconf, method)()
 
 
 def test_get(cliconf):

--- a/tests/unit/plugins/cliconf/test_default.py
+++ b/tests/unit/plugins/cliconf/test_default.py
@@ -1,0 +1,70 @@
+#
+# (c) 2016 Red Hat Inc.
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Make coding more python3-ish
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+
+import json
+
+import pytest
+
+from ansible.plugins.loader import cliconf_loader
+
+
+INFO = dict(network_os="default")
+OPERATIONS = {
+    "supports_diff_replace": False,
+    "supports_commit": False,
+    "supports_rollback": False,
+    "supports_defaults": False,
+    "supports_onbox_diff": False,
+    "supports_commit_comment": False,
+    "supports_multiline_delimiter": False,
+    "supports_diff_match": False,
+    "supports_diff_ignore_lines": False,
+    "supports_generate_diff": False,
+    "supports_replace": False,
+}
+RPC = [
+    "edit_config",
+    "enable_response_logging",
+    "get",
+    "get_capabilities",
+    "get_config",
+    "disable_response_logging",
+    "run_commands",
+]
+
+
+@pytest.fixture(name="cliconf")
+def plugin_fixture(monkeypatch):
+    cliconf = cliconf_loader.get("ansible.netcommon.default", None)
+    return cliconf
+
+
+def test_get_device_info(cliconf):
+    info = cliconf.get_device_info()
+    assert info == INFO
+
+    # Test cached info works
+    assert info == cliconf.get_device_info()
+
+
+def test_get_device_operations(cliconf):
+    ops = cliconf.get_device_operations()
+    assert ops == OPERATIONS
+
+
+def test_get_capabilities(cliconf):
+    cap = json.loads(cliconf.get_capabilities())
+    assert cap == dict(
+        rpc=RPC,
+        device_info=INFO,
+        network_api="cliconf",
+        device_operations=OPERATIONS,
+    )

--- a/tests/unit/plugins/cliconf/test_default.py
+++ b/tests/unit/plugins/cliconf/test_default.py
@@ -13,6 +13,7 @@ import json
 
 import pytest
 
+from ansible.errors import AnsibleConnectionFailure
 from ansible.plugins.loader import cliconf_loader
 
 
@@ -68,3 +69,13 @@ def test_get_capabilities(cliconf):
         network_api="cliconf",
         device_operations=OPERATIONS,
     )
+
+
+def test_get_config(cliconf):
+    with pytest.raises(AnsibleConnectionFailure):
+        cliconf.get_config()
+
+
+def test_edit_config(cliconf):
+    with pytest.raises(AnsibleConnectionFailure):
+        cliconf.edit_config()

--- a/tests/unit/plugins/cliconf/test_default.py
+++ b/tests/unit/plugins/cliconf/test_default.py
@@ -79,3 +79,13 @@ def test_get_config(cliconf):
 def test_edit_config(cliconf):
     with pytest.raises(AnsibleConnectionFailure):
         cliconf.edit_config()
+
+
+def test_get_no_command(cliconf):
+    with pytest.raises(ValueError, match="must provide value of command to execute"):
+        cliconf.get()
+
+
+def test_run_commands_no_commands(cliconf):
+    with pytest.raises(ValueError, match="'commands' value is required"):
+        cliconf.run_commands()

--- a/tests/unit/plugins/cliconf/test_default.py
+++ b/tests/unit/plugins/cliconf/test_default.py
@@ -11,6 +11,8 @@ __metaclass__ = type
 
 import json
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from ansible.errors import AnsibleConnectionFailure
@@ -43,7 +45,7 @@ RPC = [
 
 
 @pytest.fixture(name="cliconf")
-def plugin_fixture(monkeypatch):
+def plugin_fixture():
     cliconf = cliconf_loader.get("ansible.netcommon.default", None)
     return cliconf
 
@@ -81,9 +83,27 @@ def test_edit_config(cliconf):
         cliconf.edit_config()
 
 
+def test_get(cliconf):
+    return_value = "ABC FakeOS v1.23.4"
+    conn = MagicMock()
+    conn.send.return_value = return_value
+    cliconf._connection = conn
+    resp = cliconf.get("show version")
+    assert resp == return_value
+
+
 def test_get_no_command(cliconf):
     with pytest.raises(ValueError, match="must provide value of command to execute"):
         cliconf.get()
+
+
+def test_run_commands(cliconf):
+    return_value = "ABC FakeOS v1.23.4"
+    conn = MagicMock()
+    conn.send.return_value = return_value
+    cliconf._connection = conn
+    resp = cliconf.run_commands(["show version"])
+    assert resp == [return_value]
 
 
 def test_run_commands_no_commands(cliconf):


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This should simplify the zero-to-cli_command experience for new platforms (or very old ones).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cliconf/default
