### PR TITLE
Fix AttributeError in direct execution on ansible-core 2.21+

### DIFF
--- a/changelogs/fragments/fix-dexec-parsed-module-arg-221.yaml
+++ b/changelogs/fragments/fix-dexec-parsed-module-arg-221.yaml
@@ -1,9 +1,5 @@
 ---
 bugfixes:
-  - network action plugin - Initialize ``_PARSED_MODULE_ARGS`` in
-    ``DirectExecutionModule._load_params`` to fix a crash on ansible-core 2.21+.
-    The global was added in ansible-core PR #86771 and is read by
-    ``_return_formatted()`` before ``_record_module_result()`` is called.
-    Since direct execution skips stdin loading, the global stayed ``None``,
-    causing ``fail_json()`` and ``exit_json()`` to raise ``AttributeError``
-    instead of returning the module result.
+  - network action plugin - initialize ``_PARSED_MODULE_ARGS`` in
+    ``DirectExecutionModule._load_params`` to avoid ``AttributeError``
+    on ansible-core 2.21+ when ``fail_json`` or ``exit_json`` is called.

--- a/changelogs/fragments/fix-dexec-parsed-module-arg-221.yaml
+++ b/changelogs/fragments/fix-dexec-parsed-module-arg-221.yaml
@@ -1,0 +1,9 @@
+---
+bugfixes:
+  - network action plugin - Initialize ``_PARSED_MODULE_ARGS`` in
+    ``DirectExecutionModule._load_params`` to fix a crash on ansible-core 2.21+.
+    The global was added in ansible-core PR #86771 and is read by
+    ``_return_formatted()`` before ``_record_module_result()`` is called.
+    Since direct execution skips stdin loading, the global stayed ``None``,
+    causing ``fail_json()`` and ``exit_json()`` to raise ``AttributeError``
+    instead of returning the module result.

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -338,6 +338,7 @@ class ActionModule(_ActionModule):
                     host,
                 )
                 from ansible.module_utils import basic as _basic
+
                 if getattr(_basic, "_PARSED_MODULE_ARGS", None) is None:
                     _basic._PARSED_MODULE_ARGS = {}
 

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -337,7 +337,9 @@ class ActionModule(_ActionModule):
                     ),
                     host,
                 )
-                pass
+                from ansible.module_utils import basic as _basic
+                if getattr(_basic, "_PARSED_MODULE_ARGS", None) is None:
+                    _basic._PARSED_MODULE_ARGS = {}
 
             def _record_module_result(self, o):
                 """Override new 2.19.1+ hook to directly record the module result as a module attr."""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ansible-core 2.21 (PR [#86771](https://github.com/ansible/ansible/pull/86771)) introduced `_PARSED_MODULE_ARGS`, a module-level
global in `basic.py` that `_return_formatted()` reads before calling
`_record_module_result()`. In direct execution mode, `DirectExecutionModule._load_params()`
is a no-op — it skips stdin loading and lets params be set externally. The side
effect of that skip is that _PARSED_MODULE_ARGS never gets initialized and stays
`None`, so any call to fail_json() or exit_json() crashes with:

    AttributeError: 'NoneType' object has no attribute 'get'

Fix initializes `_PARSED_MODULE_ARGS = {}` inside `_load_params` when it is `None`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
