### PR TITLE
fix intermittent Datastore locked error on IOS-XR and other NETCONF t…

### DIFF
--- a/changelogs/fragments/netconf_config_fix_datastore_lock.yml
+++ b/changelogs/fragments/netconf_config_fix_datastore_lock.yml
@@ -4,7 +4,3 @@ bugfixes:
     other NETCONF targets. Local content validation (format parsing and XML
     syntax check) is now performed before acquiring the candidate datastore lock
     so invalid content never causes a lock that cannot be cleanly released.
-    Additionally, the ``finally`` block now calls ``discard_changes`` before
-    ``unlock`` to roll back any uncommitted edits on failure, and wraps the
-    ``unlock`` call in a try/except so that an unlock failure is surfaced as a
-    warning rather than silently leaving the datastore locked.

--- a/changelogs/fragments/netconf_config_fix_datastore_lock.yml
+++ b/changelogs/fragments/netconf_config_fix_datastore_lock.yml
@@ -1,0 +1,10 @@
+---
+bugfixes:
+  - netconf_config - fix intermittent ``Datastore locked`` error on IOS-XR and
+    other NETCONF targets. Local content validation (format parsing and XML
+    syntax check) is now performed before acquiring the candidate datastore lock
+    so invalid content never causes a lock that cannot be cleanly released.
+    Additionally, the ``finally`` block now calls ``discard_changes`` before
+    ``unlock`` to roll back any uncommitted edits on failure, and wraps the
+    ``unlock`` call in a try/except so that an unlock failure is surfaced as a
+    warning rather than silently leaving the datastore locked.

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -616,15 +616,10 @@ def main():
                 result["changed"] = True
                 module.exit_json(**result)
 
-            if execute_lock:
-                conn.lock(target=target)
-                locked = True
-            if before is None:
-                before = to_text(
-                    conn.get_config(source=target, filter=filter_spec),
-                    errors="surrogate_then_replace",
-                ).strip()
-
+            # Validate and normalize config content locally before acquiring the
+            # datastore lock. These checks are pure local operations and do not
+            # require device interaction. Failing here avoids acquiring a lock
+            # that would then need to be released on an error path.
             if format != "text":
                 # check for format of type json/xml/xpath
                 try:
@@ -647,6 +642,18 @@ def main():
                     format = config_format
 
             validate_config(module, config, format)
+
+            # Acquire the datastore lock only after local validation has passed.
+            # get_config (before snapshot) is kept inside the lock so the
+            # baseline state is consistent with the subsequent edit-config.
+            if execute_lock:
+                conn.lock(target=target)
+                locked = True
+            if before is None:
+                before = to_text(
+                    conn.get_config(source=target, filter=filter_spec),
+                    errors="surrogate_then_replace",
+                ).strip()
 
             kwargs = {
                 "config": config,
@@ -694,7 +701,17 @@ def main():
         module.fail_json(msg=to_text(e, errors="surrogate_then_replace").strip())
     finally:
         if locked:
-            conn.unlock(target=target)
+            try:
+                conn.discard_changes()
+            except Exception:
+                pass
+            try:
+                conn.unlock(target=target)
+            except Exception as unlock_err:
+                module.warn(
+                    "Failed to unlock '%s' datastore: %s"
+                    % (target, to_text(unlock_err, errors="surrogate_then_replace"))
+                )
 
     module.exit_json(**result)
 

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -701,17 +701,7 @@ def main():
         module.fail_json(msg=to_text(e, errors="surrogate_then_replace").strip())
     finally:
         if locked:
-            try:
-                conn.discard_changes()
-            except Exception:
-                pass
-            try:
-                conn.unlock(target=target)
-            except Exception as unlock_err:
-                module.warn(
-                    "Failed to unlock '%s' datastore: %s"
-                    % (target, to_text(unlock_err, errors="surrogate_then_replace"))
-                )
+            conn.unlock(target=target)
 
     module.exit_json(**result)
 


### PR DESCRIPTION
 

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
**Problem:** netconf_config module  which acquires a NETCONF candidate datastore lock before validating the config content. I think i know what might be the issue here looking at  a [prior task](https://github.com/ansible-collections/ansible.netcommon/blob/b7fef434617ed47c562a4fef9764e335215c8b82/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml#L52)  which sends invalid content , fail_json() is called after the l[ock is acquired](https://github.com/ansible-collections/ansible.netcommon/blob/b7fef434617ed47c562a4fef9764e335215c8b82/plugins/modules/netconf_config.py#L619). The finally [block calls](https://github.com/ansible-collections/ansible.netcommon/blob/b7fef434617ed47c562a4fef9764e335215c8b82/plugins/modules/netconf_config.py#L692-L697) conn.unlock(), but if that unlock fails silently, the IOS-XR candidate datastore stays locked , causing the next task to get Datastore locked.
**Proposed Solution:** 
netconf_config - fix intermittent ``Datastore locked`` error on IOS-XR and
    other NETCONF targets. Local content validation (format parsing and XML
    syntax check) is now performed before acquiring the candidate datastore lock
    so invalid content never causes a lock that cannot be cleanly released.
     
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf_config
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
