### PR TITLE
Deprecate Parser filter plugins

### DIFF
--- a/changelogs/fragments/deprecate_parsing_filter_plugins.yaml
+++ b/changelogs/fragments/deprecate_parsing_filter_plugins.yaml
@@ -1,0 +1,8 @@
+---
+deprecated_features:
+  - "`parse_cli` filter plugin is deprecated and will be removed in a future release after 2027-02-01. Use `ansible.utils.cli_parse` as a replacement."
+  - "`parse_cli_textfsm` filter plugin is deprecated and will be removed in a future release after 2027-02-01. Use `ansible.utils.cli_parse` with the `ansible.utils.textfsm_parser` parser as a replacement."
+  - "`parse_xml` filter plugin is deprecated and will be removed in a future release after 2027-02-01. Use `ansible.utils.cli_parse` with the `ansible.utils.xml_parser` parser as a replacement."
+  - "Added deprecation warnings for the above plugins, displayed when running respective filter plugins."
+
+

--- a/changelogs/fragments/deprecate_parsing_filter_plugins.yaml
+++ b/changelogs/fragments/deprecate_parsing_filter_plugins.yaml
@@ -4,5 +4,3 @@ deprecated_features:
   - "`parse_cli_textfsm` filter plugin is deprecated and will be removed in a future release after 2027-02-01. Use `ansible.utils.cli_parse` with the `ansible.utils.textfsm_parser` parser as a replacement."
   - "`parse_xml` filter plugin is deprecated and will be removed in a future release after 2027-02-01. Use `ansible.utils.cli_parse` with the `ansible.utils.xml_parser` parser as a replacement."
   - "Added deprecation warnings for the above plugins, displayed when running respective filter plugins."
-
-

--- a/docs/ansible.netcommon.parse_cli_filter.rst
+++ b/docs/ansible.netcommon.parse_cli_filter.rst
@@ -19,6 +19,7 @@ Synopsis
 --------
 - The filter plugins converts the output of a network device CLI command into structured JSON output.
 - Using the parameters below - ``xml_data | ansible.netcommon.parse_cli(template.yml``)
+- This plugin is deprecated and will be removed in a future release after 2027-02-01, please Use ansible.utils.cli_parse instead.
 
 
 

--- a/docs/ansible.netcommon.parse_cli_textfsm_filter.rst
+++ b/docs/ansible.netcommon.parse_cli_textfsm_filter.rst
@@ -19,6 +19,7 @@ Synopsis
 --------
 - The network filters also support parsing the output of a CLI command using the TextFSM library. To parse the CLI output with TextFSM use this filter.
 - Using the parameters below - ``data | ansible.netcommon.parse_cli_textfsm(template.yml``)
+- This plugin is deprecated and will be removed in a future release after 2027-02-01, please Use ansible.utils.cli_parse instead.
 
 
 

--- a/docs/ansible.netcommon.parse_xml_filter.rst
+++ b/docs/ansible.netcommon.parse_xml_filter.rst
@@ -19,6 +19,7 @@ Synopsis
 --------
 - This filter will load the spec file and pass the command output through it, returning JSON output.
 - The YAML spec file defines how to parse the CLI output.
+- This plugin is deprecated and will be removed in a future release after 2027-02-01, please Use ansible.utils.cli_parse instead.
 
 
 

--- a/plugins/filter/parse_cli.py
+++ b/plugins/filter/parse_cli.py
@@ -22,6 +22,7 @@ description:
   - The filter plugins converts the output of a network device
     CLI command into structured JSON output.
   - Using the parameters below - C(xml_data | ansible.netcommon.parse_cli(template.yml))
+  - This plugin is deprecated and will be removed in a future release after 2027-02-01, please Use ansible.utils.cli_parse instead.
 notes:
   - The parse_cli filter will load the spec file and pass the command output through it,
     returning JSON output. The YAML spec file defines how to parse the CLI output
@@ -135,17 +136,21 @@ from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_valid
 
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.parse_cli import parse_cli
 
-
 try:
     from jinja2.filters import pass_environment
 except ImportError:
     from jinja2.filters import environmentfilter as pass_environment
+from ansible.utils.display import Display
 
 
 @pass_environment
 def _parse_cli(*args, **kwargs):
-    """Extend vlan data"""
-
+    """parse cli"""
+    display = Display()
+    display.warning(
+      "The 'parse_cli' filter is deprecated and will be removed in a future release "
+      "after 2027-02-01. Use 'ansible.utils.cli_parse' instead."
+    )
     keys = ["output", "tmpl"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)

--- a/plugins/filter/parse_cli.py
+++ b/plugins/filter/parse_cli.py
@@ -136,10 +136,12 @@ from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_valid
 
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.parse_cli import parse_cli
 
+
 try:
     from jinja2.filters import pass_environment
 except ImportError:
     from jinja2.filters import environmentfilter as pass_environment
+
 from ansible.utils.display import Display
 
 
@@ -148,8 +150,8 @@ def _parse_cli(*args, **kwargs):
     """parse cli"""
     display = Display()
     display.warning(
-      "The 'parse_cli' filter is deprecated and will be removed in a future release "
-      "after 2027-02-01. Use 'ansible.utils.cli_parse' instead."
+        "The 'parse_cli' filter is deprecated and will be removed in a future release "
+        "after 2027-02-01. Use 'ansible.utils.cli_parse' instead."
     )
     keys = ["output", "tmpl"]
     data = dict(zip(keys, args[1:]))

--- a/plugins/filter/parse_cli_textfsm.py
+++ b/plugins/filter/parse_cli_textfsm.py
@@ -93,10 +93,12 @@ from ansible_collections.ansible.netcommon.plugins.plugin_utils.parse_cli_textfs
     parse_cli_textfsm,
 )
 
+
 try:
     from jinja2.filters import pass_environment
 except ImportError:
     from jinja2.filters import environmentfilter as pass_environment
+
 from ansible.utils.display import Display
 
 
@@ -105,8 +107,8 @@ def _parse_cli_textfsm(*args, **kwargs):
     """parse textfsm"""
     display = Display()
     display.warning(
-      "The 'parse_cli_textfsm' filter is deprecated and will be removed in a future release "
-      "after 2027-02-01. Use 'ansible.utils.cli_parse' instead."
+        "The 'parse_cli_textfsm' filter is deprecated and will be removed in a future release "
+        "after 2027-02-01. Use 'ansible.utils.cli_parse' instead."
     )
     keys = ["value", "template"]
     data = dict(zip(keys, args[1:]))

--- a/plugins/filter/parse_cli_textfsm.py
+++ b/plugins/filter/parse_cli_textfsm.py
@@ -22,6 +22,7 @@ description:
   - The network filters also support parsing the output of a CLI command using the TextFSM library.
     To parse the CLI output with TextFSM use this filter.
   - Using the parameters below - C(data | ansible.netcommon.parse_cli_textfsm(template.yml))
+  - This plugin is deprecated and will be removed in a future release after 2027-02-01, please Use ansible.utils.cli_parse instead.
 notes:
   - Use of the TextFSM filter requires the TextFSM library to be installed.
 options:
@@ -92,17 +93,21 @@ from ansible_collections.ansible.netcommon.plugins.plugin_utils.parse_cli_textfs
     parse_cli_textfsm,
 )
 
-
 try:
     from jinja2.filters import pass_environment
 except ImportError:
     from jinja2.filters import environmentfilter as pass_environment
+from ansible.utils.display import Display
 
 
 @pass_environment
 def _parse_cli_textfsm(*args, **kwargs):
-    """Extend vlan data"""
-
+    """parse textfsm"""
+    display = Display()
+    display.warning(
+      "The 'parse_cli_textfsm' filter is deprecated and will be removed in a future release "
+      "after 2027-02-01. Use 'ansible.utils.cli_parse' instead."
+    )
     keys = ["value", "template"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)

--- a/plugins/filter/parse_xml.py
+++ b/plugins/filter/parse_xml.py
@@ -22,6 +22,7 @@ description:
   - This filter will load the spec file and pass the command output
     through it, returning JSON output.
   - The YAML spec file defines how to parse the CLI output.
+  - This plugin is deprecated and will be removed in a future release after 2027-02-01, please Use ansible.utils.cli_parse instead.
 notes:
   - To convert the XML output of a network device command into structured JSON output.
 options:
@@ -166,17 +167,22 @@ from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_valid
 
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.parse_xml import parse_xml
 
-
 try:
     from jinja2.filters import pass_environment
 except ImportError:
     from jinja2.filters import environmentfilter as pass_environment
+from ansible.utils.display import Display
 
 
 @pass_environment
 def _parse_xml(*args, **kwargs):
-    """Extend vlan data"""
+    """parse xml"""
 
+    display = Display()
+    display.warning(
+      "The 'parse_xml' filter is deprecated and will be removed in a future release "
+      "after 2027-02-01. Use 'ansible.utils.cli_parse' instead."
+    )
     keys = ["output", "tmpl"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)

--- a/plugins/filter/parse_xml.py
+++ b/plugins/filter/parse_xml.py
@@ -167,10 +167,12 @@ from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_valid
 
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.parse_xml import parse_xml
 
+
 try:
     from jinja2.filters import pass_environment
 except ImportError:
     from jinja2.filters import environmentfilter as pass_environment
+
 from ansible.utils.display import Display
 
 
@@ -180,8 +182,8 @@ def _parse_xml(*args, **kwargs):
 
     display = Display()
     display.warning(
-      "The 'parse_xml' filter is deprecated and will be removed in a future release "
-      "after 2027-02-01. Use 'ansible.utils.cli_parse' instead."
+        "The 'parse_xml' filter is deprecated and will be removed in a future release "
+        "after 2027-02-01. Use 'ansible.utils.cli_parse' instead."
     )
     keys = ["output", "tmpl"]
     data = dict(zip(keys, args[1:]))


### PR DESCRIPTION
### Summary

This PR deprecates the following filter plugins in the `ansible.netcommon` collection:
- `parse_cli`
- `parse_cli_textfsm`
- `parse_xml`

These plugins are replaced by their respective counterparts in the `ansible.utils` collection:
- `parse_cli` → `cli_parse`
- `parse_cli_textfsm` → `textfsm_parser`
- `parse_xml` → `xml_parser`

### Changes

- Updated documentation with deprecation notices.
- Updated plugin code to display deprecation warnings.

### Impact
- These plugins will remain functional .
- They will be removed in a future release after 2027-02-01.

### Migration
Users are encouraged to switch to the `ansible.utils` plugins:

- Example for `parse_cli`:
```yaml
Old usage:
 - name: Parse CLI output with TextFSM
      ansible.builtin.set_fact:
        parsed_output: "{{ cli_output | parse_cli_textfsm('templates/show_ip_interface_brief.textfsm') }}""
```
```yaml
  New usage:
    - name: "Pass text and command"
      ansible.utils.cli_parse:
        text: "{{ lookup('ansible.builtin.file', 'show_ip_interface_brief.txt') }}"
        parser:
          name: ansible.utils.textfsm
          template_path: "templates/show_ip_interface_brief.textfsm"
      register: nxos_textfsm_text
```
