### PR TITLE
libssh connection: stop using PlayContext.verbosity

### DIFF
--- a/changelogs/fragments/626-verbosity.yml
+++ b/changelogs/fragments/626-verbosity.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - libssh connection plugin - stop using deprecated ``PlayContext.verbosity`` property that is no longer present in ansible-core 2.18 (https://github.com/ansible-collections/ansible.netcommon/pull/626).

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -375,7 +375,7 @@ class Connection(ConnectionBase):
 
         self.ssh = Session()
 
-        if self._play_context.verbosity > 3:
+        if display.verbosity > 3:
             self.ssh.set_log_level(logging.INFO)
 
         self.keyfile = os.path.expanduser("~/.ssh/known_hosts")


### PR DESCRIPTION
##### SUMMARY
Right now libssh cannot be used with ansible-core devel (to be 2.18) since the deprecated `PlayContext.verbosity` has been removed. (This currently makes the nightly community.routeros tests fail.)

Fixes #541.

Similar to #625.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
libssh
