### PR TITLE
Fix devel sanity issues

### DIFF
--- a/.github/workflows/check_label.yml
+++ b/.github/workflows/check_label.yml
@@ -1,5 +1,5 @@
 ---
-name: "Check label"
+name: "Check PR label 👓"
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -1,5 +1,5 @@
 ---
-name: code_coverage
+name: "Code Coverage 🎯"
 
 on:  # yamllint disable-line rule:truthy
   push:

--- a/.github/workflows/integration-simple.yml
+++ b/.github/workflows/integration-simple.yml
@@ -1,5 +1,5 @@
 ---
-name: Integration-simple
+name: "Integration tests 💻"
 on:
   pull_request_target:
     branches: [main]

--- a/.github/workflows/integration-simple.yml
+++ b/.github/workflows/integration-simple.yml
@@ -20,7 +20,7 @@ jobs:
       # lab_title_override: "Optional custom lab title"
     secrets:
       virl_host: ${{ secrets.VIRL_HOST }}
-      virl_username: ${{ secrets.VIRL_USERNAME }} # optional; defaults to admin
+      virl_username: ${{ secrets.VIRL_USERNAME }}
       virl_password: ${{ secrets.VIRL_PASSWORD }}
 
   integration-tests:
@@ -40,5 +40,5 @@ jobs:
     uses: ansible/ansible-content-actions/.github/workflows/cml_lab_destroy.yaml@main
     secrets:
       virl_host: ${{ secrets.VIRL_HOST }}
-      virl_username: ${{ secrets.VIRL_USERNAME }} # optional; defaults to admin
+      virl_username: ${{ secrets.VIRL_USERNAME }}
       virl_password: ${{ secrets.VIRL_PASSWORD }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,5 +1,5 @@
 ---
-name: Integration
+name: "Integration - old"
 on:
   pull_request_target:
     branches: [main]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 ---
-name: "Release collection"
+name: "Release collection 🚀"
 on:  # yamllint disable-line rule:truthy
   release:
     types: [published]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 ---
-name: "CI"
+name: "Collection Tests 🧪"
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/.github/workflows/token_refresh.yml
+++ b/.github/workflows/token_refresh.yml
@@ -1,5 +1,5 @@
 ---
-name: refresh_automation_hub_token
+name: "AH Token Refresh 🔧"
 on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 0 * * *'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 ---
 repos:
-  - repo: https://github.com/ansible-network/collection_prep
-    rev: 1.1.1
-    hooks:
-      - id: update-docs
+  # - repo: https://github.com/ansible-network/collection_prep
+  #   rev: 1.1.1
+  #   hooks:
+  #     - id: update-docs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 ---
 repos:
-  # - repo: https://github.com/ansible-network/collection_prep
-  #   rev: 1.1.1
-  #   hooks:
-  #     - id: update-docs
+  - repo: https://github.com/ansible-network/collection_prep
+    rev: da78082ea59b03ad16cd7dbee267f53e8ff50bb5
+    hooks:
+      - id: update-docs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/README.md
+++ b/README.md
@@ -34,10 +34,8 @@ For more information about communication, see the [Ansible communication guide](
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.16.0**.
+This collection has been tested against the following Ansible versions: **>=2.16.0**.
 
-For collections that support Ansible 2.9, please ensure you update your `network_os` to use the
-fully qualified collection name (for example, `cisco.ios.ios`).
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.
 PEP440 is the schema used to describe the versions of Ansible.

--- a/changelogs/fragments/fix_sanity_220_devel.yaml
+++ b/changelogs/fragments/fix_sanity_220_devel.yaml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - Fix sanity issues and remove old python 2.x imports and dependencies.
+  - Fix lint issues for lab files for CML based integration testing.

--- a/changelogs/fragments/fix_sanity_220_devel.yaml
+++ b/changelogs/fragments/fix_sanity_220_devel.yaml
@@ -2,3 +2,5 @@
 trivial:
   - Fix sanity issues and remove old python 2.x imports and dependencies.
   - Fix lint issues for lab files for CML based integration testing.
+  - Handles imports of passlib_or_crypt to do_encrypt for ansible-core 2.20 or above
+  - Update github workflow names for better clarity.

--- a/docs/ansible.netcommon.type5_pw_filter.rst
+++ b/docs/ansible.netcommon.type5_pw_filter.rst
@@ -19,6 +19,7 @@ Synopsis
 --------
 - Filter plugin to produce cisco type5 hashed password.
 - Using the parameters below - ``xml_data | ansible.netcommon.type5_pw(template.yml``)
+- This plugin uses do_encrypt if used with ansible-core 2.20+ and passlib_or_crypt for versions before 2.20
 
 
 

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -14,7 +14,6 @@ import time
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text
-from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.display import Display
@@ -213,14 +212,6 @@ class ActionModule(_ActionModule):
         # log early about dexec
         if dexec:
             display.vvvv("{prefix} enabled".format(prefix=DEXEC_PREFIX), host)
-
-            # disable dexec when not PY3
-            if not PY3:
-                dexec = False
-                display.vvvv(
-                    "{prefix} disabled for when not Python 3".format(prefix=DEXEC_PREFIX),
-                    host=host,
-                )
 
             # disable dexec when running async
             if self._task.async_val:

--- a/plugins/action/telnet.py
+++ b/plugins/action/telnet.py
@@ -11,13 +11,12 @@ __metaclass__ = type
 from time import sleep
 
 from ansible.module_utils._text import to_bytes, to_text
-from ansible.module_utils.six import string_types
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.compat import telnetlib
 
-
+text_type = str
 display = Display()
 
 
@@ -61,7 +60,7 @@ class ActionModule(ActionBase):
             else:
                 line_ending = "\n"
 
-            if isinstance(commands, string_types):
+            if isinstance(commands, text_type):
                 commands = commands.split(",")
 
             if isinstance(commands, list) and commands:

--- a/plugins/action/telnet.py
+++ b/plugins/action/telnet.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 from time import sleep
 
 from ansible.module_utils._text import to_bytes, to_text
-from ansible.module_utils.six import text_type
+from ansible.module_utils.six import string_types
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 
@@ -61,7 +61,7 @@ class ActionModule(ActionBase):
             else:
                 line_ending = "\n"
 
-            if isinstance(commands, text_type):
+            if isinstance(commands, string_types):
                 commands = commands.split(",")
 
             if isinstance(commands, list) and commands:

--- a/plugins/action/telnet.py
+++ b/plugins/action/telnet.py
@@ -16,6 +16,7 @@ from ansible.utils.display import Display
 
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.compat import telnetlib
 
+
 text_type = str
 display = Display()
 

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -188,7 +188,6 @@ from io import BytesIO
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_bytes
-from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import cPickle
 from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 from ansible.module_utils.urls import open_url
@@ -258,10 +257,8 @@ class Connection(NetworkConnectionBase):
     def update_play_context(self, pc_data):
         """Updates the play context information for the connection"""
         pc_data = to_bytes(pc_data)
-        if PY3:
-            pc_data = cPickle.loads(pc_data, encoding="bytes")
-        else:
-            pc_data = cPickle.loads(pc_data)
+        pc_data = cPickle.loads(pc_data, encoding="bytes")
+
         play_context = PlayContext()
         play_context.deserialize(pc_data)
 

--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -264,7 +264,7 @@ class Connection(NetworkConnectionBase):
         """Updates the play context information for the connection"""
         pc_data = to_bytes(pc_data)
         pc_data = cPickle.loads(pc_data, encoding="bytes")
-        
+
         play_context = PlayContext()
         play_context.deserialize(pc_data)
         self._play_context = play_context

--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -157,7 +157,6 @@ from ansible.errors import AnsibleConnectionFailure, AnsibleError
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE, BOOLEANS_TRUE
-from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import cPickle
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.connection import ensure_connect
@@ -264,10 +263,8 @@ class Connection(NetworkConnectionBase):
     def update_play_context(self, pc_data):
         """Updates the play context information for the connection"""
         pc_data = to_bytes(pc_data)
-        if PY3:
-            pc_data = cPickle.loads(pc_data, encoding="bytes")
-        else:
-            pc_data = cPickle.loads(pc_data)
+        pc_data = cPickle.loads(pc_data, encoding="bytes")
+        
         play_context = PlayContext()
         play_context.deserialize(pc_data)
         self._play_context = play_context

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -314,7 +314,6 @@ from io import BytesIO
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import cPickle
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import cache_loader, cliconf_loader, connection_loader, terminal_loader
@@ -553,10 +552,8 @@ class Connection(NetworkConnectionBase):
     def update_play_context(self, pc_data):
         """Updates the play context information for the connection"""
         pc_data = to_bytes(pc_data)
-        if PY3:
-            pc_data = cPickle.loads(pc_data, encoding="bytes")
-        else:
-            pc_data = cPickle.loads(pc_data)
+        pc_data = cPickle.loads(pc_data, encoding="bytes")
+
         play_context = PlayContext()
         play_context.deserialize(pc_data)
 

--- a/plugins/filter/type5_pw.py
+++ b/plugins/filter/type5_pw.py
@@ -21,6 +21,7 @@ short_description: The type5_pw filter plugin.
 description:
   - Filter plugin to produce cisco type5 hashed password.
   - Using the parameters below - C(xml_data | ansible.netcommon.type5_pw(template.yml))
+  - This plugin uses do_encrypt if used with ansible-core 2.20+ and passlib_or_crypt for versions before 2.20
 notes:
   - The filter plugin generates cisco type5 hashed password.
 options:

--- a/plugins/module_utils/network/common/facts/facts.py
+++ b/plugins/module_utils/network/common/facts/facts.py
@@ -14,7 +14,6 @@ The facts base class
 this contains methods common to all facts subsets
 """
 from ansible.module_utils._text import to_text
-from ansible.module_utils.six import iteritems
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.network import (
     get_resource_connection,
@@ -150,6 +149,6 @@ class FactsBase(object):
                 facts.update(inst.facts)
                 self._warnings.extend(inst.warnings)
 
-            for key, value in iteritems(facts):
+            for key, value in facts.itmes():
                 key = "ansible_net_%s" % key
                 self.ansible_facts[key] = value

--- a/plugins/module_utils/network/common/network.py
+++ b/plugins/module_utils/network/common/network.py
@@ -20,7 +20,6 @@ import traceback
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection, ConnectionError
-from ansible.module_utils.six import iteritems
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.netconf import (
     NetconfConnection,
@@ -53,7 +52,7 @@ NET_CONNECTIONS = dict()
 
 def _transitional_argument_spec():
     argument_spec = {}
-    for key, value in iteritems(NET_TRANSPORT_ARGS):
+    for key, value in NET_TRANSPORT_ARGS.items():
         value["required"] = False
         argument_spec[key] = value
     return argument_spec

--- a/plugins/module_utils/network/common/parsing.py
+++ b/plugins/module_utils/network/common/parsing.py
@@ -19,11 +19,12 @@ import shlex
 import time
 
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE, BOOLEANS_TRUE
-from ansible.module_utils.six import string_types, text_type
 from ansible.module_utils.six.moves import zip
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list
 
+text_type = str
+string_types = str,
 
 class FailedConditionsError(Exception):
     def __init__(self, msg, failed_conditions):

--- a/plugins/module_utils/network/common/parsing.py
+++ b/plugins/module_utils/network/common/parsing.py
@@ -23,8 +23,10 @@ from ansible.module_utils.six.moves import zip
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list
 
+
 text_type = str
-string_types = str,
+string_types = (str,)
+
 
 class FailedConditionsError(Exception):
     def __init__(self, msg, failed_conditions):

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -30,7 +30,7 @@ from ansible.module_utils import basic
 from ansible.module_utils._text import to_text
 from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils.six import iteritems, string_types
+from ansible.module_utils.six import string_types
 
 
 try:
@@ -178,12 +178,12 @@ class Entity(object):
 
         _has_key = False
 
-        for name, attr in iteritems(self._attributes):
+        for name, attr in self._attributes.items():
             if attr.get("read_from"):
                 if attr["read_from"] not in self._module.argument_spec:
                     module.fail_json(msg="argument %s does not exist" % attr["read_from"])
                 spec = self._module.argument_spec.get(attr["read_from"])
-                for key, value in iteritems(spec):
+                for key, value in spec.items():
                     if key not in attr:
                         attr[key] = value
 
@@ -198,7 +198,7 @@ class Entity(object):
 
     def to_dict(self, value):
         obj = {}
-        for name, attr in iteritems(self._attributes):
+        for name, attr in self._attributes.items():
             if attr.get("key"):
                 obj[name] = value
             else:
@@ -214,7 +214,7 @@ class Entity(object):
             if unknown:
                 self._module.fail_json(msg="invalid keys: %s" % ",".join(unknown))
 
-        for name, attr in iteritems(self._attributes):
+        for name, attr in self._attributes.items():
             if value.get(name) is None:
                 value[name] = attr.get("default")
 
@@ -299,7 +299,7 @@ def dict_diff(base, comparable):
 
     updates = dict()
 
-    for key, value in iteritems(base):
+    for key, value in base.items():
         if isinstance(value, dict):
             item = comparable.get(key)
             if item is not None:
@@ -338,7 +338,7 @@ def dict_merge(base, other):
 
     combined = dict()
 
-    for key, value in iteritems(deepcopy(base)):
+    for key, value in deepcopy(base).items():
         if isinstance(value, dict):
             if key in other:
                 item = other.get(key)
@@ -466,7 +466,7 @@ def validate_prefix(prefix):
 
 def load_provider(spec, args):
     provider = args.get("provider") or {}
-    for key, value in iteritems(spec):
+    for key, value in spec.items():
         if key not in provider:
             try:
                 # Get fallback if defined, and valid
@@ -507,7 +507,7 @@ def generate_dict(spec):
     if not spec:
         return obj
 
-    for key, val in iteritems(spec):
+    for key, val in spec.items():
         if "default" in val:
             dct = {key: val["default"]}
         elif "type" in val and val["type"] == "dict":
@@ -593,7 +593,7 @@ def remove_empties(cfg_dict):
     if not cfg_dict:
         return final_cfg
 
-    for key, val in iteritems(cfg_dict):
+    for key, val in cfg_dict.items():
         dct = None
         if isinstance(val, dict):
             child_val = remove_empties(val)
@@ -709,7 +709,7 @@ class Template:
 
 def extract_argspec(doc_obj, argpsec):
     options_obj = doc_obj.get("options")
-    for okey, ovalue in iteritems(options_obj):
+    for okey, ovalue in options_obj.items():
         argpsec[okey] = {}
         for metakey in list(ovalue):
             if metakey == "suboptions":

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -30,9 +30,8 @@ from ansible.module_utils import basic
 from ansible.module_utils._text import to_text
 from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils.six import string_types
 
-
+string_types = str,
 try:
     from jinja2 import Environment, StrictUndefined
     from jinja2.exceptions import UndefinedError

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -31,7 +31,8 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.parsing.convert_bool import boolean
 
-string_types = str,
+
+string_types = (str,)
 try:
     from jinja2 import Environment, StrictUndefined
     from jinja2.exceptions import UndefinedError

--- a/plugins/module_utils/utils/data.py
+++ b/plugins/module_utils/utils/data.py
@@ -19,7 +19,7 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import missing_required_lib
 
 
-string_types = str,
+string_types = (str,)
 try:
     HAS_LXML = True
     from lxml import etree

--- a/plugins/module_utils/utils/data.py
+++ b/plugins/module_utils/utils/data.py
@@ -17,9 +17,9 @@ import sys
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils.six import string_types
 
 
+string_types = str,
 try:
     HAS_LXML = True
     from lxml import etree

--- a/plugins/modules/restconf_config.py
+++ b/plugins/modules/restconf_config.py
@@ -125,13 +125,13 @@ import json
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import ConnectionError
-from ansible.module_utils.six import string_types
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     dict_diff,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.restconf import restconf
 
+string_types = str,
 
 def main():
     """entry point for module execution"""

--- a/plugins/modules/restconf_config.py
+++ b/plugins/modules/restconf_config.py
@@ -131,7 +131,9 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.restconf import restconf
 
-string_types = str,
+
+string_types = (str,)
+
 
 def main():
     """entry point for module execution"""

--- a/plugins/plugin_utils/parse_cli.py
+++ b/plugins/plugin_utils/parse_cli.py
@@ -19,7 +19,6 @@ import re
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common._collections_compat import Mapping
-from ansible.module_utils.six import string_types
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import Template
 
@@ -31,6 +30,7 @@ try:
 except ImportError:
     HAS_YAML = False
 
+string_types = str,
 
 def _raise_error(msg):
     raise AnsibleFilterError(msg)

--- a/plugins/plugin_utils/parse_cli.py
+++ b/plugins/plugin_utils/parse_cli.py
@@ -30,7 +30,8 @@ try:
 except ImportError:
     HAS_YAML = False
 
-string_types = str,
+string_types = (str,)
+
 
 def _raise_error(msg):
     raise AnsibleFilterError(msg)

--- a/plugins/plugin_utils/parse_cli.py
+++ b/plugins/plugin_utils/parse_cli.py
@@ -19,7 +19,7 @@ import re
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common._collections_compat import Mapping
-from ansible.module_utils.six import iteritems, string_types
+from ansible.module_utils.six import string_types
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import Template
 
@@ -41,7 +41,7 @@ def re_matchall(regex, value):
     for match in re.findall(regex.pattern, value, re.M):
         obj = {}
         if regex.groupindex:
-            for name, index in iteritems(regex.groupindex):
+            for name, index in regex.groupindex.items():
                 if len(regex.groupindex) == 1:
                     obj[name] = match
                 else:
@@ -56,7 +56,7 @@ def re_search(regex, value):
     if match:
         items = list(match.groups())
         if regex.groupindex:
-            for name, index in iteritems(regex.groupindex):
+            for name, index in regex.groupindex.items():
                 obj[name] = items[index - 1]
     return obj
 
@@ -102,7 +102,7 @@ def parse_cli(output, tmpl):
     spec = yaml.safe_load(tmpl_content)
     obj = {}
 
-    for name, attrs in iteritems(spec["keys"]):
+    for name, attrs in spec["keys"].items():
         value = attrs["value"]
 
         try:
@@ -149,7 +149,7 @@ def parse_cli(output, tmpl):
                         items.append(re_finditer(regex, block))
 
                     obj = {}
-                    for k, v in iteritems(value):
+                    for k, v in value.items():
                         try:
                             obj[k] = template(v, {"item": items}, fail_on_undefined=False)
                         except Exception:
@@ -163,7 +163,7 @@ def parse_cli(output, tmpl):
 
                     key = template(value["key"], {"item": items})
                     values = dict(
-                        [(k, template(v, {"item": items})) for k, v in iteritems(value["values"])]
+                        [(k, template(v, {"item": items})) for k, v in value["values"].items()]
                     )
                     objects.append({key: values})
 
@@ -180,7 +180,7 @@ def parse_cli(output, tmpl):
                 for item in re_matchall(regexp, output):
                     entry = {}
 
-                    for item_key, item_value in iteritems(value):
+                    for item_key, item_value in value.items():
                         entry[item_key] = template(item_value, {"item": item})
 
                     if when:
@@ -197,7 +197,7 @@ def parse_cli(output, tmpl):
                 for item in re_matchall(regexp, output):
                     entry = {}
 
-                    for item_key, item_value in iteritems(value["values"]):
+                    for item_key, item_value in value["values"].items():
                         entry[item_key] = template(item_value, {"item": item})
 
                     key = template(value["key"], {"item": item})

--- a/plugins/plugin_utils/parse_cli_textfsm.py
+++ b/plugins/plugin_utils/parse_cli_textfsm.py
@@ -18,6 +18,7 @@ import os
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils._text import to_native
 
+
 try:
     import textfsm
 
@@ -25,7 +26,8 @@ try:
 except ImportError:
     HAS_TEXTFSM = False
 
-string_types = str,
+string_types = (str,)
+
 
 def _raise_error(msg):
     raise AnsibleFilterError(msg)

--- a/plugins/plugin_utils/parse_cli_textfsm.py
+++ b/plugins/plugin_utils/parse_cli_textfsm.py
@@ -17,8 +17,6 @@ import os
 
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils._text import to_native
-from ansible.module_utils.six import string_types
-
 
 try:
     import textfsm
@@ -27,6 +25,7 @@ try:
 except ImportError:
     HAS_TEXTFSM = False
 
+string_types = str,
 
 def _raise_error(msg):
     raise AnsibleFilterError(msg)

--- a/plugins/plugin_utils/parse_xml.py
+++ b/plugins/plugin_utils/parse_xml.py
@@ -25,7 +25,8 @@ from ansible.utils.display import Display
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import Template
 
-string_types = str,
+
+string_types = (str,)
 
 try:
     import yaml

--- a/plugins/plugin_utils/parse_xml.py
+++ b/plugins/plugin_utils/parse_xml.py
@@ -21,7 +21,7 @@ from xml.etree.ElementTree import fromstring
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common._collections_compat import Mapping
-from ansible.module_utils.six import iteritems, string_types
+from ansible.module_utils.six import string_types
 from ansible.utils.display import Display
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import Template
@@ -57,7 +57,7 @@ def _extract_param(template, root, attrs, value):
     for element in root.findall(attrs["top"]):
         entry = dict()
         item_dict = dict()
-        for param, param_xpath in iteritems(param_to_xpath_map):
+        for param, param_xpath in param_to_xpath_map.items():
             fields = None
             try:
                 fields = element.findall(param_xpath)
@@ -90,7 +90,7 @@ def _extract_param(template, root, attrs, value):
                     item_dict[param] = None
 
         if isinstance(value, Mapping):
-            for item_key, item_value in iteritems(value):
+            for item_key, item_value in value.items():
                 entry[item_key] = template(item_value, {"item": item_dict})
         else:
             entry = template(value, {"item": item_dict})
@@ -134,7 +134,7 @@ def parse_xml(output, tmpl):
     spec = yaml.safe_load(tmpl_content)
     obj = {}
 
-    for name, attrs in iteritems(spec["keys"]):
+    for name, attrs in spec["keys"].items():
         value = attrs["value"]
 
         try:

--- a/plugins/plugin_utils/parse_xml.py
+++ b/plugins/plugin_utils/parse_xml.py
@@ -21,11 +21,11 @@ from xml.etree.ElementTree import fromstring
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common._collections_compat import Mapping
-from ansible.module_utils.six import string_types
 from ansible.utils.display import Display
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import Template
 
+string_types = str,
 
 try:
     import yaml

--- a/plugins/plugin_utils/type5_pw.py
+++ b/plugins/plugin_utils/type5_pw.py
@@ -25,6 +25,7 @@ try:
     from ansible.utils.encrypt import passlib_or_crypt, random_password
 except ImportError:
     # To use do_encrypt from 2.20
+    from ansible.utils.encrypt import random_password
     HAS_PASSLIB_OR_CRYPT = False
 
 string_types = (str,)

--- a/plugins/plugin_utils/type5_pw.py
+++ b/plugins/plugin_utils/type5_pw.py
@@ -20,6 +20,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.six import string_types
 from ansible.utils import encrypt
 
+
 def _raise_error(msg):
     raise AnsibleFilterError(msg)
 

--- a/plugins/plugin_utils/type5_pw.py
+++ b/plugins/plugin_utils/type5_pw.py
@@ -18,8 +18,7 @@ import string
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils._text import to_text
 from ansible.module_utils.six import string_types
-from ansible.utils.encrypt import passlib_or_crypt, random_password
-
+from ansible.utils import encrypt
 
 def _raise_error(msg):
     raise AnsibleFilterError(msg)
@@ -39,10 +38,10 @@ def type5_pw(password, salt=None):
             % (type(salt).__name__)
         )
     elif not salt:
-        salt = random_password(length=4, chars=salt_chars)
+        salt = encrypt.random_password(length=4, chars=salt_chars)
     elif not set(salt) <= set(salt_chars):
         _raise_error("type5_pw salt used inproper characters, must be one of %s" % (salt_chars))
 
-    encrypted_password = passlib_or_crypt(password, "md5_crypt", salt=salt)
+    encrypted_password = encrypt.passlib_or_crypt(password, "md5_crypt", salt=salt)
 
     return encrypted_password

--- a/plugins/plugin_utils/type5_pw.py
+++ b/plugins/plugin_utils/type5_pw.py
@@ -17,9 +17,9 @@ import string
 
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils._text import to_text
-from ansible.module_utils.six import string_types
 from ansible.utils import encrypt
 
+string_types = str,
 
 def _raise_error(msg):
     raise AnsibleFilterError(msg)

--- a/plugins/plugin_utils/type5_pw.py
+++ b/plugins/plugin_utils/type5_pw.py
@@ -26,6 +26,7 @@ try:
 except ImportError:
     # To use do_encrypt from 2.20
     from ansible.utils.encrypt import random_password
+
     HAS_PASSLIB_OR_CRYPT = False
 
 string_types = (str,)

--- a/plugins/plugin_utils/type5_pw.py
+++ b/plugins/plugin_utils/type5_pw.py
@@ -26,7 +26,6 @@ try:
 except ImportError:
     # To use do_encrypt from 2.20
     HAS_PASSLIB_OR_CRYPT = False
-    from ansible.utils.encrypt import do_encrypt, random_password
 
 string_types = (str,)
 
@@ -56,6 +55,7 @@ def type5_pw(password, salt=None):
     if HAS_PASSLIB_OR_CRYPT:
         encrypted_password = passlib_or_crypt(password, "md5_crypt", salt=salt)
     else:
+        from ansible.utils.encrypt import do_encrypt
         encrypted_password = do_encrypt(password, "md5_crypt", salt=salt)
 
     return encrypted_password

--- a/plugins/plugin_utils/type5_pw.py
+++ b/plugins/plugin_utils/type5_pw.py
@@ -18,15 +18,16 @@ import string
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils._text import to_text
 
+
 try:
     # old import
     HAS_PASSLIB_OR_CRYPT = True
-    from ansible.utils.encrypt import random_password, passlib_or_crypt
+    from ansible.utils.encrypt import passlib_or_crypt, random_password
 except ImportError:
     # To use do_encrypt from 2.20
     HAS_PASSLIB_OR_CRYPT = False
-    from ansible.utils.encrypt import random_password, do_encrypt
-    
+    from ansible.utils.encrypt import do_encrypt, random_password
+
 string_types = (str,)
 
 

--- a/plugins/plugin_utils/type5_pw.py
+++ b/plugins/plugin_utils/type5_pw.py
@@ -56,6 +56,7 @@ def type5_pw(password, salt=None):
         encrypted_password = passlib_or_crypt(password, "md5_crypt", salt=salt)
     else:
         from ansible.utils.encrypt import do_encrypt
+
         encrypted_password = do_encrypt(password, "md5_crypt", salt=salt)
 
     return encrypted_password

--- a/plugins/plugin_utils/type5_pw.py
+++ b/plugins/plugin_utils/type5_pw.py
@@ -19,7 +19,9 @@ from ansible.errors import AnsibleFilterError
 from ansible.module_utils._text import to_text
 from ansible.utils import encrypt
 
-string_types = str,
+
+string_types = (str,)
+
 
 def _raise_error(msg):
     raise AnsibleFilterError(msg)

--- a/tests/integration/labs/multi.yaml
+++ b/tests/integration/labs/multi.yaml
@@ -15,9 +15,9 @@ nodes:
         limit-resource port-channel minimum 0 maximum 511
         limit-resource m4route-mem minimum 58 maximum 58
         limit-resource m6route-mem minimum 8 maximum 8
-      
+
       feature netconf
-      
+
       no password strength-check
       username admin password 5 $5$AADOBF$GVXUV2cvmlZH42xDu6wnqfBpV9gXF61WGVNrGF5Gk6C role network-admin
       username cisco password 5 $5$CIMENF$8Bp9rf4gXUX.KMwU7RqMR2HqdxA3289SBMdkMydwaA2 role network-admin
@@ -33,146 +33,146 @@ nodes:
       rmon event 3 log trap public description ERROR(3) owner PMON@ERROR
       rmon event 4 log trap public description WARNING(4) owner PMON@WARNING
       rmon event 5 log trap public description INFORMATION(5) owner PMON@INFO
-      
+
       vlan 1
-      
+
       vrf context management
         ip name-server 192.168.255.1
         ip route 0.0.0.0/0 192.168.255.1
-      
+
       interface Ethernet1/1
-      
+
       interface Ethernet1/2
-      
+
       interface Ethernet1/3
-      
+
       interface Ethernet1/4
-      
+
       interface Ethernet1/5
-      
+
       interface Ethernet1/6
-      
+
       interface Ethernet1/7
-      
+
       interface Ethernet1/8
-      
+
       interface Ethernet1/9
-      
+
       interface Ethernet1/10
-      
+
       interface Ethernet1/11
-      
+
       interface Ethernet1/12
-      
+
       interface Ethernet1/13
-      
+
       interface Ethernet1/14
-      
+
       interface Ethernet1/15
-      
+
       interface Ethernet1/16
-      
+
       interface Ethernet1/17
-      
+
       interface Ethernet1/18
-      
+
       interface Ethernet1/19
-      
+
       interface Ethernet1/20
-      
+
       interface Ethernet1/21
-      
+
       interface Ethernet1/22
-      
+
       interface Ethernet1/23
-      
+
       interface Ethernet1/24
-      
+
       interface Ethernet1/25
-      
+
       interface Ethernet1/26
-      
+
       interface Ethernet1/27
-      
+
       interface Ethernet1/28
-      
+
       interface Ethernet1/29
-      
+
       interface Ethernet1/30
-      
+
       interface Ethernet1/31
-      
+
       interface Ethernet1/32
-      
+
       interface Ethernet1/33
-      
+
       interface Ethernet1/34
-      
+
       interface Ethernet1/35
-      
+
       interface Ethernet1/36
-      
+
       interface Ethernet1/37
-      
+
       interface Ethernet1/38
-      
+
       interface Ethernet1/39
-      
+
       interface Ethernet1/40
-      
+
       interface Ethernet1/41
-      
+
       interface Ethernet1/42
-      
+
       interface Ethernet1/43
-      
+
       interface Ethernet1/44
-      
+
       interface Ethernet1/45
-      
+
       interface Ethernet1/46
-      
+
       interface Ethernet1/47
-      
+
       interface Ethernet1/48
-      
+
       interface Ethernet1/49
-      
+
       interface Ethernet1/50
-      
+
       interface Ethernet1/51
-      
+
       interface Ethernet1/52
-      
+
       interface Ethernet1/53
-      
+
       interface Ethernet1/54
-      
+
       interface Ethernet1/55
-      
+
       interface Ethernet1/56
-      
+
       interface Ethernet1/57
-      
+
       interface Ethernet1/58
-      
+
       interface Ethernet1/59
-      
+
       interface Ethernet1/60
-      
+
       interface Ethernet1/61
-      
+
       interface Ethernet1/62
-      
+
       interface Ethernet1/63
-      
+
       interface Ethernet1/64
-      
+
       interface mgmt0
         ip address dhcp
         vrf member management
       icam monitor scale
-      
+
       line console
         exec-timeout 0
       line vty
@@ -180,7 +180,7 @@ nodes:
       event manager applet BOOTCONFIG
         event syslog pattern "Configured from vty"
         action 1.0 cli python bootflash:set_boot.py
-      
+
       no logging console
     cpu_limit: null
     cpus: null
@@ -219,25 +219,25 @@ nodes:
     configuration: |2-
       hostname iosxr
       domain name ansible.com
-      
+
       interface MgmtEth0/RP0/CPU0/0
        ipv4 address dhcp
        no shutdown
       exit
-      
+
       aaa authentication login default local
-      
+
       line default
        login authentication default
        transport input ssh
       exit
-      
+
       router static
        address-family ipv4 unicast
         0.0.0.0/0 192.168.255.1
        exit
       exit
-      
+
       ssh timeout 100
       ssh server v2
       grpc
@@ -298,175 +298,175 @@ nodes:
       !
       !
       aaa authentication login default local
-      !         
-      !         
+      !
+      !
       aaa session-id common
-      !         
-      !         
-      !         
-      !         
-      !         
-      !         
-      !         
-      !         
-      !         
-      !         
-      !         
-      !         
+      !
+      !
+      !
+      !
+      !
+      !
+      !
+      !
+      !
+      !
+      !
+      !
       ip domain name ansible.com
-      !         
-      !         
-      !         
+      !
+      !
+      !
       login on-success log
-      !         
-      !         
+      !
+      !
       subscriber templating
-      !         
-      pae       
-      !         
-      !         
+      !
+      pae
+      !
+      !
       crypto pki trustpoint SLA-TrustPoint
        enrollment pkcs12
        revocation-check crl
        hash sha256
-      !         
+      !
       crypto pki trustpoint TP-self-signed-2143900133
        enrollment selfsigned
        subject-name cn=IOS-Self-Signed-Certificate-2143900133
        revocation-check none
        rsakeypair TP-self-signed-2143900133
        hash sha256
-      !         
-      !         
+      !
+      !
       crypto pki certificate chain SLA-TrustPoint
        certificate ca 01
-        30820321 30820209 A0030201 02020101 300D0609 2A864886 F70D0101 0B050030 
-        32310E30 0C060355 040A1305 43697363 6F312030 1E060355 04031317 43697363 
-        6F204C69 63656E73 696E6720 526F6F74 20434130 1E170D31 33303533 30313934 
-        3834375A 170D3338 30353330 31393438 34375A30 32310E30 0C060355 040A1305 
-        43697363 6F312030 1E060355 04031317 43697363 6F204C69 63656E73 696E6720 
-        526F6F74 20434130 82012230 0D06092A 864886F7 0D010101 05000382 010F0030 
-        82010A02 82010100 A6BCBD96 131E05F7 145EA72C 2CD686E6 17222EA1 F1EFF64D 
-        CBB4C798 212AA147 C655D8D7 9471380D 8711441E 1AAF071A 9CAE6388 8A38E520 
-        1C394D78 462EF239 C659F715 B98C0A59 5BBB5CBD 0CFEBEA3 700A8BF7 D8F256EE 
-        4AA4E80D DB6FD1C9 60B1FD18 FFC69C96 6FA68957 A2617DE7 104FDC5F EA2956AC 
-        7390A3EB 2B5436AD C847A2C5 DAB553EB 69A9A535 58E9F3E3 C0BD23CF 58BD7188 
-        68E69491 20F320E7 948E71D7 AE3BCC84 F10684C7 4BC8E00F 539BA42B 42C68BB7 
-        C7479096 B4CB2D62 EA2F505D C7B062A4 6811D95B E8250FC4 5D5D5FB8 8F27D191 
-        C55F0D76 61F9A4CD 3D992327 A8BB03BD 4E6D7069 7CBADF8B DF5F4368 95135E44 
-        DFC7C6CF 04DD7FD1 02030100 01A34230 40300E06 03551D0F 0101FF04 04030201 
-        06300F06 03551D13 0101FF04 05300301 01FF301D 0603551D 0E041604 1449DC85 
-        4B3D31E5 1B3E6A17 606AF333 3D3B4C73 E8300D06 092A8648 86F70D01 010B0500 
-        03820101 00507F24 D3932A66 86025D9F E838AE5C 6D4DF6B0 49631C78 240DA905 
-        604EDCDE FF4FED2B 77FC460E CD636FDB DD44681E 3A5673AB 9093D3B1 6C9E3D8B 
-        D98987BF E40CBD9E 1AECA0C2 2189BB5C 8FA85686 CD98B646 5575B146 8DFC66A8 
-        467A3DF4 4D565700 6ADF0F0D CF835015 3C04FF7C 21E878AC 11BA9CD2 55A9232C 
-        7CA7B7E6 C1AF74F6 152E99B7 B1FCF9BB E973DE7F 5BDDEB86 C71E3B49 1765308B 
-        5FB0DA06 B92AFE7F 494E8A9E 07B85737 F3A58BE1 1A48A229 C37C1E69 39F08678 
-        80DDCD16 D6BACECA EEBC7CF9 8428787B 35202CDC 60E4616A B623CDBD 230E3AFB 
-        418616A9 4093E049 4D10AB75 27E86F73 932E35B5 8862FDAE 0275156F 719BB2F0 
+        30820321 30820209 A0030201 02020101 300D0609 2A864886 F70D0101 0B050030
+        32310E30 0C060355 040A1305 43697363 6F312030 1E060355 04031317 43697363
+        6F204C69 63656E73 696E6720 526F6F74 20434130 1E170D31 33303533 30313934
+        3834375A 170D3338 30353330 31393438 34375A30 32310E30 0C060355 040A1305
+        43697363 6F312030 1E060355 04031317 43697363 6F204C69 63656E73 696E6720
+        526F6F74 20434130 82012230 0D06092A 864886F7 0D010101 05000382 010F0030
+        82010A02 82010100 A6BCBD96 131E05F7 145EA72C 2CD686E6 17222EA1 F1EFF64D
+        CBB4C798 212AA147 C655D8D7 9471380D 8711441E 1AAF071A 9CAE6388 8A38E520
+        1C394D78 462EF239 C659F715 B98C0A59 5BBB5CBD 0CFEBEA3 700A8BF7 D8F256EE
+        4AA4E80D DB6FD1C9 60B1FD18 FFC69C96 6FA68957 A2617DE7 104FDC5F EA2956AC
+        7390A3EB 2B5436AD C847A2C5 DAB553EB 69A9A535 58E9F3E3 C0BD23CF 58BD7188
+        68E69491 20F320E7 948E71D7 AE3BCC84 F10684C7 4BC8E00F 539BA42B 42C68BB7
+        C7479096 B4CB2D62 EA2F505D C7B062A4 6811D95B E8250FC4 5D5D5FB8 8F27D191
+        C55F0D76 61F9A4CD 3D992327 A8BB03BD 4E6D7069 7CBADF8B DF5F4368 95135E44
+        DFC7C6CF 04DD7FD1 02030100 01A34230 40300E06 03551D0F 0101FF04 04030201
+        06300F06 03551D13 0101FF04 05300301 01FF301D 0603551D 0E041604 1449DC85
+        4B3D31E5 1B3E6A17 606AF333 3D3B4C73 E8300D06 092A8648 86F70D01 010B0500
+        03820101 00507F24 D3932A66 86025D9F E838AE5C 6D4DF6B0 49631C78 240DA905
+        604EDCDE FF4FED2B 77FC460E CD636FDB DD44681E 3A5673AB 9093D3B1 6C9E3D8B
+        D98987BF E40CBD9E 1AECA0C2 2189BB5C 8FA85686 CD98B646 5575B146 8DFC66A8
+        467A3DF4 4D565700 6ADF0F0D CF835015 3C04FF7C 21E878AC 11BA9CD2 55A9232C
+        7CA7B7E6 C1AF74F6 152E99B7 B1FCF9BB E973DE7F 5BDDEB86 C71E3B49 1765308B
+        5FB0DA06 B92AFE7F 494E8A9E 07B85737 F3A58BE1 1A48A229 C37C1E69 39F08678
+        80DDCD16 D6BACECA EEBC7CF9 8428787B 35202CDC 60E4616A B623CDBD 230E3AFB
+        418616A9 4093E049 4D10AB75 27E86F73 932E35B5 8862FDAE 0275156F 719BB2F0
         D697DF7F 28
               quit
       crypto pki certificate chain TP-self-signed-2143900133
        certificate self-signed 01
-        30820330 30820218 A0030201 02020101 300D0609 2A864886 F70D0101 0B050030 
-        31312F30 2D060355 04030C26 494F532D 53656C66 2D536967 6E65642D 43657274 
-        69666963 6174652D 32313433 39303031 3333301E 170D3235 30393033 31343136 
-        30355A17 0D333530 39303331 34313630 355A3031 312F302D 06035504 030C2649 
-        4F532D53 656C662D 5369676E 65642D43 65727469 66696361 74652D32 31343339 
-        30303133 33308201 22300D06 092A8648 86F70D01 01010500 0382010F 00308201 
-        0A028201 010089F6 23FFFA9D 14B87C4B 4AB133B5 B8C9EF27 00C1CD06 75F625E7 
-        B86E451C 821308E7 35C35B5F B5F71D1C FBDA5967 543A1024 3863B40E 129FBD08 
-        EF72915B 0D15ACB0 2E847913 856D8D67 2273B2B7 93F61AA4 237C8B4F 65E288D5 
-        8D89B76C E5DDE45B DA1552FF 129CD587 A1E125EC A909378D E89A231D CE9FFE45 
-        BAD08DA4 798A7971 D0E3F94D A70EBB80 EC57E483 505F9E2B DDBF8FF0 65973587 
-        C83AA68A BC5CD162 718F5928 9B76DDFD 4444F24B D5E8186C 2F4DFB01 1DA1BCE3 
-        32EBF413 B562E785 DE025D89 CE9FBD80 E3070099 4E336012 14E24D4E 02F11353 
-        87012240 F21E7773 55DEA3A0 335C75CA FCC860C5 ACD23AFE 26E45690 2231A5F7 
-        8BAE1D3C 7B690203 010001A3 53305130 1D060355 1D0E0416 04145B72 79CABCF2 
-        4E49043B A321FFF3 BB8AE725 5872301F 0603551D 23041830 1680145B 7279CABC 
-        F24E4904 3BA321FF F3BB8AE7 25587230 0F060355 1D130101 FF040530 030101FF 
-        300D0609 2A864886 F70D0101 0B050003 82010100 3B06640A 205AC0FE EA4BDA88 
-        070FF97B B10F3D4A 7945193C 50401FA0 2D6405E2 A9A861F6 86ADF876 EF84DD71 
-        8F9B5EF8 674FAB17 19278F95 3A794036 4946D0DF 1EF64812 9D59743C B3E5E398 
-        152BDAAF E7FA5B42 B0A6BC73 9CE856C4 59778F07 6EAE68BC 14E8DC52 7BFE23EF 
-        451B010F FE070EB4 5F9D050E 25AE1242 684A4746 F0A37E42 55163CE9 9108A0EC 
-        2BB388DB 61ECD68D 6D1CA21B 82786BD7 85D176D3 C90B5D5E 8EBFEEC9 3FC2DACB 
-        5F7A967F 417A2E65 025F2967 0BD041B3 8EECF4F6 D7172D7A A15CBA59 D83BAF17 
-        F928C6D0 A3649770 5DE73AED 95AAAF3C F955AB6F 654F6DDD 51DE7225 CB178139 
+        30820330 30820218 A0030201 02020101 300D0609 2A864886 F70D0101 0B050030
+        31312F30 2D060355 04030C26 494F532D 53656C66 2D536967 6E65642D 43657274
+        69666963 6174652D 32313433 39303031 3333301E 170D3235 30393033 31343136
+        30355A17 0D333530 39303331 34313630 355A3031 312F302D 06035504 030C2649
+        4F532D53 656C662D 5369676E 65642D43 65727469 66696361 74652D32 31343339
+        30303133 33308201 22300D06 092A8648 86F70D01 01010500 0382010F 00308201
+        0A028201 010089F6 23FFFA9D 14B87C4B 4AB133B5 B8C9EF27 00C1CD06 75F625E7
+        B86E451C 821308E7 35C35B5F B5F71D1C FBDA5967 543A1024 3863B40E 129FBD08
+        EF72915B 0D15ACB0 2E847913 856D8D67 2273B2B7 93F61AA4 237C8B4F 65E288D5
+        8D89B76C E5DDE45B DA1552FF 129CD587 A1E125EC A909378D E89A231D CE9FFE45
+        BAD08DA4 798A7971 D0E3F94D A70EBB80 EC57E483 505F9E2B DDBF8FF0 65973587
+        C83AA68A BC5CD162 718F5928 9B76DDFD 4444F24B D5E8186C 2F4DFB01 1DA1BCE3
+        32EBF413 B562E785 DE025D89 CE9FBD80 E3070099 4E336012 14E24D4E 02F11353
+        87012240 F21E7773 55DEA3A0 335C75CA FCC860C5 ACD23AFE 26E45690 2231A5F7
+        8BAE1D3C 7B690203 010001A3 53305130 1D060355 1D0E0416 04145B72 79CABCF2
+        4E49043B A321FFF3 BB8AE725 5872301F 0603551D 23041830 1680145B 7279CABC
+        F24E4904 3BA321FF F3BB8AE7 25587230 0F060355 1D130101 FF040530 030101FF
+        300D0609 2A864886 F70D0101 0B050003 82010100 3B06640A 205AC0FE EA4BDA88
+        070FF97B B10F3D4A 7945193C 50401FA0 2D6405E2 A9A861F6 86ADF876 EF84DD71
+        8F9B5EF8 674FAB17 19278F95 3A794036 4946D0DF 1EF64812 9D59743C B3E5E398
+        152BDAAF E7FA5B42 B0A6BC73 9CE856C4 59778F07 6EAE68BC 14E8DC52 7BFE23EF
+        451B010F FE070EB4 5F9D050E 25AE1242 684A4746 F0A37E42 55163CE9 9108A0EC
+        2BB388DB 61ECD68D 6D1CA21B 82786BD7 85D176D3 C90B5D5E 8EBFEEC9 3FC2DACB
+        5F7A967F 417A2E65 025F2967 0BD041B3 8EECF4F6 D7172D7A A15CBA59 D83BAF17
+        F928C6D0 A3649770 5DE73AED 95AAAF3C F955AB6F 654F6DDD 51DE7225 CB178139
         74042356 6976EBB8 6CFD01D7 5726917A 10F13A9A
               quit
-      !         
-      !         
+      !
+      !
       license udi pid C8000V sn 9TYB2BVCTEE
       memory free low-watermark processor 201711
       diagnostic bootup level minimal
-      !         
+      !
       remote-management
-      !         
-      !         
-      !         
+      !
+      !
+      !
       username ansible privilege 15 secret 9 $9$OWTrVj9K1pvYMk$Yk8C08a96MaHS0NXKemcdtr.wm50p/TyyseSUfKS1/w
       username cisco privilege 15 secret 9 $9$4kwcYNnc81prn.$7/DIFt5FkKa2H.2b8TwzW5G9Y9x8ZW3gU/fVB9eLaDk
-      !         
+      !
       redundancy
-      !         
-      !         
-      !         
-      !         
-      !         
-      !         
-      !         
-      !         
+      !
+      !
+      !
+      !
+      !
+      !
+      !
+      !
       interface GigabitEthernet1
        ip address dhcp
        negotiation auto
-      !         
+      !
       interface GigabitEthernet2
        no ip address
-       shutdown 
+       shutdown
        negotiation auto
-      !         
+      !
       interface GigabitEthernet3
        no ip address
-       shutdown 
+       shutdown
        negotiation auto
-      !         
+      !
       interface GigabitEthernet4
        no ip address
-       shutdown 
+       shutdown
        negotiation auto
-      !         
+      !
       ip forward-protocol nd
-      !         
+      !
       ip http server
       ip http authentication local
       ip http secure-server
       ip ssh bulk-mode 131072
-      !         
-      !         
-      !         
-      !         
-      !         
-      !         
-      !         
+      !
+      !
+      !
+      !
+      !
+      !
+      !
       control-plane
-      !         
-      !         
+      !
+      !
       line con 0
        stopbits 1
       line aux 0
       line vty 0 4
        transport input ssh
-      !         
-      !         
-      !         
-      !         
-      !         
-      !         
-      !         
-      restconf  
-      end       
+      !
+      !
+      !
+      !
+      !
+      !
+      !
+      restconf
+      end
     cpu_limit: null
     cpus: null
     data_volume: null

--- a/tests/integration/labs/multi.yaml
+++ b/tests/integration/labs/multi.yaml
@@ -1,3 +1,4 @@
+---
 annotations: []
 nodes:
   - boot_disk_size: null

--- a/tests/unit/mock/procenv.py
+++ b/tests/unit/mock/procenv.py
@@ -17,7 +17,6 @@ from io import BytesIO, StringIO
 from unittest import TestCase
 
 from ansible.module_utils._text import to_bytes
-from ansible.module_utils.six import PY3
 
 
 @contextmanager
@@ -28,11 +27,8 @@ def swap_stdin_and_argv(stdin_data="", argv_data=tuple()):
     real_stdin = sys.stdin
     real_argv = sys.argv
 
-    if PY3:
-        fake_stream = StringIO(stdin_data)
-        fake_stream.buffer = BytesIO(to_bytes(stdin_data))
-    else:
-        fake_stream = BytesIO(to_bytes(stdin_data))
+    fake_stream = StringIO(stdin_data)
+    fake_stream.buffer = BytesIO(to_bytes(stdin_data))
 
     try:
         sys.stdin = fake_stream
@@ -50,15 +46,10 @@ def swap_stdout():
     context manager that temporarily replaces stdout for tests that need to verify output
     """
     old_stdout = sys.stdout
-
-    if PY3:
-        fake_stream = StringIO()
-    else:
-        fake_stream = BytesIO()
+    fake_stream = StringIO()
 
     try:
         sys.stdout = fake_stream
-
         yield fake_stream
     finally:
         sys.stdout = old_stdout

--- a/tests/unit/mock/yaml_helper.py
+++ b/tests/unit/mock/yaml_helper.py
@@ -5,8 +5,6 @@ __metaclass__ = type
 import io
 
 import yaml
-
-from ansible.module_utils.six import PY3
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.parsing.yaml.loader import AnsibleLoader
 
@@ -22,18 +20,12 @@ class YamlTestUtils(object):
         return AnsibleLoader(stream)
 
     def _dump_stream(self, obj, stream, dumper=None):
-        """Dump to a py2-unicode or py3-string stream."""
-        if PY3:
-            return yaml.dump(obj, stream, Dumper=dumper)
-        else:
-            return yaml.dump(obj, stream, Dumper=dumper, encoding=None)
+        """Dump to a py3-string stream."""
+        return yaml.dump(obj, stream, Dumper=dumper)
 
     def _dump_string(self, obj, dumper=None):
-        """Dump to a py2-unicode or py3-string"""
-        if PY3:
-            return yaml.dump(obj, Dumper=dumper)
-        else:
-            return yaml.dump(obj, Dumper=dumper, encoding=None)
+        """Dump to a py3-string"""
+        return yaml.dump(obj, Dumper=dumper)
 
     def _dump_load_cycle(self, obj):
         # Each pass though a dump or load revs the 'generation'
@@ -90,22 +82,9 @@ class YamlTestUtils(object):
         stream_obj_from_stream = io.StringIO()
         stream_obj_from_string = io.StringIO()
 
-        if PY3:
-            yaml.dump(obj_from_stream, stream_obj_from_stream, Dumper=AnsibleDumper)
-            yaml.dump(obj_from_stream, stream_obj_from_string, Dumper=AnsibleDumper)
-        else:
-            yaml.dump(
-                obj_from_stream,
-                stream_obj_from_stream,
-                Dumper=AnsibleDumper,
-                encoding=None,
-            )
-            yaml.dump(
-                obj_from_stream,
-                stream_obj_from_string,
-                Dumper=AnsibleDumper,
-                encoding=None,
-            )
+
+        yaml.dump(obj_from_stream, stream_obj_from_stream, Dumper=AnsibleDumper)
+        yaml.dump(obj_from_stream, stream_obj_from_string, Dumper=AnsibleDumper)
 
         yaml_string_stream_obj_from_stream = stream_obj_from_stream.getvalue()
         yaml_string_stream_obj_from_string = stream_obj_from_string.getvalue()
@@ -113,16 +92,8 @@ class YamlTestUtils(object):
         stream_obj_from_stream.seek(0)
         stream_obj_from_string.seek(0)
 
-        if PY3:
-            yaml_string_obj_from_stream = yaml.dump(obj_from_stream, Dumper=AnsibleDumper)
-            yaml_string_obj_from_string = yaml.dump(obj_from_string, Dumper=AnsibleDumper)
-        else:
-            yaml_string_obj_from_stream = yaml.dump(
-                obj_from_stream, Dumper=AnsibleDumper, encoding=None
-            )
-            yaml_string_obj_from_string = yaml.dump(
-                obj_from_string, Dumper=AnsibleDumper, encoding=None
-            )
+        yaml_string_obj_from_stream = yaml.dump(obj_from_stream, Dumper=AnsibleDumper)
+        yaml_string_obj_from_string = yaml.dump(obj_from_string, Dumper=AnsibleDumper)
 
         assert yaml_string == yaml_string_obj_from_stream
         assert yaml_string == yaml_string_obj_from_stream == yaml_string_obj_from_string

--- a/tests/unit/mock/yaml_helper.py
+++ b/tests/unit/mock/yaml_helper.py
@@ -5,6 +5,7 @@ __metaclass__ = type
 import io
 
 import yaml
+
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.parsing.yaml.loader import AnsibleLoader
 
@@ -81,7 +82,6 @@ class YamlTestUtils(object):
 
         stream_obj_from_stream = io.StringIO()
         stream_obj_from_string = io.StringIO()
-
 
         yaml.dump(obj_from_stream, stream_obj_from_stream, Dumper=AnsibleDumper)
         yaml.dump(obj_from_stream, stream_obj_from_string, Dumper=AnsibleDumper)


### PR DESCRIPTION
## Summary
Fix sanity and lint issues for Ansible devel/2.20, modernize Python 3 imports/types, update tooling, and align tests/mocks. Adds a changelog fragment and minor CI workflow tweaks.
Handles imports of passlib_or_crypt to do_encrypt for ansible-core 2.20 or above 

## Highlights
- Fixes devel/2.20 sanity and lint across plugins and utils
- Normalizes Python 3 imports/types; removes deprecated patterns
- Updates pre-commit hooks; temporarily disables collection prep
- Minor CI workflow adjustments for integration job
- Adds changelog fragment for these fixes
- Updates tests/mocks to match code changes

## Affected areas
- CI/Tooling: `.github/workflows/integration-simple.yml`, `.pre-commit-config.yaml`
- Changelog: `changelogs/fragments/fix_sanity_220_devel.yaml`
- Action/Connection plugins: `plugins/action/{network.py,telnet.py}`, `plugins/connection/{httpapi.py,netconf.py,network_cli.py}`
- Module utils/parsers: `plugins/module_utils/network/common/{facts.py,network.py,parsing.py,utils.py}`, `plugins/module_utils/utils/data.py`, `plugins/plugin_utils/{parse_cli.py,parse_cli_textfsm.py,parse_xml.py,type5_pw.py}`
- Modules: `plugins/modules/restconf_config.py`
- Tests: `tests/integration/labs/multi.yaml`, `tests/unit/mock/{procenv.py,yaml_helper.py}`