### PR TITLE
network_cli: remove deprecated play_context.verbosity

### DIFF
--- a/changelogs/fragments/verbosity.yml
+++ b/changelogs/fragments/verbosity.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - network_cli - removed deprecated play_context.verbosity property.

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -318,6 +318,7 @@ from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import cPickle
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import cache_loader, cliconf_loader, connection_loader, terminal_loader
+from ansible.utils.display import Display
 
 from ansible_collections.ansible.netcommon.plugins.connection.libssh import HAS_PYLIBSSH
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list
@@ -332,6 +333,7 @@ try:
     HAS_SCP = True
 except ImportError:
     HAS_SCP = False
+display = Display()
 
 
 def ensure_connect(func):
@@ -597,7 +599,7 @@ class Connection(NetworkConnectionBase):
         """
         Connects to the remote device and starts the terminal
         """
-        if self._play_context.verbosity > 3:
+        if display.verbosity > 3:
             logging.getLogger(self.ssh_type).setLevel(logging.DEBUG)
 
         self.queue_message("vvvv", "invoked shell using ssh_type: %s" % self.ssh_type)


### PR DESCRIPTION
##### SUMMARY

* Core removed deprecated call to play_context.verbosity property
  in Ansible 2.18. Update the code as per.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


