### PR TITLE
Fix integration test Python version for devel/milestone ansible-core

### DIFF
--- a/.github/workflows/integration-cml.yml
+++ b/.github/workflows/integration-cml.yml
@@ -66,10 +66,10 @@ jobs:
       matrix:  #  There is no official support for matrix here as multiple applaince are needed per run, test against one core version.
         ansible_version: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.ansible_version)) || fromJSON('["devel"]') }}
     steps:
-      - name: Set up Python 3.12
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ (contains(matrix.ansible_version, 'devel') || contains(matrix.ansible_version, 'milestone')) && '3.13' || '3.12' }}
 
       - name: DEBUG Show pip list before installs
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug == 'true' || github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'debug') }}


### PR DESCRIPTION
## Summary
- ansible-core `devel` branch now requires Python >= 3.13, but the integration workflow was hardcoded to Python 3.12
- Use Python 3.13 for `devel` and `milestone` builds, fall back to 3.12 for stable versions
- This fix must land on `main` first because the integration workflow uses `pull_request_target`, which runs the workflow file from the base branch (main), not from the PR branch

## Test plan
- [ ] Merge this PR to `main`
- [ ] Re-run the `cache_fix` PR integration tests — they should now pick up Python 3.13 for devel

🤖 Generated with [Claude Code](https://claude.com/claude-code)