### PR TITLE
fix: preserve plus prefix in value conversion and handling

### DIFF
--- a/changelogs/fragments/utils.yaml
+++ b/changelogs/fragments/utils.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - network.common.utils - Preserves plus prefix in value conversion while maintaining string handling

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -686,6 +686,8 @@ class Template:
             raise
 
         if value:
+            if isinstance(value, str) and value.startswith('+'):
+                return value
             try:
                 return ast.literal_eval(value)
             except Exception:

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -686,7 +686,7 @@ class Template:
             raise
 
         if value:
-            if isinstance(value, str) and value.startswith('+'):
+            if isinstance(value, str) and value.startswith("+"):
                 return value
             try:
                 return ast.literal_eval(value)


### PR DESCRIPTION
##### SUMMARY
Improves value handling in network.common.utils to properly preserve plus prefix in value conversion while maintaining correct string handling for other cases. This fix ensures that values like "+100" are preserved correctly while other values are converted appropriately.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
network.common.utils
