### PR TITLE
Fix libssh get api call

### DIFF
--- a/changelogs/fragments/libssh_get.yaml
+++ b/changelogs/fragments/libssh_get.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - Fix get api call during scp with libssh.
+known_issues:
+  - libssh - net_put and net_get fail when the destination file intended to be fetched is not present.

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -594,7 +594,10 @@ class Connection(ConnectionBase):
         elif proto == "scp":
             scp = self.ssh.scp()
             try:
-                scp.get(out_path, in_path)
+                # this abruptly closes the connection when
+                # scp.get fails only when the file is not there
+                # it works fine if the file is actually present
+                scp.get(in_path, out_path)
             except LibsshSCPException as exc:
                 raise AnsibleError("Error transferring file from %s: %s" % (out_path, to_text(exc)))
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
bugfixes:
  - Fix get api call during scp with libssh.
known_issues:
  - libssh - net_put and net_get fail when the destination file intended to be fetched is not present.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
libssh

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
