### PR TITLE
correctly convert AnsibleUnsafeText to str

### DIFF
--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -24,6 +24,7 @@ import socket
 
 from copy import deepcopy
 from functools import reduce  # forward compatibility for Python 3
+from io import StringIO
 from itertools import chain
 
 from ansible.module_utils import basic
@@ -719,7 +720,7 @@ def extract_argspec(doc_obj, argpsec):
 
 # TODO: Support extends_documentation_fragment
 def convert_doc_to_ansible_module_kwargs(doc):
-    doc_obj = yaml.load(str(doc), SafeLoader)
+    doc_obj = yaml.load(StringIO(doc), SafeLoader)
     argspec = {}
     spec = {}
     extract_argspec(doc_obj, argspec)


### PR DESCRIPTION
##### SUMMARY
- Due to a CVE mitigation, converting AnsibleUnsafeText objects to string using `str()` does not work with latest core releases. This patch accounts for the same.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
module_utils
