### PR TITLE
net_ping: fix "note" that slipped in the examples code block

### DIFF
--- a/docs/ansible.netcommon.net_ping_module.rst
+++ b/docs/ansible.netcommon.net_ping_module.rst
@@ -154,11 +154,8 @@ Examples
         vrf: prod
         count: 20
 
-    - Note:
-        - For targets running Python, use the M(ansible.builtin.shell) module along with ping command instead.
-        - Example:
-            name: ping
-            shell: ping -c 1 <remote-ip>
+    - name: Use the ping command instead of an ansible module
+      ansible.builtin.shell: ping -c 1 <remote-ip-or-hostname>
 
 
 


### PR DESCRIPTION
Fixes: 7fe84847038c52ff5532c8479f3972f09f5f149e

That was not fixed by: 3dac28bd5cb6d601f59ffbc3b446321a6e7a088b

##### SUMMARY
The documentation has been erroneously modified to add a note into the example code block

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
[ansible.netcommon.net_ping](https://github.com/vincent-legoll/ansible.netcommon/blob/main/docs/ansible.netcommon.net_ping_module.rst)

##### ADDITIONAL INFORMATION
This is probably the result of a mismerge
