### PR TITLE
updated cliconf_base.py and connection_base.py

### DIFF
--- a/plugins/plugin_utils/cliconf_base.py
+++ b/plugins/plugin_utils/cliconf_base.py
@@ -510,6 +510,29 @@ class CliconfBase(CliconfBaseBase):
 
         return responses
 
+    def _send_config_commands(self, candidate, exit_command="end", cmd_filter=None):
+        """Send configuration commands with guaranteed config-mode exit.
+
+        :param candidate: Configuration commands (string, list, or list of dicts).
+        :param exit_command: Command to exit config mode, sent in finally block.
+        :param cmd_filter: Optional callable; return True to send, False to skip.
+        :return: Tuple of (results, requests).
+        """
+        results = []
+        requests = []
+        try:
+            for line in to_list(candidate):
+                if not isinstance(line, Mapping):
+                    line = {"command": line}
+                cmd = line["command"]
+                if cmd_filter and not cmd_filter(cmd):
+                    continue
+                results.append(self.send_command(**line))
+                requests.append(cmd)
+        finally:
+            self.send_command(exit_command)
+        return results, requests
+
     def check_edit_config_capability(
         self,
         operations,

--- a/plugins/plugin_utils/connection_base.py
+++ b/plugins/plugin_utils/connection_base.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+from functools import wraps
 
 from ansible import constants as C
 from ansible.utils.display import Display
@@ -46,10 +47,28 @@ class NetworkConnectionBase(PersistentConnectionBase):
                 if plugin:
                     method = getattr(plugin, name, None)
                     if method is not None:
+                        if name == "edit_config":
+                            return self._wrap_edit_config(method)
                         return method
             raise AttributeError(
                 "'%s' object has no attribute '%s'" % (self.__class__.__name__, name)
             )
+
+    def _wrap_edit_config(self, method):
+        @wraps(method)
+        def wrapped(*args, **kwargs):
+            try:
+                return method(*args, **kwargs)
+            except Exception:
+                try:
+                    plugin = self._sub_plugin.get("obj")
+                    if plugin and hasattr(plugin, "set_cli_prompt_context"):
+                        plugin.set_cli_prompt_context()
+                except Exception:
+                    pass
+                raise
+
+        return wrapped
 
     def get_options(self, hostvars=None):
         options = super(NetworkConnectionBase, self).get_options(hostvars=hostvars)

--- a/tests/unit/plugins/plugin_utils/test_cliconf_base.py
+++ b/tests/unit/plugins/plugin_utils/test_cliconf_base.py
@@ -1,0 +1,102 @@
+# (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from ansible_collections.ansible.netcommon.plugins.plugin_utils.cliconf_base import CliconfBase
+
+
+class ConcreteCliconf(CliconfBase):
+    def get_config(self, source="running", flags=None, format=None):
+        pass
+
+    def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
+        pass
+
+    def get_capabilities(self):
+        pass
+
+    def get_device_info(self):
+        return {}
+
+
+@pytest.fixture()
+def cliconf():
+    obj = ConcreteCliconf.__new__(ConcreteCliconf)
+    obj.send_command = MagicMock(return_value="ok")
+    return obj
+
+
+class TestSendConfigCommands:
+    def test_string_candidate(self, cliconf):
+        results, requests = cliconf._send_config_commands("interface loopback0")
+        assert results == ["ok"]
+        assert requests == ["interface loopback0"]
+        cliconf.send_command.assert_any_call(command="interface loopback0")
+        cliconf.send_command.assert_any_call("end")
+
+    def test_list_candidate(self, cliconf):
+        cmds = ["interface loopback0", "description test"]
+        results, requests = cliconf._send_config_commands(cmds)
+        assert results == ["ok", "ok"]
+        assert requests == ["interface loopback0", "description test"]
+
+    def test_list_of_dicts(self, cliconf):
+        cmds = [
+            {"command": "interface loopback0", "prompt": "#"},
+            {"command": "description test"},
+        ]
+        results, requests = cliconf._send_config_commands(cmds)
+        assert results == ["ok", "ok"]
+        assert requests == ["interface loopback0", "description test"]
+        cliconf.send_command.assert_any_call(command="interface loopback0", prompt="#")
+
+    def test_custom_exit_command(self, cliconf):
+        cliconf._send_config_commands("hostname R1", exit_command="exit")
+        assert cliconf.send_command.call_args_list[-1] == call("exit")
+
+    def test_cmd_filter_skips(self, cliconf):
+        cmds = ["interface loopback0", "!", "description test"]
+        results, requests = cliconf._send_config_commands(
+            cmds, cmd_filter=lambda cmd: cmd != "!"
+        )
+        assert requests == ["interface loopback0", "description test"]
+        assert len(results) == 2
+
+    def test_cmd_filter_none_sends_all(self, cliconf):
+        cmds = ["a", "b", "c"]
+        results, requests = cliconf._send_config_commands(cmds, cmd_filter=None)
+        assert requests == ["a", "b", "c"]
+        assert len(results) == 3
+
+    def test_exit_command_sent_on_success(self, cliconf):
+        cliconf._send_config_commands("hostname R1")
+        assert cliconf.send_command.call_args_list[-1] == call("end")
+
+    def test_exit_command_sent_on_exception(self, cliconf):
+        cliconf.send_command = MagicMock(
+            side_effect=[Exception("device error"), "ok"]
+        )
+        with pytest.raises(Exception, match="device error"):
+            cliconf._send_config_commands("bad command")
+        assert cliconf.send_command.call_args_list[-1] == call("end")
+
+    def test_empty_candidate(self, cliconf):
+        results, requests = cliconf._send_config_commands([])
+        assert results == []
+        assert requests == []
+        cliconf.send_command.assert_called_once_with("end")
+
+    def test_mixed_string_and_dict_in_list(self, cliconf):
+        cmds = ["interface loopback0", {"command": "shutdown"}]
+        results, requests = cliconf._send_config_commands(cmds)
+        assert requests == ["interface loopback0", "shutdown"]
+        assert len(results) == 2

--- a/tests/unit/plugins/plugin_utils/test_cliconf_base.py
+++ b/tests/unit/plugins/plugin_utils/test_cliconf_base.py
@@ -65,9 +65,7 @@ class TestSendConfigCommands:
 
     def test_cmd_filter_skips(self, cliconf):
         cmds = ["interface loopback0", "!", "description test"]
-        results, requests = cliconf._send_config_commands(
-            cmds, cmd_filter=lambda cmd: cmd != "!"
-        )
+        results, requests = cliconf._send_config_commands(cmds, cmd_filter=lambda cmd: cmd != "!")
         assert requests == ["interface loopback0", "description test"]
         assert len(results) == 2
 
@@ -82,9 +80,7 @@ class TestSendConfigCommands:
         assert cliconf.send_command.call_args_list[-1] == call("end")
 
     def test_exit_command_sent_on_exception(self, cliconf):
-        cliconf.send_command = MagicMock(
-            side_effect=[Exception("device error"), "ok"]
-        )
+        cliconf.send_command = MagicMock(side_effect=[Exception("device error"), "ok"])
         with pytest.raises(Exception, match="device error"):
             cliconf._send_config_commands("bad command")
         assert cliconf.send_command.call_args_list[-1] == call("end")

--- a/tests/unit/plugins/plugin_utils/test_connection_base.py
+++ b/tests/unit/plugins/plugin_utils/test_connection_base.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/unit/plugins/plugin_utils/test_connection_base.py
+++ b/tests/unit/plugins/plugin_utils/test_connection_base.py
@@ -1,0 +1,120 @@
+# (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+from ansible_collections.ansible.netcommon.plugins.plugin_utils.connection_base import (
+    NetworkConnectionBase,
+)
+
+
+@pytest.fixture()
+def connection():
+    with patch.multiple(
+        NetworkConnectionBase,
+        __init__=lambda self, *a, **kw: None,
+        __abstractmethods__=frozenset(),
+    ):
+        conn = NetworkConnectionBase.__new__(NetworkConnectionBase)
+        conn.__dict__["_sub_plugin"] = {"obj": MagicMock(), "type": "cliconf"}
+        return conn
+
+
+class TestGetattr:
+    def test_delegates_to_sub_plugin(self, connection):
+        plugin = connection._sub_plugin["obj"]
+        plugin.get_config = MagicMock(return_value="running-config")
+        result = connection.get_config()
+        assert result == "running-config"
+
+    def test_edit_config_returns_wrapped(self, connection):
+        plugin = connection._sub_plugin["obj"]
+        plugin.edit_config = MagicMock(return_value="ok")
+        wrapped = connection.edit_config
+        assert wrapped is not plugin.edit_config
+        assert callable(wrapped)
+
+    def test_private_attr_raises(self, connection):
+        with pytest.raises(AttributeError):
+            connection._nonexistent_private
+
+    def test_missing_attr_raises(self, connection):
+        plugin = connection._sub_plugin["obj"]
+        plugin.no_such_method = None
+        delattr(plugin, "no_such_method")
+        with pytest.raises(AttributeError, match="has no attribute 'no_such_method'"):
+            connection.no_such_method
+
+    def test_no_plugin_raises(self, connection):
+        connection.__dict__["_sub_plugin"] = {}
+        with pytest.raises(AttributeError):
+            connection.get_config
+
+
+class TestWrapEditConfig:
+    def test_success_returns_result(self, connection):
+        plugin = connection._sub_plugin["obj"]
+        plugin.edit_config = MagicMock(return_value={"diff": "+"})
+        result = connection.edit_config(candidate=["hostname R1"])
+        assert result == {"diff": "+"}
+        plugin.edit_config.assert_called_once_with(candidate=["hostname R1"])
+
+    def test_exception_calls_set_cli_prompt_context(self, connection):
+        plugin = connection._sub_plugin["obj"]
+        plugin.edit_config = MagicMock(side_effect=RuntimeError("config failed"))
+        plugin.set_cli_prompt_context = MagicMock()
+
+        with pytest.raises(RuntimeError, match="config failed"):
+            connection.edit_config()
+
+        plugin.set_cli_prompt_context.assert_called_once()
+
+    def test_exception_reraises_original(self, connection):
+        plugin = connection._sub_plugin["obj"]
+        error = ValueError("bad config")
+        plugin.edit_config = MagicMock(side_effect=error)
+        plugin.set_cli_prompt_context = MagicMock()
+
+        with pytest.raises(ValueError, match="bad config"):
+            connection.edit_config()
+
+    def test_exception_without_set_cli_prompt_context(self, connection):
+        plugin = connection._sub_plugin["obj"]
+        plugin.edit_config = MagicMock(side_effect=RuntimeError("fail"))
+        del plugin.set_cli_prompt_context
+
+        with pytest.raises(RuntimeError, match="fail"):
+            connection.edit_config()
+
+    def test_set_cli_prompt_context_error_suppressed(self, connection):
+        plugin = connection._sub_plugin["obj"]
+        plugin.edit_config = MagicMock(side_effect=RuntimeError("config error"))
+        plugin.set_cli_prompt_context = MagicMock(
+            side_effect=Exception("prompt context error")
+        )
+
+        with pytest.raises(RuntimeError, match="config error"):
+            connection.edit_config()
+
+    def test_no_plugin_skips_prompt_reset(self, connection):
+        plugin = connection._sub_plugin["obj"]
+        original_edit = MagicMock(side_effect=RuntimeError("fail"))
+        wrapped = connection._wrap_edit_config(original_edit)
+        connection.__dict__["_sub_plugin"] = {"obj": None}
+
+        with pytest.raises(RuntimeError, match="fail"):
+            wrapped()
+
+    def test_passes_args_and_kwargs(self, connection):
+        plugin = connection._sub_plugin["obj"]
+        plugin.edit_config = MagicMock(return_value="ok")
+        connection.edit_config("arg1", key="val")
+        plugin.edit_config.assert_called_once_with("arg1", key="val")

--- a/tests/unit/plugins/plugin_utils/test_connection_base.py
+++ b/tests/unit/plugins/plugin_utils/test_connection_base.py
@@ -97,9 +97,7 @@ class TestWrapEditConfig:
     def test_set_cli_prompt_context_error_suppressed(self, connection):
         plugin = connection._sub_plugin["obj"]
         plugin.edit_config = MagicMock(side_effect=RuntimeError("config error"))
-        plugin.set_cli_prompt_context = MagicMock(
-            side_effect=Exception("prompt context error")
-        )
+        plugin.set_cli_prompt_context = MagicMock(side_effect=Exception("prompt context error"))
 
         with pytest.raises(RuntimeError, match="config error"):
             connection.edit_config()


### PR DESCRIPTION
##### SUMMARY

**what is changed ?**
 plugins/plugin_utils/connection_base.py- __getattr__ now wraps edit_config via_wrap_edit_config() — on exception, it calls the cliconf plugin's set_cli_prompt_context() to restore operational
mode before re-raising. Applies to all callers and all vendors automatically.

  plugins/plugin_utils/cliconf_base.py
  - Added _send_config_commands(candidate, exit_command, cmd_filter) — an opt-in helper that wraps the
  command-sending loop in try/finally, guaranteeing the exit command is always sent. Available for any vendor
  cliconf to use.


**why it is changed?**
  The NetworkConnectionBase.__getattr__ in connection_base.py proxies edit_config calls directly to
  the vendor cliconf plugin with no error recovery. When  the cliconf's edit_config raises an exception
  mid-configuration, the connection has no mechanism to restore the device to operational mode. The device stays
  in config mode, and every subsequent operation on that
  connection fails.

  The existing safety mechanism — set_cli_prompt_context()  — exists in CliconfBase specifically to detect and exit
  config mode. But update_cli_prompt_context() innetwork_cli.py only calls it at task boundaries (when_task_uuid changes). Within a single task (e.g., a loop),a failed edit_config poisons the connection state for
all remaining iterations.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
