### PR TITLE
Fix parse_xml type for tmpl

### DIFF
--- a/changelogs/fragments/fix_attribute_type.yaml
+++ b/changelogs/fragments/fix_attribute_type.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix attribute types from string to str in filter plugins.

--- a/plugins/filter/parse_cli.py
+++ b/plugins/filter/parse_cli.py
@@ -37,7 +37,7 @@ options:
       It defines how to parse the CLI output and return JSON data.
     - For example C(cli_data | ansible.netcommon.parse_cli(template.yml)),
       in this case C(cli_data) represents cli output.
-    type: string
+    type: str
 """
 
 EXAMPLES = r"""

--- a/plugins/filter/parse_xml.py
+++ b/plugins/filter/parse_xml.py
@@ -36,7 +36,7 @@ options:
       It defines how to parse the XML output and return JSON data.
     - For example C(xml_data | ansible.netcommon.parse_xml(template.yml)),
       in this case C(xml_data) represents xml data option.
-    type: string
+    type: str
 """
 
 EXAMPLES = r"""

--- a/plugins/filter/vlan_expander.py
+++ b/plugins/filter/vlan_expander.py
@@ -27,7 +27,7 @@ options:
   data:
     description:
     - This option represents a string containing the range of vlans.
-    type: string
+    type: str
     required: True
 """
 


### PR DESCRIPTION
##### SUMMARY
Change the parse_xml argument validation to require a type `str` instead of a type `string` for `tmpl`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
parse_xml

##### ADDITIONAL INFORMATION
Any simple call to parse_xml would render a flavour of the following error message:

`
fatal: [localhost]: FAILED! => {"msg": "[\"argument 'tmpl' is of type <class 'ansible.utils.native_jinja.NativeJinjaText'> and we were unable to convert to string: 'NoneType' object is not callable\"]"}
`
