### PR TITLE
Exception handling when restore plugin not supported

### DIFF
--- a/changelogs/fragments/update_not_supported_exception.yaml
+++ b/changelogs/fragments/update_not_supported_exception.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fail the module execution gracefully with plugin support required message.
+  - Also guide user to open issue for respective platform. 

--- a/changelogs/fragments/update_not_supported_exception.yaml
+++ b/changelogs/fragments/update_not_supported_exception.yaml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - Fail the module execution gracefully with plugin support required message.
-  - Also guide user to open issue for respective platform. 
+  - Improved module execution to gracefully handle cases where plugin support is required, providing a clear error message to the user.
+  - Added guidance for users to open an issue for the respective platform if plugin support is needed.

--- a/plugins/modules/cli_restore.py
+++ b/plugins/modules/cli_restore.py
@@ -75,10 +75,9 @@ EXAMPLES = """
 RETURN = """
 """
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.connection import Connection
-from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils._text import to_text
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection, ConnectionError
 
 
 def validate_args(module, device_operations):
@@ -111,14 +110,14 @@ def main():
     result = {"changed": False}
     connection = Connection(module._socket_path)
     try:
-          running = connection.restore(
-              filename=module.params["filename"],
-              path=module.params["path"],
-          )
+        running = connection.restore(
+            filename=module.params["filename"],
+            path=module.params["path"],
+        )
     except ConnectionError as exc:
-        if exc.code == -32601: # Method not found
-          msg = "This platform does not support restore_plugin.Please report an issue against this platform's cliconf plugin."
-          module.fail_json(msg, code=exc.code)
+        if exc.code == -32601:  # Method not found
+            msg = "This platform does not support restore_plugin.Please report an issue against this platform's cliconf plugin."
+            module.fail_json(msg, code=exc.code)
         else:
             module.fail_json(msg=to_text(exc, errors="surrogate_then_replace").strip())
     result["__restore__"] = running

--- a/plugins/modules/cli_restore.py
+++ b/plugins/modules/cli_restore.py
@@ -116,11 +116,11 @@ def main():
               path=module.params["path"],
           )
     except ConnectionError as exc:
-        msg=to_text(exc, errors="surrogate_then_replace")
-        if msg == "Method not found":
+        if exc.code == -32601: # Method not found
           msg = "This platform does not support restore_plugin.Please report an issue against this platform's cliconf plugin."
-        module.fail_json(msg, code=exc.code)
-
+          module.fail_json(msg, code=exc.code)
+        else:
+            module.fail_json(msg=to_text(exc, errors="surrogate_then_replace").strip())
     result["__restore__"] = running
     module.exit_json(**result)
 

--- a/plugins/modules/cli_restore.py
+++ b/plugins/modules/cli_restore.py
@@ -116,7 +116,7 @@ def main():
         )
     except ConnectionError as exc:
         if exc.code == -32601:  # Method not found
-            msg = "This platform does not support restore_plugin.Please report an issue against this platform's cliconf plugin."
+            msg = "This platform is not supported with cli_restore. Please report an issue against this platform's cliconf plugin."
             module.fail_json(msg, code=exc.code)
         else:
             module.fail_json(msg=to_text(exc, errors="surrogate_then_replace").strip())

--- a/plugins/modules/cli_restore.py
+++ b/plugins/modules/cli_restore.py
@@ -78,6 +78,7 @@ RETURN = """
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
 from ansible.module_utils.connection import ConnectionError
+from ansible.module_utils._text import to_text
 
 
 def validate_args(module, device_operations):
@@ -115,7 +116,9 @@ def main():
               path=module.params["path"],
           )
     except ConnectionError as exc:
-        msg = "This platform does not support restore_plugin.Please report an issue against this platform's cliconf plugin."
+        msg=to_text(exc, errors="surrogate_then_replace")
+        if msg == "Method not found":
+          msg = "This platform does not support restore_plugin.Please report an issue against this platform's cliconf plugin."
         module.fail_json(msg, code=exc.code)
 
     result["__restore__"] = running

--- a/plugins/modules/cli_restore.py
+++ b/plugins/modules/cli_restore.py
@@ -108,12 +108,16 @@ def main():
 
     result = {"changed": False}
     connection = Connection(module._socket_path)
-    running = connection.restore(
-        filename=module.params["filename"],
-        path=module.params["path"],
-    )
-    result["__restore__"] = running
+    try:
+          running = connection.restore(
+              filename=module.params["filename"],
+              path=module.params["path"],
+          )
+    except Exception as exc:
+        msg = "This platform does not support restore_plugin.Please report an issue against this platform's cliconf plugin."
+        module.fail_json(msg, code=exc.code)
 
+    result["__restore__"] = running
     module.exit_json(**result)
 
 

--- a/plugins/modules/cli_restore.py
+++ b/plugins/modules/cli_restore.py
@@ -77,6 +77,7 @@ RETURN = """
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
+from ansible.module_utils.connection import ConnectionError
 
 
 def validate_args(module, device_operations):
@@ -113,7 +114,7 @@ def main():
               filename=module.params["filename"],
               path=module.params["path"],
           )
-    except Exception as exc:
+    except ConnectionError as exc:
         msg = "This platform does not support restore_plugin.Please report an issue against this platform's cliconf plugin."
         module.fail_json(msg, code=exc.code)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
  - Improved module execution to gracefully handle cases where plugin support is required, providing a clear error message to the user.
  - Added guidance for users to open an issue for the respective platform if plugin support is needed.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
The full traceback is:
  File "/tmp/ansible_ansible.netcommon.cli_restore_payload_rbin7u_s/ansible_ansible.netcommon.cli_restore_payload.zip/ansible_collections/ansible/netcommon/plugins/modules/cli_restore.py", line 113, in main
  File "/tmp/ansible_ansible.netcommon.cli_restore_payload_rbin7u_s/ansible_ansible.netcommon.cli_restore_payload.zip/ansible/module_utils/connection.py", line 203, in __rpc__
    raise ConnectionError(to_text(msg, errors='surrogate_then_replace'), code=code)
fatal: [iosxr]: FAILED! => changed=false 
  code: -32601
  invocation:
    module_args:
      filename: 20240417115543_iosxr_iosxr.txt
      path: /misc/
  msg: This platform does not support the restore_plugin.Please report an issue against this platform's cliconf plugin.
```
