### PR TITLE
network_cli: add terminal_stdout_re_behaviour and terminal_stderr_re_behaviour (merge / override)

### DIFF
--- a/changelogs/fragments/network_cli_terminal_std_re_behaviour.yml
+++ b/changelogs/fragments/network_cli_terminal_std_re_behaviour.yml
@@ -1,0 +1,9 @@
+---
+minor_changes:
+  - network_cli - Add ``terminal_stdout_re_behaviour`` and ``terminal_stderr_re_behaviour``
+    options (choices ``merge``, ``override``; default ``override``). When ``override``,
+    ``terminal_stdout_re`` / ``terminal_stderr_re`` patterns replace the terminal plugin
+    defaults. When ``merge``, user patterns are added to the terminal plugin defaults
+    (for example platform-specific patterns from the network OS terminal plugin like
+    ``ios``). Variables ``ansible_terminal_stdout_re_behaviour``,
+    ``ansible_terminal_stderr_re_behaviour``.

--- a/docs/ansible.netcommon.network_cli_connection.rst
+++ b/docs/ansible.netcommon.network_cli_connection.rst
@@ -595,7 +595,29 @@ Parameters
                                 <div>var: ansible_terminal_stderr_re</div>
                     </td>
                 <td>
-                        <div>This option provides the regex pattern and optional flags to match the error string from the received response chunk. This option accepts <code>pattern</code> and <code>flags</code> keys. The value of <code>pattern</code> is a python regex pattern to match the response and the value of <code>flags</code> is the value accepted by <em>flags</em> argument of <em>re.compile</em> python method to control the way regex is matched with the response, for example <em>&#x27;re.I&#x27;</em>.</div>
+                        <div>This option provides the regex pattern and optional flags to match the error string from the received response chunk. When <em>terminal_stderr_re_behaviour</em> is <em>override</em>, these patterns replace the terminal plugin defaults. When <em>merge</em>, they are added to the terminal defaults. This option accepts <code>pattern</code> and <code>flags</code> keys. The value of <code>pattern</code> is a python regex pattern to match the response and the value of <code>flags</code> is the value accepted by <em>flags</em> argument of <em>re.compile</em> python method to control the way regex is matched with the response, for example <em>&#x27;re.I&#x27;</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>terminal_stderr_re_behaviour</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>merge</li>
+                                    <li><div style="color: blue"><b>override</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                    <td>
+                                <div>var: ansible_terminal_stderr_re_behaviour</div>
+                    </td>
+                <td>
+                        <div>When <em>override</em>, <code>terminal_stderr_re</code> patterns replace the terminal plugin defaults. When <em>merge</em>, they are added to the terminal plugin defaults.</div>
                 </td>
             </tr>
             <tr>
@@ -614,7 +636,29 @@ Parameters
                                 <div>var: ansible_terminal_stdout_re</div>
                     </td>
                 <td>
-                        <div>A single regex pattern or a sequence of patterns along with optional flags to match the command prompt from the received response chunk. This option accepts <code>pattern</code> and <code>flags</code> keys. The value of <code>pattern</code> is a python regex pattern to match the response and the value of <code>flags</code> is the value accepted by <em>flags</em> argument of <em>re.compile</em> python method to control the way regex is matched with the response, for example <em>&#x27;re.I&#x27;</em>.</div>
+                        <div>A single regex pattern or a sequence of patterns along with optional flags to match the command prompt from the received response chunk. When <em>terminal_stdout_re_behaviour</em> is <em>override</em>, these patterns replace the terminal plugin defaults. When <em>merge</em>, they are added to the terminal defaults. This option accepts <code>pattern</code> and <code>flags</code> keys. The value of <code>pattern</code> is a python regex pattern to match the response and the value of <code>flags</code> is the value accepted by <em>flags</em> argument of <em>re.compile</em> python method to control the way regex is matched with the response, for example <em>&#x27;re.I&#x27;</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>terminal_stdout_re_behaviour</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>merge</li>
+                                    <li><div style="color: blue"><b>override</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                    <td>
+                                <div>var: ansible_terminal_stdout_re_behaviour</div>
+                    </td>
+                <td>
+                        <div>When <em>override</em>, <code>terminal_stdout_re</code> patterns replace the terminal plugin defaults. When <em>merge</em>, they are added to the terminal plugin defaults.</div>
                 </td>
             </tr>
     </table>

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -181,25 +181,48 @@ options:
     elements: dict
     description:
     - A single regex pattern or a sequence of patterns along with optional flags to
-      match the command prompt from the received response chunk. This option accepts
-      C(pattern) and C(flags) keys. The value of C(pattern) is a python regex pattern
-      to match the response and the value of C(flags) is the value accepted by I(flags)
-      argument of I(re.compile) python method to control the way regex is matched
-      with the response, for example I('re.I').
+      match the command prompt from the received response chunk. When
+      I(terminal_stdout_re_behaviour) is I(override), these patterns replace the
+      terminal plugin defaults. When I(merge), they are added to the terminal
+      defaults. This option accepts C(pattern) and C(flags) keys. The value of
+      C(pattern) is a python regex pattern to match the response and the value of
+      C(flags) is the value accepted by I(flags) argument of I(re.compile) python
+      method to control the way regex is matched with the response, for example
+      I('re.I').
     vars:
     - name: ansible_terminal_stdout_re
+  terminal_stdout_re_behaviour:
+    type: str
+    choices: [merge, override]
+    default: override
+    description:
+    - When I(override), C(terminal_stdout_re) patterns replace the terminal plugin
+      defaults. When I(merge), they are added to the terminal plugin defaults.
+    vars:
+    - name: ansible_terminal_stdout_re_behaviour
   terminal_stderr_re:
     type: list
     elements: dict
     description:
     - This option provides the regex pattern and optional flags to match the error
-      string from the received response chunk. This option accepts C(pattern) and
-      C(flags) keys. The value of C(pattern) is a python regex pattern to match the
-      response and the value of C(flags) is the value accepted by I(flags) argument
-      of I(re.compile) python method to control the way regex is matched with the
-      response, for example I('re.I').
+      string from the received response chunk. When I(terminal_stderr_re_behaviour)
+      is I(override), these patterns replace the terminal plugin defaults. When
+      I(merge), they are added to the terminal defaults. This option accepts
+      C(pattern) and C(flags) keys. The value of C(pattern) is a python regex
+      pattern to match the response and the value of C(flags) is the value accepted
+      by I(flags) argument of I(re.compile) python method to control the way
+      regex is matched with the response, for example I('re.I').
     vars:
     - name: ansible_terminal_stderr_re
+  terminal_stderr_re_behaviour:
+    type: str
+    choices: [merge, override]
+    default: override
+    description:
+    - When I(override), C(terminal_stderr_re) patterns replace the terminal plugin
+      defaults. When I(merge), they are added to the terminal plugin defaults.
+    vars:
+    - name: ansible_terminal_stderr_re_behaviour
   terminal_initial_prompt:
     type: list
     elements: string
@@ -1745,9 +1768,17 @@ class Connection(NetworkConnectionBase):
 
     def _get_terminal_std_re(self, option):
         terminal_std_option = self.get_option(option)
-        terminal_std_re = []
+        behaviour_option = option + "_behaviour"
+        behaviour = self.get_option(behaviour_option)
 
         if terminal_std_option:
+            if behaviour == "merge":
+                # Start with terminal plugin defaults, then append user patterns
+                terminal_std_re = list(getattr(self._terminal, option))
+            else:
+                # override: use only user-provided patterns
+                terminal_std_re = []
+
             for item in terminal_std_option:
                 if "pattern" not in item:
                     raise AnsibleConnectionFailure(
@@ -1760,8 +1791,7 @@ class Connection(NetworkConnectionBase):
                     flag = getattr(re, flag.split(".")[1])
                 terminal_std_re.append(re.compile(pattern, flag))
         else:
-            # To maintain backward compatibility
-            terminal_std_re = getattr(self._terminal, option)
+            terminal_std_re = list(getattr(self._terminal, option))
 
         return terminal_std_re
 

--- a/tests/unit/plugins/connection/test_network_cli.py
+++ b/tests/unit/plugins/connection/test_network_cli.py
@@ -308,7 +308,8 @@ def test_network_cli_exec_command_value_error_falls_back_to_bytes(conn):
 
 
 # ---- _get_terminal_std_re ----
-def test_network_cli_get_terminal_std_re_from_option(conn):
+def test_network_cli_get_terminal_std_re_from_option_override_default(conn):
+    """By default (override), user-provided patterns replace terminal defaults."""
     conn.set_options(
         direct={
             "ssh_type": "libssh",
@@ -321,6 +322,24 @@ def test_network_cli_get_terminal_std_re_from_option(conn):
 
     assert len(result) == 1
     assert result[0].pattern == rb"hostname#"
+
+
+def test_network_cli_get_terminal_std_re_from_option_merge_behaviour(conn):
+    """With terminal_stdout_re_behaviour=merge, user patterns are added to defaults."""
+    conn.set_options(
+        direct={
+            "ssh_type": "libssh",
+            "terminal_stdout_re": [{"pattern": r"hostname#"}],
+            "terminal_stdout_re_behaviour": "merge",
+        }
+    )
+    conn._terminal = _make_terminal_mock()
+
+    result = conn._get_terminal_std_re("terminal_stdout_re")
+
+    assert len(result) == 2
+    assert result[0].pattern == rb"device#"
+    assert result[1].pattern == rb"hostname#"
 
 
 def test_network_cli_get_terminal_std_re_missing_pattern_raises(conn):
@@ -354,6 +373,7 @@ def test_network_cli_get_terminal_std_re_with_flags(conn):
 
 
 def test_network_cli_get_terminal_std_re_fallback_to_terminal(conn):
+    """When option is not set, only terminal plugin defaults are used."""
     conn.set_options(direct={"ssh_type": "libssh"})
     terminal = _make_terminal_mock()
     terminal.terminal_stdout_re = [re.compile(rb"fallback#")]
@@ -362,6 +382,42 @@ def test_network_cli_get_terminal_std_re_fallback_to_terminal(conn):
     result = conn._get_terminal_std_re("terminal_stdout_re")
 
     assert result == [re.compile(rb"fallback#")]
+
+
+def test_network_cli_get_terminal_std_re_stderr_override_default(conn):
+    """By default, terminal_stderr_re overrides terminal plugin patterns."""
+    conn.set_options(
+        direct={
+            "ssh_type": "libssh",
+            "terminal_stderr_re": [{"pattern": r"custom error"}],
+        }
+    )
+    terminal = _make_terminal_mock(terminal_stderr_re=[re.compile(rb"% Error")])
+    conn._terminal = terminal
+
+    result = conn._get_terminal_std_re("terminal_stderr_re")
+
+    assert len(result) == 1
+    assert result[0].pattern == rb"custom error"
+
+
+def test_network_cli_get_terminal_std_re_stderr_merge_behaviour(conn):
+    """With terminal_stderr_re_behaviour=merge, user patterns are added to defaults."""
+    conn.set_options(
+        direct={
+            "ssh_type": "libssh",
+            "terminal_stderr_re": [{"pattern": r"custom error"}],
+            "terminal_stderr_re_behaviour": "merge",
+        }
+    )
+    terminal = _make_terminal_mock(terminal_stderr_re=[re.compile(rb"% Error")])
+    conn._terminal = terminal
+
+    result = conn._get_terminal_std_re("terminal_stderr_re")
+
+    assert len(result) == 2
+    assert result[0].pattern == rb"% Error"
+    assert result[1].pattern == rb"custom error"
 
 
 # ---- _strip, _sanitize, _find_prompt, _find_error ----


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds two new connection options so users can choose whether terminal_stdout_re and terminal_stderr_re override or merge with the terminal plugin’s default patterns (e.g. IOS terminal_stderr_re in cisco.ios).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### PROBLEM
Setting ansible_terminal_stderr_re (or terminal_stdout_re) in inventory or playbook fully replaced the terminal plugin defaults. That forced users to re-specify all platform-specific patterns (e.g. from ios.py) if they only wanted to add a few custom error patterns, which was brittle and easy to get wrong.

##### HOW IT WORKss
New options

- terminal_stdout_re_behaviour: merge | override (default: override)
- terminal_stderr_re_behaviour: merge | override (default: override)

Behaviour

- override (default): Unchanged: only the patterns from terminal_stdout_re / terminal_stderr_re are used; terminal plugin defaults are not used.
- merge: Terminal plugin defaults are used first, then the user-provided patterns are appended.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netowrk_cli

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
vars:
  ansible_terminal_stderr_re_behaviour: merge
  ansible_terminal_stderr_re:
    - pattern: "my custom error"
```
