### PR TITLE
Added _persistent = False to the CacheModule class in netcommon/plugins/cache/memory.py

### DIFF
--- a/.github/workflows/integration-cml.yml
+++ b/.github/workflows/integration-cml.yml
@@ -66,10 +66,10 @@ jobs:
       matrix:  #  There is no official support for matrix here as multiple applaince are needed per run, test against one core version.
         ansible_version: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.ansible_version)) || fromJSON('["devel"]') }}
     steps:
-      - name: Set up Python 3.12
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ (contains(matrix.ansible_version, 'devel') || contains(matrix.ansible_version, 'milestone')) && '3.13' || '3.12' }}
 
       - name: DEBUG Show pip list before installs
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug == 'true' || github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'debug') }}

--- a/changelogs/fragments/fix-cache-module-persistent-attribute.yaml
+++ b/changelogs/fragments/fix-cache-module-persistent-attribute.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+  - memory cache plugin - Add missing ``_persistent`` attribute to ``CacheModule``
+    to fix ``'CacheModule' object has no attribute '_persistent'`` error with
+    ansible-core 2.19+ when ``single_user_mode`` caching is enabled
+    (https://github.com/ansible-collections/ansible.netcommon/issues/781).

--- a/plugins/cache/memory.py
+++ b/plugins/cache/memory.py
@@ -23,6 +23,8 @@ from ansible.plugins import AnsiblePlugin
 
 
 class CacheModule(AnsiblePlugin):
+    _persistent = False
+
     def __init__(self, *args, **kwargs):
         super(CacheModule, self).__init__(*args, **kwargs)
         self._cache = {}

--- a/tests/unit/plugins/cache/test_memory.py
+++ b/tests/unit/plugins/cache/test_memory.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# Copyright 2024 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+
+from unittest import TestCase
+
+from ansible_collections.ansible.netcommon.plugins.cache.memory import CacheModule
+
+
+class TestMemoryCacheModule(TestCase):
+    def setUp(self):
+        self.cache = CacheModule()
+
+    def test_persistent_attribute_exists(self):
+        """CacheModule must expose _persistent for ansible-core >= 2.19 CachePluginAdjudicator."""
+        self.assertTrue(hasattr(self.cache, "_persistent"))
+
+    def test_persistent_is_false(self):
+        """RAM-only cache must declare _persistent = False."""
+        self.assertFalse(self.cache._persistent)
+
+    def test_set_and_get(self):
+        self.cache.set("host1", {"os": "eos"})
+        self.assertEqual(self.cache.get("host1"), {"os": "eos"})
+
+    def test_get_missing_key_returns_none(self):
+        self.assertIsNone(self.cache.get("nonexistent"))
+
+    def test_keys(self):
+        self.cache.set("a", 1)
+        self.cache.set("b", 2)
+        self.assertEqual(sorted(self.cache.keys()), ["a", "b"])
+
+    def test_flush(self):
+        self.cache.set("a", 1)
+        self.cache.flush()
+        self.assertIsNone(self.cache.get("a"))
+        self.assertEqual(list(self.cache.keys()), [])
+
+    def test_populate_and_lookup(self):
+        self.cache.populate("host1", {"os": "eos"})
+        self.assertEqual(self.cache.lookup("host1"), {"os": "eos"})
+
+    def test_invalidate(self):
+        self.cache.set("a", 1)
+        self.cache.set("b", 2)
+        self.cache.invalidate()
+        self.assertEqual(list(self.cache.keys()), [])
+
+    def test_overwrite_existing_key(self):
+        self.cache.set("key", "old")
+        self.cache.set("key", "new")
+        self.assertEqual(self.cache.get("key"), "new")
+
+    def test_independent_instances(self):
+        other = CacheModule()
+        self.cache.set("key", "value")
+        self.assertIsNone(other.get("key"))

--- a/tox-ansible.ini
+++ b/tox-ansible.ini
@@ -5,3 +5,6 @@ ignore_base_python_conflict = true
 skip =
     py3.14
     sanity-py3.13
+    sanity-py3.12-devel
+    unit-py3.12-devel
+

--- a/tox-ansible.ini
+++ b/tox-ansible.ini
@@ -7,4 +7,3 @@ skip =
     sanity-py3.13
     sanity-py3.12-devel
     unit-py3.12-devel
-


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

 In Ansible core 2.19, the CachePluginAdjudicator._do_load_key() method (at ansible/plugins/cache/__init__.py:309) accesses self._plugin._persistent: if key not in self._cache and key not in self._retrieved and self._plugin._persistent and self._plugin.contains(key),   The BaseCacheModule class defines _persistent = True as a  class attribute. However, ansible.netcommon's CacheModule in plugins/cache/memory.py inherits from AnsiblePlugin directly
  (not BaseCacheModule), so it doesn't have the _persistent  attribute, 

  When single_user_mode is enabled (which is the condition for the caching test to run), the network_cli connection plugin
  loads this cache plugin via cache_loader.get("ansible.netcommon.memory"), and eventually
  CachePluginAdjudicator tries to access _persistent on it —causing the AttributeError.

  Error : `CacheModule' object has no attribute '_persistent'` 
  
  Fix applied: Added _persistent = False to the CacheModule class in netcommon/plugins/cache/memory.py.
  This is correct because the memory cache is explicitly non-persistent (RAM-only, not persisted across runs). Setting
  it to False also means _do_load_key() will short-circuit and skip the contains() check, which is the right behavior for
  an in-memory cache.
  
  Added changes related to minimum python requirement for ansible core devel branch to integration test workflow as well as ignore sanity and unit python3.12-devel tests in tox-ansible.ini file


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
