### PR TITLE
Add a connection local deprecation warning

### DIFF
--- a/changelogs/fragments/bye_connection_local.yaml
+++ b/changelogs/fragments/bye_connection_local.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - ansible.netcommon.persistent - Connection local is marked deprecated and all dependent collections are advised to move to a proper connection plugin, complete support of connection local will be removed in a release 01-01-2027.
+  - ansible.netcommon.persistent - Connection local is marked deprecated and all dependent collections are advised to move to a proper connection plugin, complete support of connection local will be removed in a release after 01-01-2027.

--- a/changelogs/fragments/bye_connection_local.yaml
+++ b/changelogs/fragments/bye_connection_local.yaml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
-  - ansible.netcommon.persistent - Connection local is marked deprecated dependent colletions are adviced to move to proper connection plugin, complete support of connection local will be removed in a release 01-01-2027.
-  - Cleaning up already deprecated code in netconf action class.
+  - ansible.netcommon.persistent - Connection local is marked deprecated and all dependent collections are advised to move to a proper connection plugin, complete support of connection local will be removed in a release 01-01-2027.

--- a/changelogs/fragments/bye_connection_local.yaml
+++ b/changelogs/fragments/bye_connection_local.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ansible.netcommon.persistent - Deprecate connection local in favour of network_cli.

--- a/changelogs/fragments/bye_connection_local.yaml
+++ b/changelogs/fragments/bye_connection_local.yaml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
-  - ansible.netcommon.persistent - Deprecate connection local in favour of network_cli.
+  - ansible.netcommon.persistent - Connection local is marked deprecated dependent colletions are adviced to move to proper connection plugin, complete support of connection local will be removed in a release 01-01-2027.
+  - Cleaning up already deprecated code in netconf action class.

--- a/changelogs/fragments/update_error_msg.yaml
+++ b/changelogs/fragments/update_error_msg.yaml
@@ -1,3 +1,3 @@
 ---
-trivial:
+bugfixes:
   - Updated the error message for the content_templates parser to include the correct parser name and detailed error information.

--- a/plugins/action/netconf.py
+++ b/plugins/action/netconf.py
@@ -8,9 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import copy
-import sys
-
 from ansible.utils.display import Display
 
 from ansible_collections.ansible.netcommon.plugins.action.network import (

--- a/plugins/action/netconf.py
+++ b/plugins/action/netconf.py
@@ -23,85 +23,17 @@ display = Display()
 
 class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
-        del tmp  # tmp no longer has any effect
-
         module_name = self._task.action.split(".")[-1]
         self._config_module = True if module_name == "netconf_config" else False
         persistent_connection = self._play_context.connection.split(".")[-1]
         warnings = []
 
-        if persistent_connection not in ["netconf", "local"] and module_name == "netconf_config":
-            return {
-                "failed": True,
-                "msg": "Connection type %s is not valid for netconf_config module. "
-                "Valid connection type is netconf or local (deprecated)"
-                % self._play_context.connection,
-            }
-        elif persistent_connection not in ["netconf"] and module_name != "netconf_config":
+        if persistent_connection != "netconf":
             return {
                 "failed": True,
                 "msg": "Connection type %s is not valid for %s module. "
                 "Valid connection type is netconf." % (self._play_context.connection, module_name),
             }
-
-        if self._play_context.connection == "local" and module_name == "netconf_config":
-            args = self._task.args
-            pc = copy.deepcopy(self._play_context)
-            pc.connection = "ansible.netcommon.netconf"
-            pc.port = int(args.get("port") or self._play_context.port or 830)
-
-            pc.remote_user = args.get("username") or self._play_context.connection_user
-            pc.password = args.get("password") or self._play_context.password
-            pc.private_key_file = args.get("ssh_keyfile") or self._play_context.private_key_file
-
-            connection = self._shared_loader_obj.connection_loader.get(
-                "ansible.netcommon.persistent",
-                pc,
-                sys.stdin,
-                task_uuid=self._task._uuid,
-            )
-
-            # TODO: Remove below code after ansible minimal is cut out
-            if connection is None:
-                pc.connection = "netconf"
-                connection = self._shared_loader_obj.connection_loader.get(
-                    "persistent", pc, sys.stdin, task_uuid=self._task._uuid
-                )
-
-            display.vvv(
-                "using connection plugin %s (was local)" % pc.connection,
-                pc.remote_addr,
-            )
-
-            timeout = args.get("timeout")
-            command_timeout = (
-                int(timeout) if timeout else connection.get_option("persistent_command_timeout")
-            )
-            connection.set_options(
-                direct={
-                    "persistent_command_timeout": command_timeout,
-                    "look_for_keys": args.get("look_for_keys"),
-                    "hostkey_verify": args.get("hostkey_verify"),
-                    "allow_agent": args.get("allow_agent"),
-                }
-            )
-
-            socket_path = connection.run()
-            display.vvvv("socket_path: %s" % socket_path, pc.remote_addr)
-            if not socket_path:
-                return {
-                    "failed": True,
-                    "msg": "unable to open shell. Please see: "
-                    + "https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell",
-                }
-
-            task_vars["ansible_socket"] = socket_path
-            warnings.append(
-                [
-                    "connection local support for this module is deprecated and will be removed in version 2.14, use connection %s"
-                    % pc.connection
-                ]
-            )
 
         result = super(ActionModule, self).run(task_vars=task_vars)
         if warnings:

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -490,10 +490,8 @@ class Connection(NetworkConnectionBase):
         return self._matched_prompt
 
     def exec_command(self, cmd, in_data=None, sudoable=True):
-        # this try..except block is just to handle the transition to supporting
-        # network_cli as a toplevel connection.  Once connection=local is gone,
-        # this block can be removed as well and all calls passed directly to
-        # the local connection
+        # not accessible code alert can be taken out at around  01-01-2027,
+        # when connection local is removed
         if self._ssh_shell:
             try:
                 cmd = json.loads(to_text(cmd, errors="surrogate_or_strict"))

--- a/plugins/connection/persistent.py
+++ b/plugins/connection/persistent.py
@@ -73,7 +73,9 @@ class Connection(ConnectionBase):
             host=self._play_context.remote_addr,
         )
         display.deprecated(
-            "support for connection local has been deprecated from ansible.netcommon and will be removed in a release after 01-01-2027"
+            msg="support for connection local has been deprecated",
+            date="2027-01-01",
+            collection_name="ansible.netcommon",
         )
         variables = {"ansible_command_timeout": self.get_option("persistent_command_timeout")}
         socket_path = start_connection(self._play_context, variables, self._task_uuid)

--- a/plugins/connection/persistent.py
+++ b/plugins/connection/persistent.py
@@ -72,8 +72,8 @@ class Connection(ConnectionBase):
             "starting connection from persistent connection plugin",
             host=self._play_context.remote_addr,
         )
-        display.warning(
-            "connection local support from netcommon is deprecated and will be removed at 01-01-2027"
+        display.deprecated(
+            "support for connection local has been deprecated from ansible.netcommon and will be removed in a release after 01-01-2027"
         )
         variables = {"ansible_command_timeout": self.get_option("persistent_command_timeout")}
         socket_path = start_connection(self._play_context, variables, self._task_uuid)

--- a/plugins/connection/persistent.py
+++ b/plugins/connection/persistent.py
@@ -72,6 +72,9 @@ class Connection(ConnectionBase):
             "starting connection from persistent connection plugin",
             host=self._play_context.remote_addr,
         )
+        display.warning(
+            "connection local support from netcommon is deprecated and will be removed at 01-01-2027"
+        )
         variables = {"ansible_command_timeout": self.get_option("persistent_command_timeout")}
         socket_path = start_connection(self._play_context, variables, self._task_uuid)
         display.vvvv(

--- a/plugins/module_utils/network/common/network.py
+++ b/plugins/module_utils/network/common/network.py
@@ -202,8 +202,8 @@ def get_resource_connection(module):
     if network_api == "netconf":
         module._connection = NetconfConnection(module._socket_path)
     elif network_api == "local":
-        # This isn't supported, but we shouldn't fail here.
-        # Set the connection to a fake connection so it fails sensibly.
+        # not accessible code alert can be taken out at around  01-01-2027,
+        # when connection local is removed
         module._connection = LocalResourceConnection(module)
     else:
         module._connection = Connection(module._socket_path)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`[WARNING]: connection local support from netcommon is deprecated and will be removed at 01-01-2027`

Add warning for connection local! 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
percistent.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Notes - 
 - All our recent resource modules by default don't support connection local
 - We do not need to add a check for `_play_context.connection`, because the connection would be network_cli even when the connection is local because we are redirecting to network_cli even when the connection is local [ref_code](https://github.com/ansible-collections/cisco.ios/blob/3.3.2/plugins/action/ios.py#L57-L61) 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
