### PR TITLE
simplify value conversion by removing ast.literal_eval

### DIFF
--- a/changelogs/fragments/utils.yaml
+++ b/changelogs/fragments/utils.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Simplifies value handling by returning direct string conversion instead of using ast.literal_eval

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -685,11 +685,8 @@ class Template:
                 return None
             raise
 
-        if value:
-            try:
-                return ast.literal_eval(value)
-            except Exception:
-                return str(value)
+        if value is not None:
+            return str(value)  # Ensuring we returning it as a string
         else:
             return None
 

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -684,12 +684,15 @@ class Template:
             if not fail_on_undefined:
                 return None
             raise
-
+        
         if value is not None:
-            return str(value)  # Ensuring we returning it as a string
+    # Special handling for values starting with +
+            if isinstance(value, str) and value.startswith('+'):
+                return value  # Keep the + prefix intact
+            return str(value)  # Convert everything else to string
         else:
             return None
-
+        
     def contains_vars(self, data):
         if isinstance(data, string_types):
             for marker in (

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -684,15 +684,15 @@ class Template:
             if not fail_on_undefined:
                 return None
             raise
-        
+
         if value is not None:
-    # Special handling for values starting with +
-            if isinstance(value, str) and value.startswith('+'):
+            # Special handling for values starting with +
+            if isinstance(value, str) and value.startswith("+"):
                 return value  # Keep the + prefix intact
             return str(value)  # Convert everything else to string
         else:
             return None
-        
+
     def contains_vars(self, data):
         if isinstance(data, string_types):
             for marker in (


### PR DESCRIPTION
##### SUMMARY
Simplifies the value handling logic in network common utils by removing the complex ast.literal_eval approach in favor of direct string conversion.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
network.common.utils

