### PR TITLE
Avoid imports deprecated in ansible-core 2.20

### DIFF
--- a/changelogs/fragments/720-ansible-core-2.20.yml
+++ b/changelogs/fragments/720-ansible-core-2.20.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Avoid legacy imports deprecated in ansible-core 2.20 (https://github.com/ansible-collections/ansible.netcommon/pull/720)."

--- a/plugins/action/net_get.py
+++ b/plugins/action/net_get.py
@@ -13,7 +13,7 @@ import re
 import uuid
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
 from ansible.plugins.action import ActionBase

--- a/plugins/action/net_put.py
+++ b/plugins/action/net_put.py
@@ -12,7 +12,7 @@ import os
 import uuid
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
 from ansible.plugins.action import ActionBase

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -13,7 +13,7 @@ import re
 import time
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.display import Display

--- a/plugins/action/network_resource.py
+++ b/plugins/action/network_resource.py
@@ -28,7 +28,7 @@ except ImportError:
     HAS_YAML = False
 
 from ansible.errors import AnsibleActionFail, AnsibleError
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.utils.display import Display
 
 from ansible_collections.ansible.netcommon.plugins.action.network import (

--- a/plugins/action/telnet.py
+++ b/plugins/action/telnet.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 from time import sleep
 
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -187,7 +187,7 @@ options:
 from io import BytesIO
 
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.six.moves import cPickle
 from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 from ansible.module_utils.urls import open_url

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -218,8 +218,8 @@ import re
 import socket
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError, AnsibleFileNotFound
-from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.display import Display
 

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -218,7 +218,7 @@ import re
 import socket
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError, AnsibleFileNotFound
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.basic import missing_required_lib
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.display import Display

--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -154,7 +154,7 @@ import logging
 import os
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE, BOOLEANS_TRUE
 from ansible.module_utils.six.moves import cPickle

--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -154,8 +154,8 @@ import logging
 import os
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
-from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE, BOOLEANS_TRUE
 from ansible.module_utils.six.moves import cPickle
 from ansible.playbook.play_context import PlayContext

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -312,7 +312,7 @@ from functools import wraps
 from io import BytesIO
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.six.moves import cPickle
 from ansible.playbook.play_context import PlayContext

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -312,8 +312,8 @@ from functools import wraps
 from io import BytesIO
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
-from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.six.moves import cPickle
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import cache_loader, cliconf_loader, connection_loader, terminal_loader

--- a/plugins/connection/persistent.py
+++ b/plugins/connection/persistent.py
@@ -20,7 +20,7 @@ extends_documentation_fragment:
 - ansible.netcommon.connection_persistent
 """
 from ansible.executor.task_executor import start_connection
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection as SocketConnection
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.display import Display

--- a/plugins/httpapi/restconf.py
+++ b/plugins/httpapi/restconf.py
@@ -27,7 +27,7 @@ options:
 
 import json
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 

--- a/plugins/module_utils/network/common/config.py
+++ b/plugins/module_utils/network/common/config.py
@@ -16,7 +16,7 @@ __metaclass__ = type
 import hashlib
 import re
 
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.module_utils.six.moves import zip
 
 

--- a/plugins/module_utils/network/common/facts/facts.py
+++ b/plugins/module_utils/network/common/facts/facts.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 The facts base class
 this contains methods common to all facts subsets
 """
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.network import (
     get_resource_connection,

--- a/plugins/module_utils/network/common/netconf.py
+++ b/plugins/module_utils/network/common/netconf.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 import sys
 
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 
 

--- a/plugins/module_utils/network/common/network.py
+++ b/plugins/module_utils/network/common/network.py
@@ -17,8 +17,8 @@ __metaclass__ = type
 import json
 import traceback
 
-from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.netconf import (

--- a/plugins/module_utils/network/common/network.py
+++ b/plugins/module_utils/network/common/network.py
@@ -17,7 +17,7 @@ __metaclass__ = type
 import json
 import traceback
 
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection, ConnectionError
 

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -30,6 +30,7 @@ from ansible.module_utils import basic
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.parsing.convert_bool import boolean
 
+
 try:
     from collections.abc import Mapping
 except ImportError:

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -27,9 +27,14 @@ from io import StringIO
 from itertools import chain
 
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_text
-from ansible.module_utils.common._collections_compat import Mapping
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.parsing.convert_bool import boolean
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    # Python 2.7 fallback for ansible-core 2.16:
+    from ansible.module_utils.common._collections_compat import Mapping
 
 
 string_types = (str,)

--- a/plugins/module_utils/network/grpc/grpc.py
+++ b/plugins/module_utils/network/grpc/grpc.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 import json
 import re
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection
 
 

--- a/plugins/module_utils/network/netconf/netconf.py
+++ b/plugins/module_utils/network/netconf/netconf.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     from xml.etree.ElementTree import fromstring, tostring
 
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.netconf import (

--- a/plugins/module_utils/utils/data.py
+++ b/plugins/module_utils/utils/data.py
@@ -15,8 +15,8 @@ Utils functions for handle data formatting
 import json
 import sys
 
-from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.common.text.converters import to_native
 
 
 string_types = (str,)

--- a/plugins/module_utils/utils/data.py
+++ b/plugins/module_utils/utils/data.py
@@ -15,7 +15,7 @@ Utils functions for handle data formatting
 import json
 import sys
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import missing_required_lib
 
 

--- a/plugins/modules/cli_command.py
+++ b/plugins/modules/cli_command.py
@@ -145,7 +145,7 @@ json:
     }
 """
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection, ConnectionError
 

--- a/plugins/modules/cli_command.py
+++ b/plugins/modules/cli_command.py
@@ -145,8 +145,8 @@ json:
     }
 """
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 
 

--- a/plugins/modules/cli_config.py
+++ b/plugins/modules/cli_config.py
@@ -226,7 +226,7 @@ backup_path:
 
 import json
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
 

--- a/plugins/modules/cli_config.py
+++ b/plugins/modules/cli_config.py
@@ -226,8 +226,8 @@ backup_path:
 
 import json
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection
 
 

--- a/plugins/modules/cli_restore.py
+++ b/plugins/modules/cli_restore.py
@@ -75,8 +75,8 @@ EXAMPLES = """
 RETURN = """
 """
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 
 

--- a/plugins/modules/cli_restore.py
+++ b/plugins/modules/cli_restore.py
@@ -75,7 +75,7 @@ EXAMPLES = """
 RETURN = """
 """
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection, ConnectionError
 

--- a/plugins/modules/grpc_config.py
+++ b/plugins/modules/grpc_config.py
@@ -138,8 +138,8 @@ diff:
 """
 import json
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import ConnectionError
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (

--- a/plugins/modules/grpc_config.py
+++ b/plugins/modules/grpc_config.py
@@ -138,7 +138,7 @@ diff:
 """
 import json
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import ConnectionError
 

--- a/plugins/modules/grpc_get.py
+++ b/plugins/modules/grpc_get.py
@@ -125,8 +125,8 @@ output:
 """
 import json
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import ConnectionError
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list

--- a/plugins/modules/grpc_get.py
+++ b/plugins/modules/grpc_get.py
@@ -125,7 +125,7 @@ output:
 """
 import json
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import ConnectionError
 

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -403,8 +403,8 @@ diff:
 
 """
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.netconf.netconf import (

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -403,7 +403,7 @@ diff:
 
 """
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection, ConnectionError
 

--- a/plugins/modules/netconf_get.py
+++ b/plugins/modules/netconf_get.py
@@ -271,8 +271,8 @@ try:
 except ImportError:
     from xml.etree.ElementTree import tostring
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.netconf import (
     remove_namespaces,

--- a/plugins/modules/netconf_get.py
+++ b/plugins/modules/netconf_get.py
@@ -271,7 +271,7 @@ try:
 except ImportError:
     from xml.etree.ElementTree import tostring
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.netconf import (

--- a/plugins/modules/restconf_config.py
+++ b/plugins/modules/restconf_config.py
@@ -122,7 +122,7 @@ running:
 
 import json
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import ConnectionError
 

--- a/plugins/modules/restconf_config.py
+++ b/plugins/modules/restconf_config.py
@@ -122,8 +122,8 @@ running:
 
 import json
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import ConnectionError
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (

--- a/plugins/modules/restconf_get.py
+++ b/plugins/modules/restconf_get.py
@@ -83,7 +83,7 @@ response:
 
 """
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import ConnectionError
 

--- a/plugins/modules/restconf_get.py
+++ b/plugins/modules/restconf_get.py
@@ -83,8 +83,8 @@ response:
 
 """
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import ConnectionError
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.restconf import restconf

--- a/plugins/netconf/default.py
+++ b/plugins/netconf/default.py
@@ -29,7 +29,7 @@ options:
 """
 import json
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.netconf_base import NetconfBase
 

--- a/plugins/plugin_utils/cliconf_base.py
+++ b/plugins/plugin_utils/cliconf_base.py
@@ -10,10 +10,10 @@ __metaclass__ = type
 
 from abc import abstractmethod
 from functools import wraps
+from collections.abc import Mapping
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
-from ansible.module_utils._text import to_bytes, to_text
-from ansible.module_utils.common._collections_compat import Mapping
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 # Needed to satisfy PluginLoader's required_base_class
 from ansible.plugins.cliconf import CliconfBase as CliconfBaseBase

--- a/plugins/plugin_utils/cliconf_base.py
+++ b/plugins/plugin_utils/cliconf_base.py
@@ -9,8 +9,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from abc import abstractmethod
-from functools import wraps
 from collections.abc import Mapping
+from functools import wraps
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
 from ansible.module_utils.common.text.converters import to_bytes, to_text

--- a/plugins/plugin_utils/netconf_base.py
+++ b/plugins/plugin_utils/netconf_base.py
@@ -12,8 +12,8 @@ from abc import abstractmethod
 from functools import wraps
 
 from ansible.errors import AnsibleError
-from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.common.text.converters import to_native
 
 # Needed to satisfy PluginLoader's required_base_class
 from ansible.plugins.netconf import NetconfBase as NetconfBaseBase

--- a/plugins/plugin_utils/netconf_base.py
+++ b/plugins/plugin_utils/netconf_base.py
@@ -12,7 +12,7 @@ from abc import abstractmethod
 from functools import wraps
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import missing_required_lib
 
 # Needed to satisfy PluginLoader's required_base_class
@@ -62,9 +62,9 @@ class NetconfBase(NetconfBaseBase):
         :class:`TerminalBase` plugins are byte strings.  This is because of
         how close to the underlying platform these plugins operate.  Remember
         to mark literal strings as byte string (``b"string"``) and to use
-        :func:`~ansible.module_utils._text.to_bytes` and
-        :func:`~ansible.module_utils._text.to_text` to avoid unexpected
-        problems.
+        :func:`~ansible.module_utils.common.text.converters.to_bytes` and
+        :func:`~ansible.module_utils.common.text.converters.to_text` to avoid
+        unexpected problems.
 
         List of supported rpc's:
             :get: Retrieves running configuration and device state information

--- a/plugins/plugin_utils/parse_cli.py
+++ b/plugins/plugin_utils/parse_cli.py
@@ -15,6 +15,7 @@ __metaclass__ = type
 
 import os
 import re
+
 from collections.abc import Mapping
 
 from ansible.errors import AnsibleFilterError

--- a/plugins/plugin_utils/parse_cli.py
+++ b/plugins/plugin_utils/parse_cli.py
@@ -15,10 +15,10 @@ __metaclass__ = type
 
 import os
 import re
+from collections.abc import Mapping
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils._text import to_native
-from ansible.module_utils.common._collections_compat import Mapping
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import Template
 

--- a/plugins/plugin_utils/parse_cli_textfsm.py
+++ b/plugins/plugin_utils/parse_cli_textfsm.py
@@ -16,7 +16,7 @@ __metaclass__ = type
 import os
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 try:

--- a/plugins/plugin_utils/parse_xml.py
+++ b/plugins/plugin_utils/parse_xml.py
@@ -15,12 +15,12 @@ __metaclass__ = type
 
 import os
 import traceback
+from collections.abc import Mapping
 
 from xml.etree.ElementTree import fromstring
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils._text import to_native
-from ansible.module_utils.common._collections_compat import Mapping
+from ansible.module_utils.common.text.converters import to_native
 from ansible.utils.display import Display
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import Template

--- a/plugins/plugin_utils/parse_xml.py
+++ b/plugins/plugin_utils/parse_xml.py
@@ -15,8 +15,8 @@ __metaclass__ = type
 
 import os
 import traceback
-from collections.abc import Mapping
 
+from collections.abc import Mapping
 from xml.etree.ElementTree import fromstring
 
 from ansible.errors import AnsibleFilterError

--- a/plugins/plugin_utils/terminal_base.py
+++ b/plugins/plugin_utils/terminal_base.py
@@ -22,9 +22,9 @@ class TerminalBase(TerminalBaseBase):
         :class:`TerminalBase` plugins are byte strings.  This is because of
         how close to the underlying platform these plugins operate.  Remember
         to mark literal strings as byte string (``b"string"``) and to use
-        :func:`~ansible.module_utils._text.to_bytes` and
-        :func:`~ansible.module_utils._text.to_text` to avoid unexpected
-        problems.
+        :func:`~ansible.module_utils.common.text.converters.to_bytes` and
+        :func:`~ansible.module_utils.common.text.converters.to_text` to avoid
+        unexpected problems.
     """
 
     #: compiled bytes regular expressions as stdout

--- a/plugins/plugin_utils/type5_pw.py
+++ b/plugins/plugin_utils/type5_pw.py
@@ -16,7 +16,7 @@ __metaclass__ = type
 import string
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 try:

--- a/plugins/sub_plugins/cli_parser/content_templates_parser.py
+++ b/plugins/sub_plugins/cli_parser/content_templates_parser.py
@@ -32,7 +32,7 @@ EXAMPLES = """
   register: ios_bgp_health
 
 """
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.cli_parser import CliParserBase
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.cli_parser.cli_parsertemplate import (

--- a/plugins/sub_plugins/cli_parser/native_parser.py
+++ b/plugins/sub_plugins/cli_parser/native_parser.py
@@ -42,7 +42,7 @@ EXAMPLES = r"""
   register: nxos_native_text
 """
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.cli_parser import CliParserBase
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.cli_parser.cli_parsertemplate import (

--- a/plugins/sub_plugins/cli_parser/ntc_templates_parser.py
+++ b/plugins/sub_plugins/cli_parser/ntc_templates_parser.py
@@ -41,7 +41,7 @@ EXAMPLES = r"""
   register: nxos_ntc_templates_text
 """
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import missing_required_lib
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.cli_parser import CliParserBase
 

--- a/plugins/sub_plugins/cli_parser/ntc_templates_parser.py
+++ b/plugins/sub_plugins/cli_parser/ntc_templates_parser.py
@@ -41,8 +41,8 @@ EXAMPLES = r"""
   register: nxos_ntc_templates_text
 """
 
-from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.cli_parser import CliParserBase
 
 

--- a/plugins/sub_plugins/cli_parser/pyats_parser.py
+++ b/plugins/sub_plugins/cli_parser/pyats_parser.py
@@ -41,7 +41,7 @@ EXAMPLES = r"""
   register: nxos_pyats_text
 """
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import missing_required_lib
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.cli_parser import CliParserBase
 

--- a/plugins/sub_plugins/cli_parser/pyats_parser.py
+++ b/plugins/sub_plugins/cli_parser/pyats_parser.py
@@ -41,8 +41,8 @@ EXAMPLES = r"""
   register: nxos_pyats_text
 """
 
-from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.cli_parser import CliParserBase
 
 


### PR DESCRIPTION
##### SUMMARY
When using this collection with ansible-core devel, you get several deprecation messages:
```
[DEPRECATION WARNING]: Importing 'to_bytes' from 'ansible.module_utils._text' is deprecated. This feature will be removed from ansible-core version 2.24. Use ansible.module_utils.common.text.converters instead.
[DEPRECATION WARNING]: Importing 'to_text' from 'ansible.module_utils._text' is deprecated. This feature will be removed from ansible-core version 2.24. Use ansible.module_utils.common.text.converters instead.
[DEPRECATION WARNING]: Importing 'to_native' from 'ansible.module_utils._text' is deprecated. This feature will be removed from ansible-core version 2.24. Use ansible.module_utils.common.text.converters instead.
[DEPRECATION WARNING]: The `ansible.module_utils.common._collections_compat` module is deprecated. This feature will be removed from ansible-core version 2.24. Use `collections.abc` from the Python standard library instead.
```
These are mostly very easy to replace, except for `_collections_compat` in module_utils, since this collection still supports ansible-core 2.16. But also there a simple `try/except` solves it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
various
