### PR TITLE
Fix vlan_parser IndexError on empty list input

### DIFF
--- a/changelogs/fragments/fix-vlan-parser-empty-list.yaml
+++ b/changelogs/fragments/fix-vlan-parser-empty-list.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vlan_parser - Fix ``IndexError`` when an empty list is passed as input by returning
+    an empty list instead of crashing (https://github.com/ansible-collections/ansible.netcommon/issues/302).

--- a/plugins/plugin_utils/vlan_parser.py
+++ b/plugins/plugin_utils/vlan_parser.py
@@ -35,6 +35,9 @@ def vlan_parser(data, first_line_len=48, other_line_len=44):
     # Sort and remove duplicates
     sorted_list = sorted(set(data))
 
+    if not sorted_list:
+        return []
+
     if sorted_list[0] < 1 or sorted_list[-1] > 4094:
         _raise_error("Valid VLAN range is 1-4094")
 

--- a/tests/unit/plugins/filter/test_vlan_parser.py
+++ b/tests/unit/plugins/filter/test_vlan_parser.py
@@ -73,6 +73,10 @@ class TestVlanParser(TestCase):
             "1-3",
         )
 
+    def test_vlan_parser_empty_list(self):
+        result = vlan_parser([])
+        self.assertEqual(result, [])
+
     def test_vlan_parser_fail_wrong_data(self):
         data = "13"
         args = [data]


### PR DESCRIPTION
## Summary

- Fixes `IndexError: list index out of range` when passing an empty list (`[]`) to the `vlan_parser` filter, by returning an empty list early before the VLAN range validation.
- Adds a unit test covering the empty list input case.
- Adds a changelog fragment for the bugfix.

Fixes #302

## Test plan

- [x] New unit test `test_vlan_parser_empty_list` passes
- [x] All existing `vlan_parser` tests still pass (both `test_vlan_parser.py` and `test_network.py::TestVlanParser`)