### PR TITLE
[WIP] - Patch for fixing the direct execution using patched AnsibleModule

### DIFF
--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -275,11 +275,16 @@ class ActionModule(_ActionModule):
         :param task_vars: The vars provided to the task
         :type task_vars: dict
         """
-        import copy, json
+        import copy
+        import json
+
         import ansible.module_utils.basic as mod_utils
+
         # update the task args w/ all the magic vars
         self._update_module_args(self._task.action, self._task.args, task_vars)
-        mod_utils._ANSIBLE_ARGS = json.dumps({"ANSIBLE_MODULE_ARGS": copy.deepcopy(self._task.args)}).encode("utf-8")
+        mod_utils._ANSIBLE_ARGS = json.dumps(
+            {"ANSIBLE_MODULE_ARGS": copy.deepcopy(self._task.args)}
+        ).encode("utf-8")
         mod_utils._ANSIBLE_PROFILE = "legacy"
 
     def _exec_module(self, module):

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -277,7 +277,7 @@ class ActionModule(_ActionModule):
         """
         import copy, json
         import ansible.module_utils.basic as mod_utils
-
+        # update the task args w/ all the magic vars
         self._update_module_args(self._task.action, self._task.args, task_vars)
         mod_utils._ANSIBLE_ARGS = json.dumps({"ANSIBLE_MODULE_ARGS": copy.deepcopy(self._task.args)}).encode("utf-8")
         mod_utils._ANSIBLE_PROFILE = "legacy"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR is an alternative fix for enabling direct execution (`import_modules=True`) in `network.py` action plugin for Ansible-core 2.19+.

This better aligns with how ansible-core 2.19 expects modules to behave under direct execution, and avoids module deserialization errors like: `Module result deserialization failed: No start of json char found`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Related to: https://issues.redhat.com/browse/AAP-41594
Fixes: https://github.com/ansible-collections/ansible.netcommon/issues/698
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`network.py`