### PR TITLE
fix CI - pyats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ venv.bak/
 
 # vs code configuration
 .vscode/
+.ansible/

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,10 +10,6 @@ pytest-cov
 
 # The following are 3rd party libs for cli_parse
 ntc_templates
-# 21.4 changed the output of an error message we checked in the tests
-pyats >= 21.4 ; python_version < '3.11'
-# fix genie version for python version less than 3.11
-genie == 24.3 ; python_version < '3.11'
-# use the latest genie version for every Python version greater than 3.11 and less than 3.13
-genie ; python_version < '3.13' and python_version >= '3.11'
+pyats
+genie
 passlib

--- a/tests/unit/plugins/cli_parsers/test_pyats_parser.py
+++ b/tests/unit/plugins/cli_parsers/test_pyats_parser.py
@@ -145,7 +145,7 @@ class TestPyatsParser(TestCase):
         error = {
             "errors": [
                 "The pyats library return an error for 'show inventory' for 'wrong_os'. "
-                "Error: Could not find parser for show inventory under ('wrong_os',)."
+                "Error: Parser Output is empty."
             ]
         }
         self.assertEqual(result, error)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
```bash
=========================== short test summary info ============================
FAILED tests/unit/plugins/cli_parsers/test_pyats_parser.py::TestPyatsParser::test_pyats_parser - ImportError: Failed to import FileUtilsBase from genie.libs.filetransferutils.bases.fileutils. FileUtils are not available without genielibs installed.
FAILED tests/unit/plugins/cli_parsers/test_pyats_parser.py::TestPyatsParser::test_pyats_parser_ano_invalid - AssertionError: {'err[81 chars]ror: Failed to import FileUtilsBase from genie[96 chars].."]} != {'err[81 chars]ror: Could not find parser for show inventory [18 chars])."]}
  {'errors': ["The pyats library return an error for 'show inventory' for "
+             "'wrong_os'. Error: Could not find parser for show inventory under "
+             "('wrong_os',)."]}
-             "'wrong_os'. Error: Failed to import FileUtilsBase from "
-             'genie.libs.filetransferutils.bases.fileutils. FileUtils are not '
-             'available without genielibs installed..']}
FAILED tests/unit/plugins/cli_parsers/test_pyats_parser.py::TestPyatsParser::test_pyats_parser_ano_shortname - AssertionError: {'errors': ["The pyats library return an er[148 chars]'."]} != {'parsed': {'platform': {'hardware': {'boot[509 chars]'}}}}
Diff is 1678 characters long. Set self.maxDiff to None to see **it.**
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test fix

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests/unit/plugins/cli_parsers/test_pyats_parser

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
As older python versions are dropped from CI, uncapping pyats and genie versions for the CI to pick up latest.
<!--- Paste verbatim command output below, e.g. before and after your change -->

