### PR TITLE
Fixed #633 - telnet module parameter typo: changed clrf to corrected …

### DIFF
--- a/plugins/action/telnet.py
+++ b/plugins/action/telnet.py
@@ -49,14 +49,14 @@ class ActionModule(ActionBase):
             pause = int(self._task.args.get("pause", 1))
 
             send_newline = self._task.args.get("send_newline", False)
-            clrf = self._task.args.get("clrf", False)
+            crlf = self._task.args.get("crlf", False)
 
             login_prompt = to_text(self._task.args.get("login_prompt", "login: "))
             password_prompt = to_text(self._task.args.get("password_prompt", "Password: "))
             prompts = self._task.args.get("prompts", ["\\$ "])
             commands = self._task.args.get("command") or self._task.args.get("commands")
 
-            if clrf:
+            if crlf:
                 line_ending = "\r\n"
             else:
                 line_ending = "\n"


### PR DESCRIPTION
…crlf

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #633: Typo in variable name regarding line ending type (CRLF vs LF) - ```clrf``` which should have been (and is currently documented as) ```crlf```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.netcommon.telnet
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
#633 goes into detail of the issue: a typo in the ```crlf``` parameter for ansible module ansible.netcommon.telnet.
