### PR TITLE
Clarify that netcommon.net_ping is ICMP ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Name | Description
 [ansible.netcommon.grpc_config](https://github.com/ansible-collections/ansible.netcommon/blob/main/docs/ansible.netcommon.grpc_config_module.rst)|Fetch configuration/state data from gRPC enabled target hosts.
 [ansible.netcommon.grpc_get](https://github.com/ansible-collections/ansible.netcommon/blob/main/docs/ansible.netcommon.grpc_get_module.rst)|Fetch configuration/state data from gRPC enabled target hosts.
 [ansible.netcommon.net_get](https://github.com/ansible-collections/ansible.netcommon/blob/main/docs/ansible.netcommon.net_get_module.rst)|Copy a file from a network device to Ansible Controller
-[ansible.netcommon.net_ping](https://github.com/ansible-collections/ansible.netcommon/blob/main/docs/ansible.netcommon.net_ping_module.rst)|Tests reachability using ping from a network device
+[ansible.netcommon.net_ping](https://github.com/ansible-collections/ansible.netcommon/blob/main/docs/ansible.netcommon.net_ping_module.rst)|Tests reachability using ICMP ping from a network device
 [ansible.netcommon.net_put](https://github.com/ansible-collections/ansible.netcommon/blob/main/docs/ansible.netcommon.net_put_module.rst)|Copy a file from Ansible Controller to a network device
 [ansible.netcommon.netconf_config](https://github.com/ansible-collections/ansible.netcommon/blob/main/docs/ansible.netcommon.netconf_config_module.rst)|netconf device configuration
 [ansible.netcommon.netconf_get](https://github.com/ansible-collections/ansible.netcommon/blob/main/docs/ansible.netcommon.netconf_get_module.rst)|Fetch configuration/state data from NETCONF enabled network devices.

--- a/docs/ansible.netcommon.net_ping_module.rst
+++ b/docs/ansible.netcommon.net_ping_module.rst
@@ -5,7 +5,7 @@
 ansible.netcommon.net_ping
 **************************
 
-**Tests reachability using ping from a network device**
+**Tests reachability using ICMP ping from a network device**
 
 
 Version added: 1.0.0
@@ -17,7 +17,7 @@ Version added: 1.0.0
 
 Synopsis
 --------
-- Tests reachability using ping from network device to a remote destination.
+- Tests reachability using ICMP ping from network device to a remote destination.
 
 
 

--- a/plugins/modules/net_ping.py
+++ b/plugins/modules/net_ping.py
@@ -14,9 +14,9 @@ __metaclass__ = type
 DOCUMENTATION = """
 module: net_ping
 author: Jacob McGill (@jmcgill298)
-short_description: Tests reachability using ping from a network device
+short_description: Tests reachability using ICMP ping from a network device
 description:
-- Tests reachability using ping from network device to a remote destination.
+- Tests reachability using ICMP ping from network device to a remote destination.
 version_added: 1.0.0
 extends_documentation_fragment:
 - ansible.netcommon.network_agnostic


### PR DESCRIPTION
##### SUMMARY

Prevent confusion with https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/ping_module.html

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.netcommon.net_ping

