### PR TITLE
[net_put] fix net_put api call, also adds `check_destination` to ignore remote file check

### DIFF
--- a/docs/ansible.netcommon.net_put_module.rst
+++ b/docs/ansible.netcommon.net_put_module.rst
@@ -148,15 +148,31 @@ Examples
 
 .. code-block:: yaml
 
-    - name: copy file from ansible controller to a network device
+    - name: Copy file from ansible controller to a network device (defaults to scp)
       ansible.netcommon.net_put:
         src: running_cfg_ios1.txt
 
-    - name: copy file at root dir of flash in slot 3 of sw1(ios)
+    # changed: [Appliance] => changed=true
+    #   destination: running_cfg_sw1.txt
+
+    - name: Copy file at root dir of flash in slot 3 of sw1(ios)
       ansible.netcommon.net_put:
         src: running_cfg_sw1.txt
         protocol: sftp
         dest: flash3:/running_cfg_sw1.txt
+
+    # changed: [Appliance] => changed=true
+    #   destination: running_cfg_sw1.txt
+
+    - name: Copy file from ansible controller to a network device (does not check destination)
+      ansible.netcommon.net_put:
+        src: running_cfg_sw1.txt
+        protocol: scp
+        dest: ios_running_cfg_sw1.txt
+        check_destination: false
+
+    # changed: [Appliance] => changed=true
+    #   destination: ios_running_cfg_sw1.txt
 
 
 

--- a/docs/ansible.netcommon.net_put_module.rst
+++ b/docs/ansible.netcommon.net_put_module.rst
@@ -42,6 +42,25 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>check_destination</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Enabling this check for the file in the destination if the file exists or not and only copy the file if it does not exist.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>dest</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/action/net_put.py
+++ b/plugins/action/net_put.py
@@ -103,9 +103,7 @@ class ActionModule(ActionBase):
 
         if check_destination:
             try:
-                changed = self._handle_existing_file(
-                    conn, output_file, dest, proto, sock_timeout
-                )
+                changed = self._handle_existing_file(conn, output_file, dest, proto, sock_timeout)
                 if changed is False:
                     result["changed"] = changed
                     result["destination"] = dest
@@ -129,9 +127,7 @@ class ActionModule(ActionBase):
                 if network_os == "iosxr":
                     # IOSXR sometimes closes socket prematurely after completion
                     # of file transfer
-                    result["msg"] = (
-                        "Warning: iosxr scp server pre close issue. Please check dest"
-                    )
+                    result["msg"] = "Warning: iosxr scp server pre close issue. Please check dest"
             else:
                 result["failed"] = True
                 result["msg"] = "Exception received: %s" % exc

--- a/plugins/action/net_put.py
+++ b/plugins/action/net_put.py
@@ -96,7 +96,9 @@ class ActionModule(ActionBase):
         if dest is None:
             dest = src_file_path_name
         try:
-            changed = self._handle_existing_file(conn, output_file, dest, proto, sock_timeout)
+            changed = self._handle_existing_file(
+                conn, output_file, dest, proto, sock_timeout
+            )
             if changed is False:
                 result["changed"] = changed
                 result["destination"] = dest
@@ -119,7 +121,9 @@ class ActionModule(ActionBase):
                 if network_os == "iosxr":
                     # IOSXR sometimes closes socket prematurely after completion
                     # of file transfer
-                    result["msg"] = "Warning: iosxr scp server pre close issue. Please check dest"
+                    result["msg"] = (
+                        "Warning: iosxr scp server pre close issue. Please check dest"
+                    )
             else:
                 result["failed"] = True
                 result["msg"] = "Exception received: %s" % exc
@@ -142,11 +146,10 @@ class ActionModule(ActionBase):
         filename = str(uuid.uuid4())
         tmp_source_file = os.path.join(cwd, filename)
         try:
-            conn.get_file(
+            conn.put_file(
                 source=dest,
                 destination=tmp_source_file,
                 proto=proto,
-                timeout=timeout,
             )
         except ConnectionError as exc:
             error = to_text(exc)

--- a/plugins/action/net_put.py
+++ b/plugins/action/net_put.py
@@ -13,7 +13,7 @@ import uuid
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_text
-from ansible.module_utils.connection import Connection, ConnectionError
+from ansible.module_utils.connection import Connection
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
@@ -64,6 +64,11 @@ class ActionModule(ActionBase):
         if mode is None:
             mode = "binary"
 
+        # Check if the file is present in destination or not
+        check_destination = self._task.args.get("check_destination")
+        if check_destination is None:
+            check_destination = True
+
         if mode == "text":
             try:
                 self._handle_src_option(convert_data=False)
@@ -95,32 +100,38 @@ class ActionModule(ActionBase):
 
         if dest is None:
             dest = src_file_path_name
-        try:
-            changed = self._handle_existing_file(conn, output_file, dest, proto, sock_timeout)
-            if changed is False:
-                result["changed"] = changed
-                result["destination"] = dest
-                if mode == "text":
-                    # Cleanup tmp file expanded wih ansible vars
-                    os.remove(output_file)
-                return result
-        except Exception as exc:
-            result["msg"] = "Warning: %s idempotency check failed. Check dest" % exc
+
+        if check_destination:
+            try:
+                changed = self._handle_existing_file(
+                    conn, output_file, dest, proto, sock_timeout
+                )
+                if changed is False:
+                    result["changed"] = changed
+                    result["destination"] = dest
+                    if mode == "text":
+                        # Cleanup tmp file expanded wih ansible vars
+                        os.remove(output_file)
+                    return result
+            except Exception as exc:
+                result["msg"] = "Warning: %s idempotency check failed. Check dest" % exc
 
         try:
-            # libssh fails if file is not present in remote appliance
             conn.copy_file(
                 source=output_file,
                 destination=dest,
                 proto=proto,
                 timeout=sock_timeout,
             )
+            changed = True
         except Exception as exc:
             if to_text(exc) == "No response from server":
                 if network_os == "iosxr":
                     # IOSXR sometimes closes socket prematurely after completion
                     # of file transfer
-                    result["msg"] = "Warning: iosxr scp server pre close issue. Please check dest"
+                    result["msg"] = (
+                        "Warning: iosxr scp server pre close issue. Please check dest"
+                    )
             else:
                 result["failed"] = True
                 result["msg"] = "Exception received: %s" % exc
@@ -155,6 +166,7 @@ class ActionModule(ActionBase):
                 if os.path.exists(tmp_source_file):
                     os.remove(tmp_source_file)
                 return True
+
         try:
             with open(source, "r") as f:
                 new_content = f.read()

--- a/plugins/action/net_put.py
+++ b/plugins/action/net_put.py
@@ -96,7 +96,9 @@ class ActionModule(ActionBase):
         if dest is None:
             dest = src_file_path_name
         try:
-            changed = self._handle_existing_file(conn, output_file, dest, proto, sock_timeout)
+            changed = self._handle_existing_file(
+                conn, output_file, dest, proto, sock_timeout
+            )
             if changed is False:
                 result["changed"] = changed
                 result["destination"] = dest
@@ -108,6 +110,7 @@ class ActionModule(ActionBase):
             result["msg"] = "Warning: %s idempotency check failed. Check dest" % exc
 
         try:
+            # libssh fails if file is not present in remote appliance
             conn.copy_file(
                 source=output_file,
                 destination=dest,
@@ -119,7 +122,9 @@ class ActionModule(ActionBase):
                 if network_os == "iosxr":
                     # IOSXR sometimes closes socket prematurely after completion
                     # of file transfer
-                    result["msg"] = "Warning: iosxr scp server pre close issue. Please check dest"
+                    result["msg"] = (
+                        "Warning: iosxr scp server pre close issue. Please check dest"
+                    )
             else:
                 result["failed"] = True
                 result["msg"] = "Exception received: %s" % exc

--- a/plugins/action/net_put.py
+++ b/plugins/action/net_put.py
@@ -142,10 +142,11 @@ class ActionModule(ActionBase):
         filename = str(uuid.uuid4())
         tmp_source_file = os.path.join(cwd, filename)
         try:
-            conn.put_file(
+            conn.get_file(
                 source=dest,
                 destination=tmp_source_file,
                 proto=proto,
+                timeout=timeout,
             )
         except ConnectionError as exc:
             error = to_text(exc)

--- a/plugins/action/net_put.py
+++ b/plugins/action/net_put.py
@@ -96,9 +96,7 @@ class ActionModule(ActionBase):
         if dest is None:
             dest = src_file_path_name
         try:
-            changed = self._handle_existing_file(
-                conn, output_file, dest, proto, sock_timeout
-            )
+            changed = self._handle_existing_file(conn, output_file, dest, proto, sock_timeout)
             if changed is False:
                 result["changed"] = changed
                 result["destination"] = dest
@@ -121,9 +119,7 @@ class ActionModule(ActionBase):
                 if network_os == "iosxr":
                     # IOSXR sometimes closes socket prematurely after completion
                     # of file transfer
-                    result["msg"] = (
-                        "Warning: iosxr scp server pre close issue. Please check dest"
-                    )
+                    result["msg"] = "Warning: iosxr scp server pre close issue. Please check dest"
             else:
                 result["failed"] = True
                 result["msg"] = "Exception received: %s" % exc

--- a/plugins/action/net_put.py
+++ b/plugins/action/net_put.py
@@ -96,9 +96,7 @@ class ActionModule(ActionBase):
         if dest is None:
             dest = src_file_path_name
         try:
-            changed = self._handle_existing_file(
-                conn, output_file, dest, proto, sock_timeout
-            )
+            changed = self._handle_existing_file(conn, output_file, dest, proto, sock_timeout)
             if changed is False:
                 result["changed"] = changed
                 result["destination"] = dest
@@ -122,9 +120,7 @@ class ActionModule(ActionBase):
                 if network_os == "iosxr":
                     # IOSXR sometimes closes socket prematurely after completion
                     # of file transfer
-                    result["msg"] = (
-                        "Warning: iosxr scp server pre close issue. Please check dest"
-                    )
+                    result["msg"] = "Warning: iosxr scp server pre close issue. Please check dest"
             else:
                 result["failed"] = True
                 result["msg"] = "Exception received: %s" % exc

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -246,7 +246,9 @@ class MyAddPolicy(object):
         self.connection = connection
         self._options = connection._options
 
-    def missing_host_key(self, session, hostname, username, key_type, fingerprint, message):
+    def missing_host_key(
+        self, session, hostname, username, key_type, fingerprint, message
+    ):
         if all(
             (
                 self._options["host_key_checking"],
@@ -260,7 +262,8 @@ class MyAddPolicy(object):
                 # don't print the prompt string since the user cannot respond
                 # to the question anyway
                 raise AnsibleError(
-                    AUTHENTICITY_MSG.rsplit("\n", 2)[0] % (hostname, message, key_type, fingerprint)
+                    AUTHENTICITY_MSG.rsplit("\n", 2)[0]
+                    % (hostname, message, key_type, fingerprint)
                 )
 
             self.connection.connection_lock()
@@ -385,7 +388,9 @@ class Connection(ConnectionBase):
         try:
             private_key = None
             if self._play_context.private_key_file:
-                with open(os.path.expanduser(self._play_context.private_key_file)) as fp:
+                with open(
+                    os.path.expanduser(self._play_context.private_key_file)
+                ) as fp:
                     b_content = fp.read()
                     private_key = to_bytes(b_content, errors="surrogate_or_strict")
 
@@ -395,10 +400,13 @@ class Connection(ConnectionBase):
             if self.get_option("config_file"):
                 ssh_connect_kwargs["config_file"] = self.get_option("config_file")
 
-            if self.get_option("password_prompt") and (Version(PYLIBSSH_VERSION) < "1.0.0"):
+            if self.get_option("password_prompt") and (
+                Version(PYLIBSSH_VERSION) < "1.0.0"
+            ):
                 raise AnsibleError(
                     "Configuring password prompt is not supported in ansible-pylibssh version %s. "
-                    "Please upgrade to ansible-pylibssh 1.0.0 or newer." % PYLIBSSH_VERSION
+                    "Please upgrade to ansible-pylibssh 1.0.0 or newer."
+                    % PYLIBSSH_VERSION
                 )
 
             self.ssh.set_missing_host_key_policy(MyAddPolicy(self._new_stdin, self))
@@ -505,14 +513,20 @@ class Connection(ConnectionBase):
                             to_bytes(become_pass, errors="surrogate_or_strict") + b"\n"
                         )
                     else:
-                        raise AnsibleError("A password is required but none was supplied")
+                        raise AnsibleError(
+                            "A password is required but none was supplied"
+                        )
                 else:
                     no_prompt_out += become_output
                     no_prompt_err += become_output
             else:
-                result = self.chan.exec_command(to_text(cmd, errors="surrogate_or_strict"))
+                result = self.chan.exec_command(
+                    to_text(cmd, errors="surrogate_or_strict")
+                )
         except socket.timeout:
-            raise AnsibleError("ssh timed out waiting for privilege escalation.\n" + become_output)
+            raise AnsibleError(
+                "ssh timed out waiting for privilege escalation.\n" + become_output
+            )
 
         if result:
             rc = result.returncode
@@ -553,9 +567,13 @@ class Connection(ConnectionBase):
             try:
                 scp.put(in_path, out_path)
             except LibsshSCPException as exc:
-                raise AnsibleError("Error transferring file to %s: %s" % (out_path, to_text(exc)))
+                raise AnsibleError(
+                    "Error transferring file to %s: %s" % (out_path, to_text(exc))
+                )
         else:
-            raise AnsibleError("Don't know how to transfer file over protocol %s" % proto)
+            raise AnsibleError(
+                "Don't know how to transfer file over protocol %s" % proto
+            )
 
     def _connect_sftp(self):
         cache_key = "%s__%s__" % (
@@ -581,7 +599,9 @@ class Connection(ConnectionBase):
             try:
                 self.sftp = self._connect_sftp()
             except Exception as e:
-                raise AnsibleError("failed to open a SFTP connection (%s)" % to_native(e))
+                raise AnsibleError(
+                    "failed to open a SFTP connection (%s)" % to_native(e)
+                )
 
             try:
                 self.sftp.get(
@@ -593,16 +613,18 @@ class Connection(ConnectionBase):
         elif proto == "scp":
             scp = self.ssh.scp()
             try:
-                # scp.get(out_path, in_path) # wrong call
-
                 # this abruptly closes the connection when
                 # scp.get fails only when the file is not there
                 # it works fine if the file is actually present
                 scp.get(in_path, out_path)  # correct call
-            except Exception as exc:
-                raise AnsibleError("Error transferring file from %s: %s" % (out_path, to_text(exc)))
+            except LibsshSCPException as exc:
+                raise AnsibleError(
+                    "Error transferring file from %s: %s" % (out_path, to_text(exc))
+                )
         else:
-            raise AnsibleError("Don't know how to transfer file over protocol %s" % proto)
+            raise AnsibleError(
+                "Don't know how to transfer file over protocol %s" % proto
+            )
 
     def reset(self):
         self.close()

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -246,7 +246,9 @@ class MyAddPolicy(object):
         self.connection = connection
         self._options = connection._options
 
-    def missing_host_key(self, session, hostname, username, key_type, fingerprint, message):
+    def missing_host_key(
+        self, session, hostname, username, key_type, fingerprint, message
+    ):
         if all(
             (
                 self._options["host_key_checking"],
@@ -260,7 +262,8 @@ class MyAddPolicy(object):
                 # don't print the prompt string since the user cannot respond
                 # to the question anyway
                 raise AnsibleError(
-                    AUTHENTICITY_MSG.rsplit("\n", 2)[0] % (hostname, message, key_type, fingerprint)
+                    AUTHENTICITY_MSG.rsplit("\n", 2)[0]
+                    % (hostname, message, key_type, fingerprint)
                 )
 
             self.connection.connection_lock()
@@ -385,7 +388,9 @@ class Connection(ConnectionBase):
         try:
             private_key = None
             if self._play_context.private_key_file:
-                with open(os.path.expanduser(self._play_context.private_key_file)) as fp:
+                with open(
+                    os.path.expanduser(self._play_context.private_key_file)
+                ) as fp:
                     b_content = fp.read()
                     private_key = to_bytes(b_content, errors="surrogate_or_strict")
 
@@ -395,10 +400,13 @@ class Connection(ConnectionBase):
             if self.get_option("config_file"):
                 ssh_connect_kwargs["config_file"] = self.get_option("config_file")
 
-            if self.get_option("password_prompt") and (Version(PYLIBSSH_VERSION) < "1.0.0"):
+            if self.get_option("password_prompt") and (
+                Version(PYLIBSSH_VERSION) < "1.0.0"
+            ):
                 raise AnsibleError(
                     "Configuring password prompt is not supported in ansible-pylibssh version %s. "
-                    "Please upgrade to ansible-pylibssh 1.0.0 or newer." % PYLIBSSH_VERSION
+                    "Please upgrade to ansible-pylibssh 1.0.0 or newer."
+                    % PYLIBSSH_VERSION
                 )
 
             self.ssh.set_missing_host_key_policy(MyAddPolicy(self._new_stdin, self))
@@ -505,14 +513,20 @@ class Connection(ConnectionBase):
                             to_bytes(become_pass, errors="surrogate_or_strict") + b"\n"
                         )
                     else:
-                        raise AnsibleError("A password is required but none was supplied")
+                        raise AnsibleError(
+                            "A password is required but none was supplied"
+                        )
                 else:
                     no_prompt_out += become_output
                     no_prompt_err += become_output
             else:
-                result = self.chan.exec_command(to_text(cmd, errors="surrogate_or_strict"))
+                result = self.chan.exec_command(
+                    to_text(cmd, errors="surrogate_or_strict")
+                )
         except socket.timeout:
-            raise AnsibleError("ssh timed out waiting for privilege escalation.\n" + become_output)
+            raise AnsibleError(
+                "ssh timed out waiting for privilege escalation.\n" + become_output
+            )
 
         if result:
             rc = result.returncode
@@ -553,9 +567,13 @@ class Connection(ConnectionBase):
             try:
                 scp.put(in_path, out_path)
             except LibsshSCPException as exc:
-                raise AnsibleError("Error transferring file to %s: %s" % (out_path, to_text(exc)))
+                raise AnsibleError(
+                    "Error transferring file to %s: %s" % (out_path, to_text(exc))
+                )
         else:
-            raise AnsibleError("Don't know how to transfer file over protocol %s" % proto)
+            raise AnsibleError(
+                "Don't know how to transfer file over protocol %s" % proto
+            )
 
     def _connect_sftp(self):
         cache_key = "%s__%s__" % (
@@ -570,7 +588,6 @@ class Connection(ConnectionBase):
 
     def fetch_file(self, in_path, out_path, proto="sftp"):
         """save a remote file to the specified path"""
-
         super(Connection, self).fetch_file(in_path, out_path)
 
         display.vvv(
@@ -582,7 +599,9 @@ class Connection(ConnectionBase):
             try:
                 self.sftp = self._connect_sftp()
             except Exception as e:
-                raise AnsibleError("failed to open a SFTP connection (%s)" % to_native(e))
+                raise AnsibleError(
+                    "failed to open a SFTP connection (%s)" % to_native(e)
+                )
 
             try:
                 self.sftp.get(
@@ -594,12 +613,16 @@ class Connection(ConnectionBase):
         elif proto == "scp":
             scp = self.ssh.scp()
             try:
-                # scp.get(out_path, in_path)
-                scp.get(in_path, out_path)
-            except LibsshSCPException as exc:
-                raise AnsibleError("Error transferring file from %s: %s" % (out_path, to_text(exc)))
+                # scp.get(out_path, in_path) # wrong call
+                scp.get(in_path, out_path)  # correct call
+            except Exception as exc:
+                raise AnsibleError(
+                    "Error transferring file from %s: %s" % (out_path, to_text(exc))
+                )
         else:
-            raise AnsibleError("Don't know how to transfer file over protocol %s" % proto)
+            raise AnsibleError(
+                "Don't know how to transfer file over protocol %s" % proto
+            )
 
     def reset(self):
         self.close()

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -594,7 +594,8 @@ class Connection(ConnectionBase):
         elif proto == "scp":
             scp = self.ssh.scp()
             try:
-                scp.get(out_path, in_path)
+                # scp.get(out_path, in_path)
+                scp.get(in_path, out_path)
             except LibsshSCPException as exc:
                 raise AnsibleError("Error transferring file from %s: %s" % (out_path, to_text(exc)))
         else:

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -246,9 +246,7 @@ class MyAddPolicy(object):
         self.connection = connection
         self._options = connection._options
 
-    def missing_host_key(
-        self, session, hostname, username, key_type, fingerprint, message
-    ):
+    def missing_host_key(self, session, hostname, username, key_type, fingerprint, message):
         if all(
             (
                 self._options["host_key_checking"],
@@ -262,8 +260,7 @@ class MyAddPolicy(object):
                 # don't print the prompt string since the user cannot respond
                 # to the question anyway
                 raise AnsibleError(
-                    AUTHENTICITY_MSG.rsplit("\n", 2)[0]
-                    % (hostname, message, key_type, fingerprint)
+                    AUTHENTICITY_MSG.rsplit("\n", 2)[0] % (hostname, message, key_type, fingerprint)
                 )
 
             self.connection.connection_lock()
@@ -388,9 +385,7 @@ class Connection(ConnectionBase):
         try:
             private_key = None
             if self._play_context.private_key_file:
-                with open(
-                    os.path.expanduser(self._play_context.private_key_file)
-                ) as fp:
+                with open(os.path.expanduser(self._play_context.private_key_file)) as fp:
                     b_content = fp.read()
                     private_key = to_bytes(b_content, errors="surrogate_or_strict")
 
@@ -400,13 +395,10 @@ class Connection(ConnectionBase):
             if self.get_option("config_file"):
                 ssh_connect_kwargs["config_file"] = self.get_option("config_file")
 
-            if self.get_option("password_prompt") and (
-                Version(PYLIBSSH_VERSION) < "1.0.0"
-            ):
+            if self.get_option("password_prompt") and (Version(PYLIBSSH_VERSION) < "1.0.0"):
                 raise AnsibleError(
                     "Configuring password prompt is not supported in ansible-pylibssh version %s. "
-                    "Please upgrade to ansible-pylibssh 1.0.0 or newer."
-                    % PYLIBSSH_VERSION
+                    "Please upgrade to ansible-pylibssh 1.0.0 or newer." % PYLIBSSH_VERSION
                 )
 
             self.ssh.set_missing_host_key_policy(MyAddPolicy(self._new_stdin, self))
@@ -513,20 +505,14 @@ class Connection(ConnectionBase):
                             to_bytes(become_pass, errors="surrogate_or_strict") + b"\n"
                         )
                     else:
-                        raise AnsibleError(
-                            "A password is required but none was supplied"
-                        )
+                        raise AnsibleError("A password is required but none was supplied")
                 else:
                     no_prompt_out += become_output
                     no_prompt_err += become_output
             else:
-                result = self.chan.exec_command(
-                    to_text(cmd, errors="surrogate_or_strict")
-                )
+                result = self.chan.exec_command(to_text(cmd, errors="surrogate_or_strict"))
         except socket.timeout:
-            raise AnsibleError(
-                "ssh timed out waiting for privilege escalation.\n" + become_output
-            )
+            raise AnsibleError("ssh timed out waiting for privilege escalation.\n" + become_output)
 
         if result:
             rc = result.returncode
@@ -567,13 +553,9 @@ class Connection(ConnectionBase):
             try:
                 scp.put(in_path, out_path)
             except LibsshSCPException as exc:
-                raise AnsibleError(
-                    "Error transferring file to %s: %s" % (out_path, to_text(exc))
-                )
+                raise AnsibleError("Error transferring file to %s: %s" % (out_path, to_text(exc)))
         else:
-            raise AnsibleError(
-                "Don't know how to transfer file over protocol %s" % proto
-            )
+            raise AnsibleError("Don't know how to transfer file over protocol %s" % proto)
 
     def _connect_sftp(self):
         cache_key = "%s__%s__" % (
@@ -599,9 +581,7 @@ class Connection(ConnectionBase):
             try:
                 self.sftp = self._connect_sftp()
             except Exception as e:
-                raise AnsibleError(
-                    "failed to open a SFTP connection (%s)" % to_native(e)
-                )
+                raise AnsibleError("failed to open a SFTP connection (%s)" % to_native(e))
 
             try:
                 self.sftp.get(
@@ -616,13 +596,9 @@ class Connection(ConnectionBase):
                 # scp.get(out_path, in_path) # wrong call
                 scp.get(in_path, out_path)  # correct call
             except Exception as exc:
-                raise AnsibleError(
-                    "Error transferring file from %s: %s" % (out_path, to_text(exc))
-                )
+                raise AnsibleError("Error transferring file from %s: %s" % (out_path, to_text(exc)))
         else:
-            raise AnsibleError(
-                "Don't know how to transfer file over protocol %s" % proto
-            )
+            raise AnsibleError("Don't know how to transfer file over protocol %s" % proto)
 
     def reset(self):
         self.close()

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -594,6 +594,10 @@ class Connection(ConnectionBase):
             scp = self.ssh.scp()
             try:
                 # scp.get(out_path, in_path) # wrong call
+
+                # this abruptly closes the connection when
+                # scp.get fails only when the file is not there
+                # it works fine if the file is actually present
                 scp.get(in_path, out_path)  # correct call
             except Exception as exc:
                 raise AnsibleError("Error transferring file from %s: %s" % (out_path, to_text(exc)))

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -246,9 +246,7 @@ class MyAddPolicy(object):
         self.connection = connection
         self._options = connection._options
 
-    def missing_host_key(
-        self, session, hostname, username, key_type, fingerprint, message
-    ):
+    def missing_host_key(self, session, hostname, username, key_type, fingerprint, message):
         if all(
             (
                 self._options["host_key_checking"],
@@ -262,8 +260,7 @@ class MyAddPolicy(object):
                 # don't print the prompt string since the user cannot respond
                 # to the question anyway
                 raise AnsibleError(
-                    AUTHENTICITY_MSG.rsplit("\n", 2)[0]
-                    % (hostname, message, key_type, fingerprint)
+                    AUTHENTICITY_MSG.rsplit("\n", 2)[0] % (hostname, message, key_type, fingerprint)
                 )
 
             self.connection.connection_lock()
@@ -388,9 +385,7 @@ class Connection(ConnectionBase):
         try:
             private_key = None
             if self._play_context.private_key_file:
-                with open(
-                    os.path.expanduser(self._play_context.private_key_file)
-                ) as fp:
+                with open(os.path.expanduser(self._play_context.private_key_file)) as fp:
                     b_content = fp.read()
                     private_key = to_bytes(b_content, errors="surrogate_or_strict")
 
@@ -400,13 +395,10 @@ class Connection(ConnectionBase):
             if self.get_option("config_file"):
                 ssh_connect_kwargs["config_file"] = self.get_option("config_file")
 
-            if self.get_option("password_prompt") and (
-                Version(PYLIBSSH_VERSION) < "1.0.0"
-            ):
+            if self.get_option("password_prompt") and (Version(PYLIBSSH_VERSION) < "1.0.0"):
                 raise AnsibleError(
                     "Configuring password prompt is not supported in ansible-pylibssh version %s. "
-                    "Please upgrade to ansible-pylibssh 1.0.0 or newer."
-                    % PYLIBSSH_VERSION
+                    "Please upgrade to ansible-pylibssh 1.0.0 or newer." % PYLIBSSH_VERSION
                 )
 
             self.ssh.set_missing_host_key_policy(MyAddPolicy(self._new_stdin, self))
@@ -513,20 +505,14 @@ class Connection(ConnectionBase):
                             to_bytes(become_pass, errors="surrogate_or_strict") + b"\n"
                         )
                     else:
-                        raise AnsibleError(
-                            "A password is required but none was supplied"
-                        )
+                        raise AnsibleError("A password is required but none was supplied")
                 else:
                     no_prompt_out += become_output
                     no_prompt_err += become_output
             else:
-                result = self.chan.exec_command(
-                    to_text(cmd, errors="surrogate_or_strict")
-                )
+                result = self.chan.exec_command(to_text(cmd, errors="surrogate_or_strict"))
         except socket.timeout:
-            raise AnsibleError(
-                "ssh timed out waiting for privilege escalation.\n" + become_output
-            )
+            raise AnsibleError("ssh timed out waiting for privilege escalation.\n" + become_output)
 
         if result:
             rc = result.returncode
@@ -567,13 +553,9 @@ class Connection(ConnectionBase):
             try:
                 scp.put(in_path, out_path)
             except LibsshSCPException as exc:
-                raise AnsibleError(
-                    "Error transferring file to %s: %s" % (out_path, to_text(exc))
-                )
+                raise AnsibleError("Error transferring file to %s: %s" % (out_path, to_text(exc)))
         else:
-            raise AnsibleError(
-                "Don't know how to transfer file over protocol %s" % proto
-            )
+            raise AnsibleError("Don't know how to transfer file over protocol %s" % proto)
 
     def _connect_sftp(self):
         cache_key = "%s__%s__" % (
@@ -599,9 +581,7 @@ class Connection(ConnectionBase):
             try:
                 self.sftp = self._connect_sftp()
             except Exception as e:
-                raise AnsibleError(
-                    "failed to open a SFTP connection (%s)" % to_native(e)
-                )
+                raise AnsibleError("failed to open a SFTP connection (%s)" % to_native(e))
 
             try:
                 self.sftp.get(
@@ -618,13 +598,9 @@ class Connection(ConnectionBase):
                 # it works fine if the file is actually present
                 scp.get(in_path, out_path)  # correct call
             except LibsshSCPException as exc:
-                raise AnsibleError(
-                    "Error transferring file from %s: %s" % (out_path, to_text(exc))
-                )
+                raise AnsibleError("Error transferring file from %s: %s" % (out_path, to_text(exc)))
         else:
-            raise AnsibleError(
-                "Don't know how to transfer file over protocol %s" % proto
-            )
+            raise AnsibleError("Don't know how to transfer file over protocol %s" % proto)
 
     def reset(self):
         self.close()

--- a/plugins/modules/net_put.py
+++ b/plugins/modules/net_put.py
@@ -71,15 +71,31 @@ notes:
 """
 
 EXAMPLES = """
-- name: copy file from ansible controller to a network device
+- name: Copy file from ansible controller to a network device (defaults to scp)
   ansible.netcommon.net_put:
     src: running_cfg_ios1.txt
 
-- name: copy file at root dir of flash in slot 3 of sw1(ios)
+# changed: [Appliance] => changed=true
+#   destination: running_cfg_sw1.txt
+
+- name: Copy file at root dir of flash in slot 3 of sw1(ios)
   ansible.netcommon.net_put:
     src: running_cfg_sw1.txt
     protocol: sftp
     dest: flash3:/running_cfg_sw1.txt
+
+# changed: [Appliance] => changed=true
+#   destination: running_cfg_sw1.txt
+
+- name: Copy file from ansible controller to a network device (does not check destination)
+  ansible.netcommon.net_put:
+    src: running_cfg_sw1.txt
+    protocol: scp
+    dest: ios_running_cfg_sw1.txt
+    check_destination: false
+
+# changed: [Appliance] => changed=true
+#   destination: ios_running_cfg_sw1.txt
 """
 
 RETURN = """

--- a/plugins/modules/net_put.py
+++ b/plugins/modules/net_put.py
@@ -35,6 +35,13 @@ options:
     choices:
     - scp
     - sftp
+  check_destination:
+    description:
+    - Enabling this check for the file in the destination if the file exists or not and
+      only copy the file if it does not exist.
+    type: bool
+    default: true
+    required: false
   dest:
     description:
     - Specifies the destination file. The path to destination file can either be the


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix net_put API call.
Adds check_destination to ignore remote file check
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
net_put
libssh

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
note it's not advised to pass the path with netput call in libssh that would still be a bug.

observations - 
1 - libssh->scp_obj.get() fails to handle situations where the file is being fetched but not present. The connection fails abruptly. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
task - 
```paste below
    - name: Copy file from ansible controller to a network device
      ansible.netcommon.net_put:
        src: /home/../backup_nxos.cfg
        protocol: scp
        dest: nxos_conf.cfg
        
[nxos]
10.0.-.-

[nxos:vars]
ansible_network_os=cisco.nxos.nxos
ansible_user=****
ansible_ssh_pass=****
ansible_connection=ansible.netcommon.network_cli
ansible_network_cli_ssh_type=libssh
```
new attribute - 
```yaml
    - name: Copy file from ansible controller to a network device
      ansible.netcommon.net_put:
        src: backup/backup_ios.cfg
        protocol: scp
        dest: ios_conf.cfg
        check_destination: false  # if false does not check the remote destination about the file's existence, if true it checks
```
^ impacts paramiko and libssh both