### PR TITLE
Update netaddr to specify the same version requirement as ansible.utils

### DIFF
--- a/changelogs/fragments/netaddr_version_bump.yaml
+++ b/changelogs/fragments/netaddr_version_bump.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Updated netaddr to specify the same version requirement as dependency ansible.utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ansible-pylibssh >= 0.2.0
 jxmlease
 ncclient
-netaddr
+netaddr>=0.10.1
 paramiko
 xmltodict
 grpcio


### PR DESCRIPTION
… ansible.utils

##### SUMMARY
 Updated netaddr to specify the same version requirement as dependency ansible.utils

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
As Per https://github.com/ansible/ansible-builder/issues/688

This is causing a conflict in AAP 2.4 versions of rhel8 builds, should either remove the requirement as the dependency has it, or match it. 
