### PR TITLE
Add transcript recording to network_cli connection plugin

### DIFF
--- a/changelogs/fragments/transcript-recording-network-cli.yaml
+++ b/changelogs/fragments/transcript-recording-network-cli.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - network_cli - Add transcript recording support to capture command/response pairs exchanged over SSH sessions. Enable via ``ANSIBLE_NETWORK_CLI_RECORD=1`` environment variable. Recordings are written as JSONL files to ``/tmp/transcript-recordings/`` (configurable via ``ANSIBLE_NETWORK_CLI_RECORD_PATH``). Useful for generating offline test fixtures for CISSHGO-based integration testing.

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -960,7 +960,13 @@ class Connection(NetworkConnectionBase):
         # Transcript recording for CISSHGO fixture generation.
         # Enable via ANSIBLE_NETWORK_CLI_RECORD=1 to capture every
         # command/response pair exchanged over the SSH channel.
-        self._transcript_recording = bool(os.environ.get("ANSIBLE_NETWORK_CLI_RECORD"))
+        # NOTE: Log accumulates in memory for the connection lifetime and
+        # flushes to disk on close(). Each entry is ~200-600 bytes; a
+        # 10,000-command playbook uses ~6MB. For very long-running sessions,
+        # consider splitting into shorter plays.
+        self._transcript_recording = os.environ.get(
+            "ANSIBLE_NETWORK_CLI_RECORD", ""
+        ).strip().lower() in ("1", "true", "yes")
         self._transcript_log = [] if self._transcript_recording else None
         self._transcript_output_dir = os.environ.get(
             "ANSIBLE_NETWORK_CLI_RECORD_PATH", "/tmp/transcript-recordings"
@@ -1275,6 +1281,15 @@ class Connection(NetworkConnectionBase):
 
             self.queue_message("vvvv", "ssh connection has completed successfully")
 
+            if self._transcript_recording:
+                self.queue_message(
+                    "warning",
+                    "Transcript recording is ENABLED. Raw commands and responses "
+                    "will be written to %s. Sensitive data (passwords, keys, IPs, "
+                    "hostnames) MUST be sanitized before committing fixtures to "
+                    "any repository." % self._transcript_output_dir,
+                )
+
         return self
 
     def _on_become(self, become_pass=None):
@@ -1338,11 +1353,13 @@ class Connection(NetworkConnectionBase):
         """Write recorded command/response pairs to a JSONL file."""
         host = self._play_context.remote_addr
         port = self._play_context.port or 22
-        filename = "%s_%s.jsonl" % (host, port)
+        safe_host = re.sub(r"[^\w.\-]", "_", host)
+        filename = "%s_%s.jsonl" % (safe_host, port)
         try:
-            os.makedirs(self._transcript_output_dir, exist_ok=True)
+            os.makedirs(self._transcript_output_dir, mode=0o700, exist_ok=True)
             filepath = os.path.join(self._transcript_output_dir, filename)
-            with open(filepath, "a") as f:
+            fd = os.open(filepath, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+            with os.fdopen(fd, "a") as f:
                 for entry in self._transcript_log:
                     f.write(json.dumps(entry) + "\n")
             self.queue_message(

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -957,6 +957,15 @@ class Connection(NetworkConnectionBase):
         # Managing prompt context
         self._check_prompt = False
 
+        # Transcript recording for CISSHGO fixture generation.
+        # Enable via ANSIBLE_NETWORK_CLI_RECORD=1 to capture every
+        # command/response pair exchanged over the SSH channel.
+        self._transcript_recording = bool(os.environ.get("ANSIBLE_NETWORK_CLI_RECORD"))
+        self._transcript_log = [] if self._transcript_recording else None
+        self._transcript_output_dir = os.environ.get(
+            "ANSIBLE_NETWORK_CLI_RECORD_PATH", "/tmp/transcript-recordings"
+        )
+
         self._task_uuid = to_text(kwargs.get("task_uuid", ""))
         self._ssh_type_conn = None
         self._ssh_type = None
@@ -1307,6 +1316,9 @@ class Connection(NetworkConnectionBase):
         """
         Close the active connection to the device
         """
+        if self._transcript_recording and self._transcript_log:
+            self._flush_transcript_log()
+
         # only close the connection if its connected.
         if self._connected:
             self.queue_message("debug", "closing ssh connection to device")
@@ -1321,6 +1333,27 @@ class Connection(NetworkConnectionBase):
                 self._ssh_type_conn = None
                 self.queue_message("debug", "ssh connection has been closed successfully")
         super(Connection, self).close()
+
+    def _flush_transcript_log(self):
+        """Write recorded command/response pairs to a JSONL file."""
+        host = self._play_context.remote_addr
+        port = self._play_context.port or 22
+        filename = "%s_%s.jsonl" % (host, port)
+        try:
+            os.makedirs(self._transcript_output_dir, exist_ok=True)
+            filepath = os.path.join(self._transcript_output_dir, filename)
+            with open(filepath, "a") as f:
+                for entry in self._transcript_log:
+                    f.write(json.dumps(entry) + "\n")
+            self.queue_message(
+                "log",
+                "Transcript recorded: %d entries written to %s" % (len(self._transcript_log), filepath),
+            )
+        except (IOError, OSError) as exc:
+            self.queue_message(
+                "warning",
+                "Failed to write transcript log to %s: %s" % (self._transcript_output_dir, exc),
+            )
 
     def _read_post_command_prompt_match(self):
         time.sleep(self.get_option("persistent_buffer_read_timeout"))
@@ -1593,6 +1626,15 @@ class Connection(NetworkConnectionBase):
                 strip_prompt,
             )
             response = to_text(response, errors="surrogate_then_replace")
+
+            if self._transcript_recording:
+                self._transcript_log.append(
+                    {
+                        "command": to_text(command, errors="surrogate_then_replace"),
+                        "response": response,
+                        "timestamp": time.time(),
+                    }
+                )
 
             if (not prompt) and (self._single_user_mode):
                 if self._needs_cache_invalidation(command):

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -1364,7 +1364,8 @@ class Connection(NetworkConnectionBase):
                     f.write(json.dumps(entry) + "\n")
             self.queue_message(
                 "log",
-                "Transcript recorded: %d entries written to %s" % (len(self._transcript_log), filepath),
+                "Transcript recorded: %d entries written to %s"
+                % (len(self._transcript_log), filepath),
             )
         except (IOError, OSError) as exc:
             self.queue_message(

--- a/tests/unit/plugins/connection/test_network_cli.py
+++ b/tests/unit/plugins/connection/test_network_cli.py
@@ -895,3 +895,216 @@ def test_paramiko_shim_var_options_ignores_unknown_keys():
         paramiko_conn.get_option("ssh_type")
     with pytest.raises(KeyError):
         paramiko_conn.get_option("nonexistent_option")
+
+
+# --- transcript recording tests (PR #772) ---
+
+
+def test_transcript_recording_disabled_by_default(conn):
+    """Recording is off when ANSIBLE_NETWORK_CLI_RECORD is not set."""
+    assert conn._transcript_recording is False
+    assert conn._transcript_log is None
+
+
+def test_transcript_recording_enabled_by_env(monkeypatch):
+    """Setting ANSIBLE_NETWORK_CLI_RECORD=1 turns on recording."""
+    monkeypatch.setenv("ANSIBLE_NETWORK_CLI_RECORD", "1")
+    pc = PlayContext()
+    pc.network_os = "fakeos"
+    monkeypatch.setattr(terminal_loader, "get", lambda *a, **kw: MagicMock())
+    conn = connection_loader.get("ansible.netcommon.network_cli", pc, "/dev/null")
+    assert conn._transcript_recording is True
+    assert conn._transcript_log == []
+
+
+def test_transcript_recording_custom_output_dir(monkeypatch):
+    """ANSIBLE_NETWORK_CLI_RECORD_PATH overrides the default output dir."""
+    monkeypatch.setenv("ANSIBLE_NETWORK_CLI_RECORD", "1")
+    monkeypatch.setenv("ANSIBLE_NETWORK_CLI_RECORD_PATH", "/custom/path")
+    pc = PlayContext()
+    pc.network_os = "fakeos"
+    monkeypatch.setattr(terminal_loader, "get", lambda *a, **kw: MagicMock())
+    conn = connection_loader.get("ansible.netcommon.network_cli", pc, "/dev/null")
+    assert conn._transcript_output_dir == "/custom/path"
+
+
+def test_transcript_recording_default_output_dir(monkeypatch):
+    """Default output dir is /tmp/transcript-recordings."""
+    monkeypatch.setenv("ANSIBLE_NETWORK_CLI_RECORD", "1")
+    monkeypatch.delenv("ANSIBLE_NETWORK_CLI_RECORD_PATH", raising=False)
+    pc = PlayContext()
+    pc.network_os = "fakeos"
+    monkeypatch.setattr(terminal_loader, "get", lambda *a, **kw: MagicMock())
+    conn = connection_loader.get("ansible.netcommon.network_cli", pc, "/dev/null")
+    assert conn._transcript_output_dir == "/tmp/transcript-recordings"
+
+
+def test_send_appends_to_transcript_log(conn):
+    """When recording is on, send() appends command/response to the log."""
+    conn._transcript_recording = True
+    conn._transcript_log = []
+    conn._connected = True
+    conn._ssh_shell = MagicMock()
+    conn._history = []
+    conn._single_user_mode = False
+
+    mock_terminal = _make_terminal_mock()
+    conn._terminal = mock_terminal
+
+    # Mock receive to return a known response
+    with patch.object(conn, "receive", return_value=b"hostname box1\n"):
+        with patch.object(conn, "update_cli_prompt_context"):
+            conn.send(b"show running-config | section ^hostname")
+
+    assert len(conn._transcript_log) == 1
+    entry = conn._transcript_log[0]
+    assert entry["command"] == "show running-config | section ^hostname"
+    assert entry["response"] == "hostname box1\n"
+    assert "timestamp" in entry
+    assert isinstance(entry["timestamp"], float)
+
+
+def test_send_does_not_record_when_disabled(conn):
+    """When recording is off, send() does not create a log entry."""
+    conn._transcript_recording = False
+    conn._transcript_log = None
+    conn._connected = True
+    conn._ssh_shell = MagicMock()
+    conn._history = []
+    conn._single_user_mode = False
+
+    mock_terminal = _make_terminal_mock()
+    conn._terminal = mock_terminal
+
+    with patch.object(conn, "receive", return_value=b"hostname box1\n"):
+        with patch.object(conn, "update_cli_prompt_context"):
+            conn.send(b"show running-config | section ^hostname")
+
+    assert conn._transcript_log is None
+
+
+def test_flush_transcript_log_writes_jsonl(conn, tmp_path):
+    """_flush_transcript_log writes each entry as a JSON line."""
+    conn._transcript_recording = True
+    conn._transcript_log = [
+        {"command": "terminal length 0", "response": "", "timestamp": 1714300000.0},
+        {"command": "show version", "response": "Cisco IOS XE\n", "timestamp": 1714300001.0},
+    ]
+    conn._transcript_output_dir = str(tmp_path)
+    conn._play_context.remote_addr = "192.168.1.1"
+    conn._play_context.port = 22
+
+    conn._flush_transcript_log()
+
+    outfile = tmp_path / "192.168.1.1_22.jsonl"
+    assert outfile.exists()
+    lines = outfile.read_text().strip().split("\n")
+    assert len(lines) == 2
+    assert json.loads(lines[0])["command"] == "terminal length 0"
+    assert json.loads(lines[1])["command"] == "show version"
+    assert json.loads(lines[1])["response"] == "Cisco IOS XE\n"
+
+
+def test_flush_transcript_log_appends(conn, tmp_path):
+    """Successive flushes append to the same file, not overwrite."""
+    conn._transcript_recording = True
+    conn._transcript_output_dir = str(tmp_path)
+    conn._play_context.remote_addr = "10.0.0.1"
+    conn._play_context.port = 830
+
+    # First flush
+    conn._transcript_log = [
+        {"command": "cmd1", "response": "resp1", "timestamp": 1.0},
+    ]
+    conn._flush_transcript_log()
+
+    # Second flush
+    conn._transcript_log = [
+        {"command": "cmd2", "response": "resp2", "timestamp": 2.0},
+    ]
+    conn._flush_transcript_log()
+
+    outfile = tmp_path / "10.0.0.1_830.jsonl"
+    lines = outfile.read_text().strip().split("\n")
+    assert len(lines) == 2
+    assert json.loads(lines[0])["command"] == "cmd1"
+    assert json.loads(lines[1])["command"] == "cmd2"
+
+
+def test_flush_transcript_log_default_port(conn, tmp_path):
+    """When port is None, default to 22 in the filename."""
+    conn._transcript_recording = True
+    conn._transcript_log = [
+        {"command": "show clock", "response": "12:00:00", "timestamp": 1.0},
+    ]
+    conn._transcript_output_dir = str(tmp_path)
+    conn._play_context.remote_addr = "router1"
+    conn._play_context.port = None
+
+    conn._flush_transcript_log()
+
+    outfile = tmp_path / "router1_22.jsonl"
+    assert outfile.exists()
+
+
+def test_flush_transcript_log_handles_write_error(conn):
+    """_flush_transcript_log emits a warning on write failure, does not raise."""
+    conn._transcript_recording = True
+    conn._transcript_log = [
+        {"command": "show clock", "response": "12:00:00", "timestamp": 1.0},
+    ]
+    conn._transcript_output_dir = "/nonexistent/deeply/nested/path"
+    conn._play_context.remote_addr = "host1"
+    conn._play_context.port = 22
+
+    # Patch os.makedirs to raise so we test the error handling path
+    with patch("os.makedirs", side_effect=OSError("Permission denied")):
+        # Should not raise
+        conn._flush_transcript_log()
+
+
+def test_close_flushes_transcript(conn):
+    """close() calls _flush_transcript_log when recording is active with entries."""
+    conn._transcript_recording = True
+    conn._transcript_log = [
+        {"command": "cmd", "response": "resp", "timestamp": 1.0},
+    ]
+    conn._connected = True
+    conn._ssh_shell = MagicMock()
+    conn._terminal = _make_terminal_mock()
+    conn._ssh_type_conn = MagicMock()
+
+    with patch.object(conn, "_flush_transcript_log") as mock_flush:
+        conn.close()
+
+    mock_flush.assert_called_once()
+
+
+def test_close_skips_flush_when_log_empty(conn):
+    """close() does not flush when the transcript log is empty."""
+    conn._transcript_recording = True
+    conn._transcript_log = []
+    conn._connected = True
+    conn._ssh_shell = MagicMock()
+    conn._terminal = _make_terminal_mock()
+    conn._ssh_type_conn = MagicMock()
+
+    with patch.object(conn, "_flush_transcript_log") as mock_flush:
+        conn.close()
+
+    mock_flush.assert_not_called()
+
+
+def test_close_skips_flush_when_recording_disabled(conn):
+    """close() does not flush when recording was never enabled."""
+    conn._transcript_recording = False
+    conn._transcript_log = None
+    conn._connected = True
+    conn._ssh_shell = MagicMock()
+    conn._terminal = _make_terminal_mock()
+    conn._ssh_type_conn = MagicMock()
+
+    with patch.object(conn, "_flush_transcript_log") as mock_flush:
+        conn.close()
+
+    mock_flush.assert_not_called()

--- a/tests/unit/plugins/connection/test_network_cli.py
+++ b/tests/unit/plugins/connection/test_network_cli.py
@@ -1108,3 +1108,87 @@ def test_close_skips_flush_when_recording_disabled(conn):
         conn.close()
 
     mock_flush.assert_not_called()
+
+
+@pytest.mark.parametrize("env_value", ["0", "false", "False", "FALSE", "no", "No", ""])
+def test_transcript_recording_disabled_for_falsy_values(monkeypatch, env_value):
+    """Setting ANSIBLE_NETWORK_CLI_RECORD to '0', 'false', 'no', or '' does NOT enable recording."""
+    monkeypatch.setenv("ANSIBLE_NETWORK_CLI_RECORD", env_value)
+    pc = PlayContext()
+    pc.network_os = "fakeos"
+    monkeypatch.setattr(terminal_loader, "get", lambda *a, **kw: MagicMock())
+    conn = connection_loader.get("ansible.netcommon.network_cli", pc, "/dev/null")
+    assert conn._transcript_recording is False
+    assert conn._transcript_log is None
+
+
+@pytest.mark.parametrize("env_value", ["1", "true", "True", "TRUE", "yes", "Yes", "YES"])
+def test_transcript_recording_enabled_for_truthy_values(monkeypatch, env_value):
+    """Setting ANSIBLE_NETWORK_CLI_RECORD to '1', 'true', or 'yes' enables recording."""
+    monkeypatch.setenv("ANSIBLE_NETWORK_CLI_RECORD", env_value)
+    pc = PlayContext()
+    pc.network_os = "fakeos"
+    monkeypatch.setattr(terminal_loader, "get", lambda *a, **kw: MagicMock())
+    conn = connection_loader.get("ansible.netcommon.network_cli", pc, "/dev/null")
+    assert conn._transcript_recording is True
+    assert conn._transcript_log == []
+
+
+def test_flush_transcript_log_sanitizes_hostname(conn, tmp_path):
+    """Path traversal characters in hostname are sanitized in the output filename."""
+    conn._transcript_recording = True
+    conn._transcript_log = [
+        {"command": "show clock", "response": "12:00:00", "timestamp": 1.0},
+    ]
+    conn._transcript_output_dir = str(tmp_path)
+    conn._play_context.remote_addr = "../../etc/cron.d/evil"
+    conn._play_context.port = 22
+
+    conn._flush_transcript_log()
+
+    # The traversal characters (/ and spaces) should be replaced with
+    # underscores so the file stays inside the output directory.
+    # Dots and hyphens are preserved by the regex [^\w.\-]
+    expected = tmp_path / ".._.._etc_cron.d_evil_22.jsonl"
+    assert expected.exists()
+    # Verify no file was written outside the output directory
+    import pathlib
+
+    for f in pathlib.Path(str(tmp_path)).rglob("*.jsonl"):
+        assert str(f).startswith(str(tmp_path))
+
+
+def test_flush_transcript_log_preserves_normal_hostnames(conn, tmp_path):
+    """Normal hostnames (IPs, FQDNs, hyphens) are not altered by sanitization."""
+    conn._transcript_recording = True
+    conn._transcript_log = [
+        {"command": "show clock", "response": "12:00:00", "timestamp": 1.0},
+    ]
+    conn._transcript_output_dir = str(tmp_path)
+    conn._play_context.remote_addr = "router-core.lab.local"
+    conn._play_context.port = 22
+
+    conn._flush_transcript_log()
+
+    outfile = tmp_path / "router-core.lab.local_22.jsonl"
+    assert outfile.exists()
+
+
+def test_flush_transcript_log_restrictive_permissions(conn, tmp_path):
+    """Output directory is created with 0o700 and files with 0o600."""
+    output_dir = tmp_path / "recordings"
+    conn._transcript_recording = True
+    conn._transcript_log = [
+        {"command": "show clock", "response": "12:00:00", "timestamp": 1.0},
+    ]
+    conn._transcript_output_dir = str(output_dir)
+    conn._play_context.remote_addr = "10.0.0.1"
+    conn._play_context.port = 22
+
+    conn._flush_transcript_log()
+
+    assert output_dir.exists()
+    assert oct(output_dir.stat().st_mode & 0o777) == oct(0o700)
+    outfile = output_dir / "10.0.0.1_22.jsonl"
+    assert outfile.exists()
+    assert oct(outfile.stat().st_mode & 0o777) == oct(0o600)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds opt-in transcript recording to the network_cli connection plugin, capturing every command/response pair exchanged over SSH sessions. This enables automated generation of offline test fixtures for CISSHGO-based integration testing.
Three surgical additions to network_cli.py:

__init__() — initializes recording state when ANSIBLE_NETWORK_CLI_RECORD=1 is set
send() — appends each command/response pair to an in-memory log
close() — flushes the log to a JSONL file at <host>_<port>.jsonl
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

#### Usage:
ANSIBLE_NETWORK_CLI_RECORD=1 \
ANSIBLE_NETWORK_CLI_RECORD_PATH=/tmp/recordings \
ansible-playbook site.yml -i inventory

Output format (JSONL):
json{"command": "show running-config | section ^hostname", "response": "hostname box1\n", "timestamp": 1714300000.123}
{"command": "configure terminal", "response": "", "timestamp": 1714300001.456}
Recording is disabled by default and has zero overhead when not enabled. Output path defaults to /tmp/transcript-recordings/ and is configurable via ANSIBLE_NETWORK_CLI_RECORD_PATH.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

Assisted By : Claude Code(Sonnet 4.6)
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
