### PR TITLE
Revert edit_config signature updates in #653

### DIFF
--- a/changelogs/fragments/bug_653.yaml
+++ b/changelogs/fragments/bug_653.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - The v6.1.2 release introduced a change in cliconfbase's edit_config() signature which broke many platform cliconfs. This patch would revert that change.

--- a/plugins/module_utils/network/common/rm_base/resource_module.py
+++ b/plugins/module_utils/network/common/rm_base/resource_module.py
@@ -145,9 +145,9 @@ class ResourceModule(RmEngineBase):  # pylint: disable=R0902
                 else:
                     self.addcmd(have, parser, True)
 
-    def run_commands(self, err_responses=None):
+    def run_commands(self):
         """Send commands to the device"""
         if self.commands and self.state in self.ACTION_STATES:
             if not self._module.check_mode:
-                self._connection.edit_config(candidate=self.commands, err_responses=err_responses)
+                self._connection.edit_config(candidate=self.commands)
             self.changed = True

--- a/plugins/plugin_utils/cliconf_base.py
+++ b/plugins/plugin_utils/cliconf_base.py
@@ -215,7 +215,6 @@ class CliconfBase(CliconfBaseBase):
         replace=None,
         diff=False,
         comment=None,
-        err_responses=None,
     ):
         """Loads the candidate configuration into the network device
 
@@ -235,8 +234,6 @@ class CliconfBase(CliconfBaseBase):
                         the file in this case should be present on the remote host in the mentioned path as a
                         prerequisite.
         :param comment: Commit comment provided it is supported by remote host.
-        :param err_responses: A list of error regexes that will be used to evaluate the responses received
-                              from executing the candidate command(s).
         :return: Returns a json string with contains configuration applied on remote host, the returned
                  response on executing configuration commands and platform relevant data.
                {


### PR DESCRIPTION
##### SUMMARY
- Adding `err_responses` kwarg in edit_config has broken platform cliconfs' that don't have this implemented.
- Adding a new kwarg in a platform cliconf shouldn't really trip sanity/pylint, however, the missing `diff` kwarg in edit_config of platforms that do not have on-box diff is causing issues.
- Ideally, `diff` should not be in `edit_config` because of what I mentioned above. But that needs to be handled separately and carefully.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
cliconfbase.py
