### PR TITLE
Gns3 io sv telent

### DIFF
--- a/plugins/action/telnet.py
+++ b/plugins/action/telnet.py
@@ -48,8 +48,8 @@ class ActionModule(ActionBase):
             timeout = int(self._task.args.get("timeout", 120))
             pause = int(self._task.args.get("pause", 1))
 
+            send_carriage_return = self._task.args.get("send_carriage_return", False)           
             send_newline = self._task.args.get("send_newline", False)
-            send_carriage_return = self._task.args.get("send_carriage_return", False)
 
             login_prompt = to_text(self._task.args.get("login_prompt", "login: "))
             password_prompt = to_text(self._task.args.get("password_prompt", "Password: "))
@@ -64,10 +64,10 @@ class ActionModule(ActionBase):
 
                 self.output = bytes()
                 try:
+                    if send_carriage_return:
+                        self.tn.write(b"\r")                   
                     if send_newline:
                         self.tn.write(b"\n")
-                    if send_carriage_return:
-                        self.tn.write(b"\r")
 
                     self.await_prompts([login_prompt], timeout)
                     self.tn.write(to_bytes(user + "\n"))

--- a/plugins/action/telnet.py
+++ b/plugins/action/telnet.py
@@ -46,6 +46,7 @@ class ActionModule(ActionBase):
             pause = int(self._task.args.get("pause", 1))
 
             send_newline = self._task.args.get("send_newline", False)
+            send_carriage_return = self._task.args.get("send_carriage_return", False)
 
             login_prompt = to_text(self._task.args.get("login_prompt", "login: "))
             password_prompt = to_text(self._task.args.get("password_prompt", "Password: "))
@@ -62,6 +63,8 @@ class ActionModule(ActionBase):
                 try:
                     if send_newline:
                         self.tn.write(b"\n")
+                    if send_carriage_return:
+                        self.tn.write(b"\r")
 
                     self.await_prompts([login_prompt], timeout)
                     self.tn.write(to_bytes(user + "\n"))

--- a/plugins/modules/telnet.py
+++ b/plugins/modules/telnet.py
@@ -83,6 +83,12 @@ options:
     required: false
     type: bool
     default: false
+  send_carriage_return:
+    description:
+    - Sends a carriage return character upon successful connection to start the terminal session.
+    required: false
+    type: bool
+    default: false
 notes:
 - The C(environment) keyword does not work with this task
 author:

--- a/plugins/modules/telnet.py
+++ b/plugins/modules/telnet.py
@@ -78,18 +78,19 @@ options:
     required: false
     type: int
     default: 1
+  send_carriage_return:
+    description:
+    - Sends a carriage return character upon successful connection to start the terminal session, this occurs before send_newline option.
+    required: false
+    type: bool
+    default: false
   send_newline:
     description:
     - Sends a newline character upon successful connection to start the terminal session.
     required: false
     type: bool
     default: false
-  send_carriage_return:
-    description:
-    - Sends a carriage return character upon successful connection to start the terminal session.
-    required: false
-    type: bool
-    default: false
+
 notes:
 - The C(environment) keyword does not work with this task
 author:


### PR DESCRIPTION
##### SUMMARY
Add "send_carriage_return" option to send "\r" upon connection similar to existing send-newline.
This add ability to connect to IOSv devices in GNS3 which need get the "/r" as the first character in the telnet connection otherwise the prompt is never found. It seem that a carriage return is required to display the NAG banner after which the prompt is output.
Issue #542 describes similar issue with nag banner on Procurve switches



##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.netcommon.telnet

##### ADDITIONAL INFORMATION

Using GNS3 a new project is created with a single IOSv router con0 is made available on 198.18.1.200:500.
thj last output on the console is "%PLATFORM-5-SIGNATURE_VERIFIED: Image 'flash0:/vios-adventerprisek9-m' passed code signing verification" and the IOSV then waits for a "\r" before display in the NAG and prompt:

**************************************************************************
* IOSv is strictly limited to use for evaluation, demonstration and IOS  *
* education. IOSv is provided as-is and is not supported by Cisco's      *
* Technical Advisory Center. Any use or disclosure, in whole or in part, *
* of the IOSv Software or Documentation to any third party for any       *
* purposes is expressly prohibited except as otherwise authorized by     *
* Cisco in writing.                                                      *
**************************************************************************
Router#

SO using the inventory :-
all:
  hosts:
    R1:
      ansible_host: 198.18.1.200
      port: 5000
      device_type: "cisco_ios_telnet"
and playbook :-
- name: Configure hostname using Telnet connection
  gather_facts: false
  hosts: all
  tasks:
    - name: Configure hostname
      telnetX:
        port: '{{ hostvars[inventory_hostname].port }}'
        timeout: 5
        # send_carriage_return: true
        prompts:
          - '[>#]'
        command:
          - configure terminal
          - hostname {{ inventory_hostname }}

results in output :
(.venv) local@ansible:$ansible-playbook -i ./ansible/inventory/telnetX_hosts.yml ./ansible/telnetX.yml 

PLAY [Configure hostname using Telnet connection] ********************************************************************

TASK [Configure hostname] ********************************************************************************************
fatal: [R1]: FAILED! => {"changed": true, "msg": "Telnet timed out trying to find prompt(s): '['[>#]']'", "stdout": "", "stdout_lines": []}

PLAY RECAP ***********************************************************************************************************
R1                         : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   

(.venv) local@ansible:$

This is the second run as the first output all the startup output from the device but results in the same behaviour.

With support for sending carriage return and adding send_carriage_return: true send_carriage_return: true to the task :-

- name: Configure hostname using Telnet connection
  gather_facts: false
  hosts: all
  tasks:
    - name: Configure hostname
      telnetX:
        port: '{{ hostvars[inventory_hostname].port }}'
        timeout: 5
        send_carriage_return: true
        prompts:
          - '[>#]'
        command:
          - configure terminal
          - hostname {{ inventory_hostname }}

(.venv) adm-local@ansible:$ansible-playbook -i ./ansible/inventory/telnetX_hosts.yml ./ansible/telnetX.yml 

PLAY [Configure hostname using Telnet connection] ********************************************************************

TASK [Configure hostname] ********************************************************************************************
changed: [R1]

PLAY RECAP ***********************************************************************************************************
R1                         : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

(.venv) adm-local@ansible:$


