### PR TITLE
Prep release 8.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,20 @@ Ansible Netcommon Collection Release Notes
 
 .. contents:: Topics
 
+v8.4.0
+======
+
+Release Summary
+---------------
+
+Re-released 8.3.1 with features added in the last release.
+
+Minor Changes
+-------------
+
+- Option to use libssh as transport while using netconf, is added.
+- The ssh-python module is needed, which will ensure libssh as transport for netconf operations. When use_libssh is enabled.
+
 v8.3.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -924,3 +924,13 @@ releases:
     fragments:
       - libsssh-fix.yml
     release_date: "2026-02-04"
+  8.4.0:
+    changes:
+      minor_changes:
+        - Option to use libssh as transport while using netconf, is added.
+        - The ssh-python module is needed, which will ensure libssh as transport for
+          netconf operations. When use_libssh is enabled.
+      release_summary: Re-released 8.3.1 with features added in the last release.
+    fragments:
+      - re_release_832.yaml
+    release_date: "2026-02-04"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -24,4 +24,4 @@ build_ignore:
   - sonar-project.properties
   - codecov.yml
   - .github/
-version: 8.3.1
+version: 8.4.0


### PR DESCRIPTION
re-release for the previous release for 8.3.0 was wrongly tagged as 8.3.1 in Github/ galaxy.