### PR TITLE
send netconf session_close RPC only if connection is alive

### DIFF
--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -430,6 +430,6 @@ class Connection(NetworkConnectionBase):
         )
 
     def close(self):
-        if self._manager:
+        if self._manager.connected:
             self._manager.close_session()
         super(Connection, self).close()


### PR DESCRIPTION
Connection can be lost from control plane reset or device restart. meta: reset_connection task wll attempt to send a session_close RPC to a dead connection and ncclient will raise an exception preventing the connection socket_path from being closed out.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #348 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf connection

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
meta: reset_connection attempts to close the connection:
https://github.com/ansible/ansible/blob/4cc47307ef2c5f63215f2eb1cffeabdeab1c59d6/lib/ansible/plugins/connection/__init__.py#L379

Which calls the netconf connection close:
https://github.com/ansible-collections/ansible.netcommon/blob/3185a944a82ee9ed6c3e77076239542369b4e4bd/plugins/connection/netconf.py#L434

If the conneciton was lost due to restart, ncclient raises exeption preventing the ansible socket from being closed:
https://github.com/ncclient/ncclient/blob/a641253370c632182a94b58aa53b66993b8c9a63/ncclient/transport/session.py#L257

This checks the connection status before attempting to send the RPC call to close the session.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
- junos_facts:

- junos_command:
    commands: request system reboot

# ncclient connection will be lost

- wait_for::
     port: 830
     delay: 300
     timeout: 600
  delegate_to: localhost

# currently fails to close ansible socket
- meta: reset_connection

# existing socket found and ncclient raises exception
- junos_facts:
```
