### PR TITLE
Remediate deprecated ansible.module utils dependencies in ansible.netcommon

### DIFF
--- a/changelogs/fragments/remediate_deprecated_warnings.yaml
+++ b/changelogs/fragments/remediate_deprecated_warnings.yaml
@@ -1,16 +1,15 @@
 minor_changes:
-  - Remediate deprecated ``warnings`` parameter in ``exit_json`` calls by using
-    ``AnsibleModule.warn()`` across all netcommon modules to address deprecation
-    warning from ansible-core 2.23.
-
-  - Added ``emit_warnings`` and ``warn_and_exit`` utility functions in
+  - Remediate deprecated ``warnings`` parameter in ``exit_json`` calls by
+    introducing ``emit_warnings`` and ``warn_and_exit`` utility functions in
     ``plugins/module_utils/network/common/utils.py`` to centralize warning
     emission logic.
-
-  - Fixed ``ResourceModule.result`` property in ``rm_base/resource_module.py``
-    to emit warnings via ``module.warn()`` before returning the result dict.
-    This automatically addresses the deprecation for all downstream collections
-    using ``ResourceModule`` (e.g. cisco.iosxr, cisco.ios, arista.eos).
+    The following modules were updated to use ``warn_and_exit`` -
+    ``cli_backup``, ``cli_command``, ``cli_config``, ``cli_restore``,
+    ``grpc_config``, ``grpc_get``, ``netconf_config``, ``netconf_get``,
+    ``netconf_rpc``, ``restconf_config``, ``restconf_get``.
+    ``ResourceModule`` base class in ``rm_base/resource_module.py`` was updated
+    to use ``emit_warnings``, which automatically addresses the deprecation for
+    all downstream collections (e.g. cisco.iosxr, cisco.ios, arista.eos).
 
   - Remediate deprecated ``to_text`` and ``to_bytes`` from
     ``ansible.module_utils._text`` and replaced with

--- a/changelogs/fragments/remediate_deprecated_warnings.yaml
+++ b/changelogs/fragments/remediate_deprecated_warnings.yaml
@@ -22,3 +22,9 @@ minor_changes:
   - Remediate deprecated ``ansible.module_utils.six`` module and replaced it with
     native Python 3 equivalents like ``pickle``, ``zip``, ``urllib.parse``,
     ``urllib.error`` etc.
+  
+  - Remediate deprecated - `parse_cli_textfsm` filter plugin and replaced with `ansible.utils.cli_parse` with the `ansible.utils.textfsm_parser` parser as a replacement .
+
+  - Remediate deprecated - `parse_cli` filter plugin and replaced with `ansible.utils.cli_parse`.
+
+  - Remediate deprecated - `parse_xml` filter plugin and replaced with `ansible.utils.cli_parse` with the `ansible.utils.xml_parser` parser as a replacement.

--- a/changelogs/fragments/remediate_deprecated_warnings.yaml
+++ b/changelogs/fragments/remediate_deprecated_warnings.yaml
@@ -1,0 +1,24 @@
+minor_changes:
+  - Remediate deprecated ``warnings`` parameter in ``exit_json`` calls by using
+    ``AnsibleModule.warn()`` across all netcommon modules to address deprecation
+    warning from ansible-core 2.23.
+
+  - Added ``emit_warnings`` and ``warn_and_exit`` utility functions in
+    ``plugins/module_utils/network/common/utils.py`` to centralize warning
+    emission logic.
+
+  - Fixed ``ResourceModule.result`` property in ``rm_base/resource_module.py``
+    to emit warnings via ``module.warn()`` before returning the result dict.
+    This automatically addresses the deprecation for all downstream collections
+    using ``ResourceModule`` (e.g. cisco.iosxr, cisco.ios, arista.eos).
+
+  - Remediate deprecated ``to_text`` and ``to_bytes`` from
+    ``ansible.module_utils._text`` and replaced with
+    ``ansible.module_utils.common.text.converters``.
+
+  - Remediate deprecated ``ansible.module_utils.common._collections_compat`` module
+    and replaced with ``collections.abc`` from the Python standard library.
+
+  - Remediate deprecated ``ansible.module_utils.six`` module and replaced it with
+    native Python 3 equivalents like ``pickle``, ``zip``, ``urllib.parse``,
+    ``urllib.error`` etc.

--- a/changelogs/fragments/remediate_deprecated_warnings.yaml
+++ b/changelogs/fragments/remediate_deprecated_warnings.yaml
@@ -22,9 +22,3 @@ minor_changes:
   - Remediate deprecated ``ansible.module_utils.six`` module and replaced it with
     native Python 3 equivalents like ``pickle``, ``zip``, ``urllib.parse``,
     ``urllib.error`` etc.
-  
-  - Remediate deprecated - `parse_cli_textfsm` filter plugin and replaced with `ansible.utils.cli_parse` with the `ansible.utils.textfsm_parser` parser as a replacement .
-
-  - Remediate deprecated - `parse_cli` filter plugin and replaced with `ansible.utils.cli_parse`.
-
-  - Remediate deprecated - `parse_xml` filter plugin and replaced with `ansible.utils.cli_parse` with the `ansible.utils.xml_parser` parser as a replacement.

--- a/plugins/action/net_get.py
+++ b/plugins/action/net_get.py
@@ -15,7 +15,7 @@ import uuid
 from ansible.errors import AnsibleError
 from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.connection import Connection, ConnectionError
-from ansible.module_utils.six.moves.urllib.parse import urlsplit
+from urllib.parse import urlsplit
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 

--- a/plugins/action/net_get.py
+++ b/plugins/action/net_get.py
@@ -12,10 +12,11 @@ import os
 import re
 import uuid
 
+from urllib.parse import urlsplit
+
 from ansible.errors import AnsibleError
 from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.connection import Connection, ConnectionError
-from urllib.parse import urlsplit
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 

--- a/plugins/action/net_put.py
+++ b/plugins/action/net_put.py
@@ -11,10 +11,11 @@ import hashlib
 import os
 import uuid
 
+from urllib.parse import urlsplit
+
 from ansible.errors import AnsibleError
 from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.connection import Connection, ConnectionError
-from urllib.parse import urlsplit
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 

--- a/plugins/action/net_put.py
+++ b/plugins/action/net_put.py
@@ -14,7 +14,7 @@ import uuid
 from ansible.errors import AnsibleError
 from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.connection import Connection, ConnectionError
-from ansible.module_utils.six.moves.urllib.parse import urlsplit
+from urllib.parse import urlsplit
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -14,7 +14,7 @@ import time
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.common.text.converters import to_text
-from ansible.module_utils.six.moves.urllib.parse import urlsplit
+from urllib.parse import urlsplit
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.display import Display
 from ansible.utils.hashing import checksum, checksum_s

--- a/plugins/action/network.py
+++ b/plugins/action/network.py
@@ -12,9 +12,10 @@ import os
 import re
 import time
 
+from urllib.parse import urlsplit
+
 from ansible.errors import AnsibleError
 from ansible.module_utils.common.text.converters import to_text
-from urllib.parse import urlsplit
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.display import Display
 from ansible.utils.hashing import checksum, checksum_s

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -184,12 +184,13 @@ options:
     - name: ansible_platform_type
 """
 
-from io import BytesIO
 import pickle
+
+from io import BytesIO
+from urllib.error import HTTPError, URLError
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils.common.text.converters import to_bytes
-from urllib.error import HTTPError, URLError
 from ansible.module_utils.urls import open_url
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.connection import ensure_connect

--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -185,11 +185,11 @@ options:
 """
 
 from io import BytesIO
+import pickle
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils.common.text.converters import to_bytes
-from ansible.module_utils.six.moves import cPickle
-from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
+from urllib.error import HTTPError, URLError
 from ansible.module_utils.urls import open_url
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.connection import ensure_connect
@@ -257,7 +257,7 @@ class Connection(NetworkConnectionBase):
     def update_play_context(self, pc_data):
         """Updates the play context information for the connection"""
         pc_data = to_bytes(pc_data)
-        pc_data = cPickle.loads(pc_data, encoding="bytes")
+        pc_data = pickle.loads(pc_data, encoding="bytes")
 
         play_context = PlayContext()
         play_context.deserialize(pc_data)

--- a/plugins/connection/netconf.py
+++ b/plugins/connection/netconf.py
@@ -166,12 +166,12 @@ options:
 import json
 import logging
 import os
+import pickle
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE, BOOLEANS_TRUE
-from ansible.module_utils.six.moves import cPickle
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.connection import ensure_connect
 from ansible.plugins.loader import netconf_loader
@@ -277,7 +277,7 @@ class Connection(NetworkConnectionBase):
     def update_play_context(self, pc_data):
         """Updates the play context information for the connection"""
         pc_data = to_bytes(pc_data)
-        pc_data = cPickle.loads(pc_data, encoding="bytes")
+        pc_data = pickle.loads(pc_data, encoding="bytes")
 
         play_context = PlayContext()
         play_context.deserialize(pc_data)

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -328,6 +328,7 @@ import socket
 import tempfile
 import time
 import traceback
+import pickle
 
 from binascii import hexlify
 from functools import wraps
@@ -336,7 +337,6 @@ from io import BytesIO
 from ansible.errors import AnsibleAuthenticationFailure, AnsibleConnectionFailure, AnsibleError
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
-from ansible.module_utils.six.moves import cPickle
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import cache_loader, cliconf_loader, connection_loader, terminal_loader
 from ansible.utils.display import Display
@@ -1136,7 +1136,7 @@ class Connection(NetworkConnectionBase):
     def update_play_context(self, pc_data):
         """Updates the play context information for the connection"""
         pc_data = to_bytes(pc_data)
-        pc_data = cPickle.loads(pc_data, encoding="bytes")
+        pc_data = pickle.loads(pc_data, encoding="bytes")
 
         play_context = PlayContext()
         play_context.deserialize(pc_data)

--- a/plugins/connection/network_cli.py
+++ b/plugins/connection/network_cli.py
@@ -322,13 +322,13 @@ import getpass
 import json
 import logging
 import os
+import pickle
 import re
 import signal
 import socket
 import tempfile
 import time
 import traceback
-import pickle
 
 from binascii import hexlify
 from functools import wraps

--- a/plugins/httpapi/restconf.py
+++ b/plugins/httpapi/restconf.py
@@ -27,9 +27,10 @@ options:
 
 import json
 
+from urllib.error import HTTPError
+
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import ConnectionError
-from urllib.error import HTTPError
 
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.httpapi_base import HttpApiBase
 

--- a/plugins/httpapi/restconf.py
+++ b/plugins/httpapi/restconf.py
@@ -29,7 +29,7 @@ import json
 
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import ConnectionError
-from ansible.module_utils.six.moves.urllib.error import HTTPError
+from urllib.error import HTTPError
 
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.httpapi_base import HttpApiBase
 

--- a/plugins/module_utils/network/common/config.py
+++ b/plugins/module_utils/network/common/config.py
@@ -17,7 +17,6 @@ import hashlib
 import re
 
 from ansible.module_utils.common.text.converters import to_bytes, to_native
-from ansible.module_utils.six.moves import zip
 
 
 DEFAULT_COMMENT_TOKENS = ["#", "!", "/*", "*/", "echo"]

--- a/plugins/module_utils/network/common/parsing.py
+++ b/plugins/module_utils/network/common/parsing.py
@@ -19,7 +19,6 @@ import shlex
 import time
 
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE, BOOLEANS_TRUE
-from ansible.module_utils.six.moves import zip
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list
 

--- a/plugins/module_utils/network/common/rm_base/resource_module.py
+++ b/plugins/module_utils/network/common/rm_base/resource_module.py
@@ -69,8 +69,8 @@ class ResourceModule(RmEngineBase):  # pylint: disable=R0902
         """Compute the final result"""
         result = {"warnings": self.warnings}
 
-        emit_warnings(self._module,result)
-        
+        emit_warnings(self._module, result)
+
         if self.state not in self.ACTION_STATES:
             if self.state == "gathered":
                 result["gathered"] = self.before

--- a/plugins/module_utils/network/common/rm_base/resource_module.py
+++ b/plugins/module_utils/network/common/rm_base/resource_module.py
@@ -20,6 +20,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.r
     RmEngineBase,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
     get_from_dict,
     remove_empties,
     to_list,
@@ -67,6 +68,9 @@ class ResourceModule(RmEngineBase):  # pylint: disable=R0902
     def result(self):
         """Compute the final result"""
         result = {"warnings": self.warnings}
+
+        emit_warnings(self._module,result)
+        
         if self.state not in self.ACTION_STATES:
             if self.state == "gathered":
                 result["gathered"] = self.before

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -30,13 +30,7 @@ from ansible.module_utils import basic
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.parsing.convert_bool import boolean
 
-
-try:
-    from collections.abc import Mapping
-except ImportError:
-    # Python 2.7 fallback for ansible-core 2.16:
-    from ansible.module_utils.common._collections_compat import Mapping
-
+from collections.abc import Mapping
 
 string_types = (str,)
 try:

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -21,6 +21,7 @@ import operator
 import re
 import socket
 
+from collections.abc import Mapping
 from copy import deepcopy
 from functools import reduce  # forward compatibility for Python 3
 from io import StringIO
@@ -30,7 +31,6 @@ from ansible.module_utils import basic
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.parsing.convert_bool import boolean
 
-from collections.abc import Mapping
 
 string_types = (str,)
 try:
@@ -742,6 +742,7 @@ def convert_doc_to_ansible_module_kwargs(doc):
             spec.update({item: doc_obj[item]})
     return spec
 
+
 def emit_warnings(module, result):
     """Pop warnings from result dict and emit via module.warn().
     Passing 'warnings' to exit_json is deprecated in ansible-core 2.23.
@@ -749,9 +750,9 @@ def emit_warnings(module, result):
     for warning in result.pop("warnings", []):
         module.warn(warning)
 
+
 def warn_and_exit(module, result):
     # Passing 'warnings' to exit_json is deprecated in ansible-core 2.23.
     # Emit warnings via module.warn() and remove the key before exit.
-    emit_warnings(module,result)
+    emit_warnings(module, result)
     module.exit_json(**result)
-    

--- a/plugins/module_utils/network/common/utils.py
+++ b/plugins/module_utils/network/common/utils.py
@@ -747,3 +747,17 @@ def convert_doc_to_ansible_module_kwargs(doc):
         if item in VALID_ANSIBLEMODULE_ARGS:
             spec.update({item: doc_obj[item]})
     return spec
+
+def emit_warnings(module, result):
+    """Pop warnings from result dict and emit via module.warn().
+    Passing 'warnings' to exit_json is deprecated in ansible-core 2.23.
+    """
+    for warning in result.pop("warnings", []):
+        module.warn(warning)
+
+def warn_and_exit(module, result):
+    # Passing 'warnings' to exit_json is deprecated in ansible-core 2.23.
+    # Emit warnings via module.warn() and remove the key before exit.
+    emit_warnings(module,result)
+    module.exit_json(**result)
+    

--- a/plugins/modules/cli_backup.py
+++ b/plugins/modules/cli_backup.py
@@ -66,6 +66,8 @@ backup_path:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
+
 
 def validate_args(module, device_operations):
     """validate param if it is supported on the platform"""
@@ -119,7 +121,7 @@ def main():
     running = connection.get_config(flags=flags)
     result["__backup__"] = running
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/cli_backup.py
+++ b/plugins/modules/cli_backup.py
@@ -66,7 +66,9 @@ backup_path:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    warn_and_exit,
+)
 
 
 def validate_args(module, device_operations):

--- a/plugins/modules/cli_command.py
+++ b/plugins/modules/cli_command.py
@@ -146,6 +146,8 @@ json:
 """
 
 from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 
@@ -191,7 +193,7 @@ def main():
 
         result.update({"stdout": response})
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/cli_command.py
+++ b/plugins/modules/cli_command.py
@@ -146,10 +146,12 @@ json:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
+
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    warn_and_exit,
+)
 
 
 def main():

--- a/plugins/modules/cli_config.py
+++ b/plugins/modules/cli_config.py
@@ -230,7 +230,9 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    warn_and_exit,
+)
 
 
 def validate_args(module, device_operations):

--- a/plugins/modules/cli_config.py
+++ b/plugins/modules/cli_config.py
@@ -230,6 +230,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
+
 
 def validate_args(module, device_operations):
     """validate param if it is supported on the platform"""
@@ -449,7 +451,7 @@ def main():
         except Exception as exc:
             module.fail_json(msg=to_text(exc))
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/cli_restore.py
+++ b/plugins/modules/cli_restore.py
@@ -79,7 +79,9 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    warn_and_exit,
+)
 
 
 def validate_args(module, device_operations):

--- a/plugins/modules/cli_restore.py
+++ b/plugins/modules/cli_restore.py
@@ -79,6 +79,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
+
 
 def validate_args(module, device_operations):
     """validate param if it is supported on the platform"""
@@ -121,7 +123,7 @@ def main():
         else:
             module.fail_json(msg=to_text(exc, errors="surrogate_then_replace").strip())
     result["__restore__"] = running
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/grpc_config.py
+++ b/plugins/modules/grpc_config.py
@@ -144,6 +144,7 @@ from ansible.module_utils.connection import ConnectionError
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     dict_diff,
+    warn_and_exit,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.grpc.grpc import (
     delete_config,
@@ -238,7 +239,7 @@ def main():
 
     result["stdout"] = output
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/grpc_get.py
+++ b/plugins/modules/grpc_get.py
@@ -129,7 +129,10 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import ConnectionError
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list, warn_and_exit
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    to_list,
+    warn_and_exit,
+)
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.grpc.grpc import (
     get,
     get_capabilities,

--- a/plugins/modules/grpc_get.py
+++ b/plugins/modules/grpc_get.py
@@ -129,7 +129,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import ConnectionError
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list, warn_and_exit
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.grpc.grpc import (
     get,
     get_capabilities,
@@ -210,7 +210,7 @@ def main():
     else:
         result["output"] = to_list(response)
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -407,6 +407,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.netconf.netconf import (
     get_capabilities,
     get_config,
@@ -614,7 +615,7 @@ def main():
                     "check mode not supported as Netconf server doesn't support candidate capability"
                 )
                 result["changed"] = True
-                module.exit_json(**result)
+                warn_and_exit(module, result)
 
             if execute_lock:
                 conn.lock(target=target)
@@ -696,7 +697,7 @@ def main():
         if locked:
             conn.unlock(target=target)
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/netconf_config.py
+++ b/plugins/modules/netconf_config.py
@@ -407,7 +407,9 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    warn_and_exit,
+)
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.netconf.netconf import (
     get_capabilities,
     get_config,

--- a/plugins/modules/netconf_get.py
+++ b/plugins/modules/netconf_get.py
@@ -277,6 +277,7 @@ from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.netconf import (
     remove_namespaces,
 )
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.netconf.netconf import (
     get,
     get_capabilities,
@@ -408,7 +409,7 @@ def main():
 
     result = {"stdout": xml_resp, "output": output}
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/netconf_get.py
+++ b/plugins/modules/netconf_get.py
@@ -277,7 +277,9 @@ from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.netconf import (
     remove_namespaces,
 )
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    warn_and_exit,
+)
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.netconf.netconf import (
     get,
     get_capabilities,

--- a/plugins/modules/netconf_rpc.py
+++ b/plugins/modules/netconf_rpc.py
@@ -164,7 +164,9 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.netconf import (
     remove_namespaces,
 )
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    warn_and_exit,
+)
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.netconf.netconf import (
     dispatch,
 )

--- a/plugins/modules/netconf_rpc.py
+++ b/plugins/modules/netconf_rpc.py
@@ -164,6 +164,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.netconf import (
     remove_namespaces,
 )
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.netconf.netconf import (
     dispatch,
 )
@@ -280,7 +281,7 @@ def main():
 
     result = {"stdout": xml_resp, "output": output}
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/restconf_config.py
+++ b/plugins/modules/restconf_config.py
@@ -128,6 +128,7 @@ from ansible.module_utils.connection import ConnectionError
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     dict_diff,
+    warn_and_exit,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.restconf import restconf
 
@@ -213,7 +214,7 @@ def main():
     except ConnectionError as exc:
         module.fail_json(msg=str(exc), code=exc.code)
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/restconf_get.py
+++ b/plugins/modules/restconf_get.py
@@ -87,6 +87,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import ConnectionError
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.restconf import restconf
 from ansible_collections.ansible.netcommon.plugins.module_utils.utils.data import xml_to_dict
 
@@ -116,7 +117,7 @@ def main():
 
     result.update({"response": response})
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/restconf_get.py
+++ b/plugins/modules/restconf_get.py
@@ -87,7 +87,9 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import ConnectionError
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import warn_and_exit
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    warn_and_exit,
+)
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.restconf import restconf
 from ansible_collections.ansible.netcommon.plugins.module_utils.utils.data import xml_to_dict
 

--- a/tests/integration/targets/cli_parse/tasks/nxos_textfsm.yaml
+++ b/tests/integration/targets/cli_parse/tasks/nxos_textfsm.yaml
@@ -9,14 +9,9 @@
   ansible.builtin.set_fact:
     textfsm_template_path: "{{ role_path }}/templates/nxos_show_version.textfsm"
 
-- name: "Parse with textfsm using cli_parse"
-  ansible.utils.cli_parse:
-    text: "{{ version_output.stdout[0] }}"
-    parser:
-      name: ansible.netcommon.ntc_templates
-      command: show version
-      template_path: "{{ textfsm_template_path }}"
-    set_fact: device_neighbors
+- name: "Invoke parse_cli_textfsm"
+  ansible.builtin.set_fact:
+    device_neighbors: "{{ version_output.stdout[0] | parse_cli_textfsm(textfsm_template_path) }}"
   register: nxos_textfsm_text
 
 - name: Check textfsm parse output (would fail on underlying device update)

--- a/tests/integration/targets/cli_parse/tasks/nxos_textfsm.yaml
+++ b/tests/integration/targets/cli_parse/tasks/nxos_textfsm.yaml
@@ -9,9 +9,13 @@
   ansible.builtin.set_fact:
     textfsm_template_path: "{{ role_path }}/templates/nxos_show_version.textfsm"
 
-- name: "Invoke parse_cli_textfsm"
-  ansible.builtin.set_fact:
-    device_neighbors: "{{ version_output.stdout[0] | parse_cli_textfsm(textfsm_template_path) }}"
+- name: "Parse with textfsm using cli_parse"
+  ansible.utils.cli_parse:
+    text: "{{ version_output.stdout[0] }}"
+    parser:
+      name: ansible.netcommon.ntc_templates
+      template_path: "{{ textfsm_template_path }}"
+    set_fact: device_neighbors
   register: nxos_textfsm_text
 
 - name: Check textfsm parse output (would fail on underlying device update)

--- a/tests/integration/targets/cli_parse/tasks/nxos_textfsm.yaml
+++ b/tests/integration/targets/cli_parse/tasks/nxos_textfsm.yaml
@@ -14,6 +14,7 @@
     text: "{{ version_output.stdout[0] }}"
     parser:
       name: ansible.netcommon.ntc_templates
+      command: show version
       template_path: "{{ textfsm_template_path }}"
     set_fact: device_neighbors
   register: nxos_textfsm_text

--- a/tests/integration/targets/cli_parse/tasks/nxos_xml.yaml
+++ b/tests/integration/targets/cli_parse/tasks/nxos_xml.yaml
@@ -8,14 +8,17 @@
   ansible.builtin.set_fact:
     xml: "{{ lookup('file', xml_fixture_path) }}"
 
-- name: Parse xml invocation
-  ansible.builtin.debug:
-    msg: "{{ xml | ansible.netcommon.parse_xml(xml_template_path) }}"
+- name: Parse xml using cli_parse
+  ansible.utils.cli_parse:
+    text: "{{ xml }}"
+    parser:
+      name: ansible.utils.xml_parser
+      template_path: "{{ xml_template_path }}"
   register: nxos_xml_text
 
 - name: Check xml parse output
   ansible.builtin.assert:
     that: "{{ item }}"
   with_items:
-    - "{{ nxos_xml_text['msg']['result'][0]['address'][0] == '10.1.1.1' }}"
-    - "{{ nxos_xml_text['msg']['result'][0]['reachability'][0] == '0' }}"
+    - "{{ nxos_xml_text['parsed']['result'][0]['address'][0] == '10.1.1.1' }}"
+    - "{{ nxos_xml_text['parsed']['result'][0]['reachability'][0] == '0' }}"

--- a/tests/integration/targets/cli_parse/tasks/nxos_xml.yaml
+++ b/tests/integration/targets/cli_parse/tasks/nxos_xml.yaml
@@ -8,12 +8,9 @@
   ansible.builtin.set_fact:
     xml: "{{ lookup('file', xml_fixture_path) }}"
 
-- name: Parse xml using cli_parse
-  ansible.utils.cli_parse:
-    text: "{{ xml }}"
-    parser:
-      name: ansible.utils.xml
-      template_path: "{{ xml_template_path }}"
+- name: Parse xml invocation
+  ansible.builtin.debug:
+    msg: "{{ xml | ansible.netcommon.parse_xml(xml_template_path) }}"
   register: nxos_xml_text
 
 - name: Check xml parse output

--- a/tests/integration/targets/cli_parse/tasks/nxos_xml.yaml
+++ b/tests/integration/targets/cli_parse/tasks/nxos_xml.yaml
@@ -12,7 +12,7 @@
   ansible.utils.cli_parse:
     text: "{{ xml }}"
     parser:
-      name: ansible.utils.xml_parser
+      name: ansible.utils.xml
       template_path: "{{ xml_template_path }}"
   register: nxos_xml_text
 
@@ -20,5 +20,5 @@
   ansible.builtin.assert:
     that: "{{ item }}"
   with_items:
-    - "{{ nxos_xml_text['parsed']['result'][0]['address'][0] == '10.1.1.1' }}"
-    - "{{ nxos_xml_text['parsed']['result'][0]['reachability'][0] == '0' }}"
+    - "{{ nxos_xml_text['msg']['result'][0]['address'][0] == '10.1.1.1' }}"
+    - "{{ nxos_xml_text['msg']['result'][0]['reachability'][0] == '0' }}"

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 import os
 
 from ansible.errors import AnsibleParserError
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.parsing.dataloader import DataLoader
 
 

--- a/tests/unit/mock/procenv.py
+++ b/tests/unit/mock/procenv.py
@@ -16,7 +16,7 @@ from contextlib import contextmanager
 from io import BytesIO, StringIO
 from unittest import TestCase
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 @contextmanager

--- a/tests/unit/mock/vault_helper.py
+++ b/tests/unit/mock/vault_helper.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.parsing.vault import VaultSecret
 
 

--- a/tests/unit/module_utils/network/common/test_utils.py
+++ b/tests/unit/module_utils/network/common/test_utils.py
@@ -459,10 +459,11 @@ def test_to_ipv6_subnet():
     assert "2001:0db8:85a3:4242::" == to_ipv6_subnet("2001:0db8:85a3:4242:0000:8a2e:0370:7334")
     assert "2001:0db8:85a3:4242::" == to_ipv6_subnet("2001:0db8:85a3:4242:0:8a2e:0370:7334")
 
+
 def test_emit_warnings():
     module = MagicMock()
-    result = {"warnings":["This is a warning", "This is second warning"], "changed":False} 
-    utils.emit_warnings(module,result)
+    result = {"warnings": ["This is a warning", "This is second warning"], "changed": False}
+    utils.emit_warnings(module, result)
     # Warning key should be removed from result
     assert "warnings" not in result
     # module.warn should be called twice once per warning
@@ -470,26 +471,29 @@ def test_emit_warnings():
     module.warn.assert_any_call("This is a warning")
     module.warn.assert_any_call("This is second warning")
 
+
 def test_emit_warnings_no_warning_key():
     module = MagicMock()
     result = {"changed": False}
-    utils.emit_warnings(module,result)
+    utils.emit_warnings(module, result)
     # Since no warning key exists in results module.warn should not be called
     module.warn.assert_not_called()
     assert result == {"changed": False}
 
+
 def test_emit_warnings_empty_warning_list():
     module = MagicMock()
-    result = {"changed": False,"warnings":[]}
-    utils.emit_warnings(module,result)
+    result = {"changed": False, "warnings": []}
+    utils.emit_warnings(module, result)
     # Since warning is empty list in results module.warn should not be called
     module.warn.assert_not_called()
     assert result == {"changed": False}
 
+
 def test_warn_and_exit():
     module = MagicMock()
-    result = {"changed":False,"commands":{"K":"v","res":[1,2]},"warnings":["warning1"]}
-    utils.warn_and_exit(module,result)
+    result = {"changed": False, "commands": {"K": "v", "res": [1, 2]}, "warnings": ["warning1"]}
+    utils.warn_and_exit(module, result)
     module.warn.assert_called_once_with("warning1")
     # exit_json was called WITHOUT warnings key
-    module.exit_json.assert_called_once_with(changed = False,commands={"K":"v","res":[1,2]})
+    module.exit_json.assert_called_once_with(changed=False, commands={"K": "v", "res": [1, 2]})

--- a/tests/unit/module_utils/network/common/test_utils.py
+++ b/tests/unit/module_utils/network/common/test_utils.py
@@ -458,3 +458,38 @@ def test_to_ipv6_subnet():
     assert "2001:db8::" == to_ipv6_subnet("2001:db8::")
     assert "2001:0db8:85a3:4242::" == to_ipv6_subnet("2001:0db8:85a3:4242:0000:8a2e:0370:7334")
     assert "2001:0db8:85a3:4242::" == to_ipv6_subnet("2001:0db8:85a3:4242:0:8a2e:0370:7334")
+
+def test_emit_warnings():
+    module = MagicMock()
+    result = {"warnings":["This is a warning", "This is second warning"], "changed":False} 
+    utils.emit_warnings(module,result)
+    # Warning key should be removed from result
+    assert "warnings" not in result
+    # module.warn should be called twice once per warning
+    assert module.warn.call_count == 2
+    module.warn.assert_any_call("This is a warning")
+    module.warn.assert_any_call("This is second warning")
+
+def test_emit_warnings_no_warning_key():
+    module = MagicMock()
+    result = {"changed": False}
+    utils.emit_warnings(module,result)
+    # Since no warning key exists in results module.warn should not be called
+    module.warn.assert_not_called()
+    assert result == {"changed": False}
+
+def test_emit_warnings_empty_warning_list():
+    module = MagicMock()
+    result = {"changed": False,"warnings":[]}
+    utils.emit_warnings(module,result)
+    # Since warning is empty list in results module.warn should not be called
+    module.warn.assert_not_called()
+    assert result == {"changed": False}
+
+def test_warn_and_exit():
+    module = MagicMock()
+    result = {"changed":False,"commands":{"K":"v","res":[1,2]},"warnings":["warning1"]}
+    utils.warn_and_exit(module,result)
+    module.warn.assert_called_once_with("warning1")
+    # exit_json was called WITHOUT warnings key
+    module.exit_json.assert_called_once_with(changed = False,commands={"K":"v","res":[1,2]})

--- a/tests/unit/modules/utils.py
+++ b/tests/unit/modules/utils.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 cur_context = None

--- a/tests/unit/plugins/connection/test_libssh.py
+++ b/tests/unit/plugins/connection/test_libssh.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ansible.errors import AnsibleError, AnsibleFileNotFound
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
 

--- a/tests/unit/plugins/connection/test_network_cli.py
+++ b/tests/unit/plugins/connection/test_network_cli.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import cache_loader, connection_loader
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

- Remediates deprecated ansible.module utils dependencies in ansible.netcommon
- Replaces deprecated modules with suggested python3 equivalent modules
- Adds utility functions to process and handle warnings before passing to exit_json 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- netcommon

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

- Ran unit tests and it is passing
<img width="696" height="308" alt="Screenshot 2026-06-30 at 4 07 08 PM" src="https://github.com/user-attachments/assets/c8704040-e02d-4846-b571-fdb85ee80bac" />

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
