### PR TITLE
cli_config: push config and detect changes when platform lacks diff support

### DIFF
--- a/changelogs/fragments/156-cli-config-no-diff-fallback.yaml
+++ b/changelogs/fragments/156-cli-config-no-diff-fallback.yaml
@@ -1,3 +1,5 @@
 ---
 bugfixes:
   - "cli_config: Push configuration and detect changes by comparing running-config snapshots taken before and after the change, for platforms whose cliconf plugin supports neither onbox diff nor generate diff. Previously the configuration was silently never pushed to the device in this scenario (https://github.com/ansible-collections/ansible.netcommon/issues/156)."
+  - "cli_config: Fail with a clear error instead of silently pushing configuration when the connection plugin's capabilities cannot be determined (for example due to a malformed or empty response), rather than treating that failure the same as a platform explicitly declaring no diff support (https://github.com/ansible-collections/ansible.netcommon/issues/156)."
+  - "cli_config: Apply C(diff_ignore_lines) when comparing the before/after running-config snapshots on platforms that support neither onbox diff nor generate diff, so volatile configuration lines no longer cause C(changed=true) on every run (https://github.com/ansible-collections/ansible.netcommon/issues/156)."

--- a/changelogs/fragments/156-cli-config-no-diff-fallback.yaml
+++ b/changelogs/fragments/156-cli-config-no-diff-fallback.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "cli_config: Push configuration and detect changes by comparing running-config snapshots taken before and after the change, for platforms whose cliconf plugin supports neither onbox diff nor generate diff. Previously the configuration was silently never pushed to the device in this scenario (https://github.com/ansible-collections/ansible.netcommon/issues/156)."

--- a/docs/ansible.netcommon.cli_config_module.rst
+++ b/docs/ansible.netcommon.cli_config_module.rst
@@ -280,6 +280,7 @@ Notes
 .. note::
    - The commands will be returned only for platforms that do not support onbox diff. The ``--diff`` option with the playbook will return the difference in configuration for devices that has support for onbox diff
    - To ensure idempotency and correct diff the configuration lines in the relevant module options should be similar to how they appear if present in the running configuration on device including the indentation.
+   - For platforms whose cliconf plugin supports neither ``supports_onbox_diff`` nor ``supports_generate_diff``, the configuration is pushed to the device unconditionally and the ``changed`` status is determined by comparing a running-config snapshot taken before and after the change. Check mode is not supported in this scenario.
    - This module is supported on ``ansible_network_os`` network platforms. See the :ref:`Network Platform Options <platform_options>` for details.
 
 
@@ -387,9 +388,10 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                       <span style="color: purple">string</span>
                     </div>
                 </td>
-                <td>When <em>supports_onbox_diff=True</em> in the platform&#x27;s cliconf plugin</td>
+                <td>When <em>supports_onbox_diff=True</em> in the platform&#x27;s cliconf plugin, or when neither <em>supports_onbox_diff</em> nor <em>supports_generate_diff</em> is set and the <code>--diff</code> option is used</td>
                 <td>
-                            <div>The diff generated on the device when the commands were applied</div>
+                            <div>The diff generated on the device when the commands were applied.</div>
+                            <div>When neither <em>supports_onbox_diff</em> nor <em>supports_generate_diff</em> is set in the platform&#x27;s cliconf plugin, this is a dictionary with <code>before</code> and <code>after</code> keys containing the running configuration snapshots taken before and after the configuration was pushed.</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
                         <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">--- system:/running-config

--- a/docs/ansible.netcommon.cli_config_module.rst
+++ b/docs/ansible.netcommon.cli_config_module.rst
@@ -181,7 +181,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Use this argument to specify one or more lines that should be ignored during the diff. This is used for lines in the configuration that are automatically updated by the system. This argument takes a list of regular expressions or exact line matches. Note that this parameter will be ignored if the platform has onbox diff support.</div>
+                        <div>Use this argument to specify one or more lines that should be ignored during the diff. This is used for lines in the configuration that are automatically updated by the system. This argument takes a list of regular expressions or exact line matches. Note that this parameter will be ignored if the platform has onbox diff support. For platforms whose cliconf plugin supports generate diff, this is passed to the connection plugin&#x27;s diff generation. For platforms whose cliconf plugin supports neither onbox diff nor generate diff, this is instead applied locally by the module when comparing the before/after running-config snapshots used to detect <code>changed</code>.</div>
                 </td>
             </tr>
             <tr>
@@ -281,6 +281,7 @@ Notes
    - The commands will be returned only for platforms that do not support onbox diff. The ``--diff`` option with the playbook will return the difference in configuration for devices that has support for onbox diff
    - To ensure idempotency and correct diff the configuration lines in the relevant module options should be similar to how they appear if present in the running configuration on device including the indentation.
    - For platforms whose cliconf plugin supports neither ``supports_onbox_diff`` nor ``supports_generate_diff``, the configuration is pushed to the device unconditionally and the ``changed`` status is determined by comparing a running-config snapshot taken before and after the change. Check mode is not supported in this scenario.
+   - If the connection plugin's capabilities response is missing, empty, or not a valid mapping, the module fails with an error instead of assuming the platform supports neither ``supports_onbox_diff`` nor ``supports_generate_diff``. This distinguishes a connection/cliconf plugin problem from a platform that intentionally declares no diff support.
    - This module is supported on ``ansible_network_os`` network platforms. See the :ref:`Network Platform Options <platform_options>` for details.
 
 
@@ -392,6 +393,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                 <td>
                             <div>The diff generated on the device when the commands were applied.</div>
                             <div>When neither <em>supports_onbox_diff</em> nor <em>supports_generate_diff</em> is set in the platform&#x27;s cliconf plugin, this is a dictionary with <code>before</code> and <code>after</code> keys containing the running configuration snapshots taken before and after the configuration was pushed.</div>
+                            <div>When <em>diff_ignore_lines</em> is set, it only affects whether <code>changed</code> (and therefore whether this diff) is reported for that fallback path; the <code>before</code> and <code>after</code> snapshots themselves are not filtered and may still contain lines matched by <em>diff_ignore_lines</em>.</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
                         <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">--- system:/running-config

--- a/plugins/modules/cli_config.py
+++ b/plugins/modules/cli_config.py
@@ -25,6 +25,11 @@ notes:
   C(supports_generate_diff), the configuration is pushed to the device unconditionally
   and the C(changed) status is determined by comparing a running-config snapshot taken
   before and after the change. Check mode is not supported in this scenario.
+- If the connection plugin's capabilities response is missing, empty, or not
+  a valid mapping, the module fails with an error instead of assuming the
+  platform supports neither C(supports_onbox_diff) nor C(supports_generate_diff).
+  This distinguishes a connection/cliconf plugin problem from a platform that
+  intentionally declares no diff support.
 short_description: Push text based configuration to network devices over network_cli
 description:
 - This module provides platform agnostic way of pushing text based configuration to
@@ -129,7 +134,11 @@ options:
       the diff. This is used for lines in the configuration that are automatically
       updated by the system. This argument takes a list of regular expressions or
       exact line matches. Note that this parameter will be ignored if the platform
-      has onbox diff support.
+      has onbox diff support. For platforms whose cliconf plugin supports generate
+      diff, this is passed to the connection plugin's diff generation. For platforms
+      whose cliconf plugin supports neither onbox diff nor generate diff, this is
+      instead applied locally by the module when comparing the before/after
+      running-config snapshots used to detect C(changed).
     type: list
     elements: str
   backup_options:
@@ -208,6 +217,10 @@ diff:
     platform's cliconf plugin, this is a dictionary with C(before) and C(after) keys
     containing the running configuration snapshots taken before and after the
     configuration was pushed.
+  - When I(diff_ignore_lines) is set, it only affects whether C(changed) (and therefore
+    whether this diff) is reported for that fallback path; the C(before) and C(after)
+    snapshots themselves are not filtered and may still contain lines matched by
+    I(diff_ignore_lines).
   returned: When I(supports_onbox_diff=True) in the platform's cliconf plugin, or when
     neither I(supports_onbox_diff) nor I(supports_generate_diff) is set and the C(--diff)
     option is used
@@ -241,6 +254,9 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (
+    NetworkConfig,
+)
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     warn_and_exit,
 )
@@ -259,7 +275,28 @@ def validate_args(module, device_operations):
         "diff_ignore_lines",
     ]
 
+    # diff_ignore_lines is normally delegated to the cliconf plugin's
+    # connection.get_diff() call, which is why the plugin must declare
+    # supports_diff_ignore_lines. However, when the platform supports neither
+    # onbox diff nor generate diff, diff_ignore_lines is instead applied
+    # locally by this module (see the fallback branch in run()) and does not
+    # depend on the connection plugin at all, so it should not be gated on
+    # that declaration in this case. Note that this only holds when run()
+    # will actually reach that fallback branch: a rollback request takes
+    # priority over device_operations entirely (see run()), so diff_ignore_lines
+    # is neither delegated nor applied locally when rollback is requested, and
+    # the platform's declaration should still be enforced in that case.
+    delegates_diff_ignore_lines = device_operations.get(
+        "supports_onbox_diff"
+    ) or device_operations.get("supports_generate_diff")
+    applies_diff_ignore_lines_locally = (
+        module.params["rollback"] is None and not delegates_diff_ignore_lines
+    )
+
     for feature in feature_list:
+        if feature == "diff_ignore_lines" and applies_diff_ignore_lines_locally:
+            continue
+
         if module.params[feature]:
             supports_feature = device_operations.get("supports_%s" % feature)
             if supports_feature is None:
@@ -393,7 +430,19 @@ def run(module, device_operations, connection, candidate, running, rollback_id, 
 
             running_after = connection.get_config(flags=flags or [])
 
-            if running != running_after:
+            # Compare the before/after snapshots with diff_ignore_lines applied
+            # (the same way the supports_generate_diff branch already does),
+            # rather than a raw string comparison. Without this, volatile lines
+            # that change on every fetch regardless of the actual configuration
+            # (timestamps, byte counts, etc.) would cause changed=True on every
+            # run, which is especially likely on the platforms that reach this
+            # branch since they lack well-formed CLI diff support to begin with.
+            running_config_obj = NetworkConfig(contents=running, ignore_lines=diff_ignore_lines)
+            running_after_config_obj = NetworkConfig(
+                contents=running_after, ignore_lines=diff_ignore_lines
+            )
+
+            if running_config_obj.sha1 != running_after_config_obj.sha1:
                 result["changed"] = True
                 if module._diff:
                     result["diff"] = {"before": running, "after": running_after}
@@ -464,11 +513,28 @@ def main():
     connection = Connection(module._socket_path)
     capabilities = module.from_json(connection.get_capabilities())
 
-    if capabilities:
-        device_operations = capabilities.get("device_operations", dict())
-        validate_args(module, device_operations)
-    else:
-        device_operations = dict()
+    # A well-formed capabilities response always includes device_operations
+    # (every cliconf plugin, including this collection's own "default" plugin,
+    # populates it). Anything else - an empty/null/non-dict response, or a dict
+    # that's missing device_operations entirely - indicates a connection or
+    # cliconf plugin problem rather than an intentional declaration that a
+    # platform supports neither onbox diff nor generate diff, so fail loudly
+    # instead of silently falling through to the fallback branch that pushes
+    # configuration unconditionally.
+    if not isinstance(capabilities, dict) or not isinstance(
+        capabilities.get("device_operations"), dict
+    ):
+        module.fail_json(
+            msg="Unable to retrieve device capabilities from the connection plugin."
+            " This usually indicates a connection or cliconf plugin problem rather"
+            " than an intentional declaration that a feature is unsupported, so the"
+            " module is failing rather than silently pushing configuration to the"
+            " device without knowing whether onbox diff or generate diff is"
+            " supported."
+        )
+
+    device_operations = capabilities["device_operations"]
+    validate_args(module, device_operations)
 
     if module.params["defaults"]:
         if "get_default_flag" in capabilities.get("rpc"):

--- a/plugins/modules/cli_config.py
+++ b/plugins/modules/cli_config.py
@@ -21,6 +21,10 @@ notes:
 - To ensure idempotency and correct diff the configuration lines in the relevant module
   options should be similar to how they appear if present in the running configuration on
   device including the indentation.
+- For platforms whose cliconf plugin supports neither C(supports_onbox_diff) nor
+  C(supports_generate_diff), the configuration is pushed to the device unconditionally
+  and the C(changed) status is determined by comparing a running-config snapshot taken
+  before and after the change. Check mode is not supported in this scenario.
 short_description: Push text based configuration to network devices over network_cli
 description:
 - This module provides platform agnostic way of pushing text based configuration to
@@ -198,8 +202,15 @@ EXAMPLES = """
 
 RETURN = """
 diff:
-  description: The diff generated on the device when the commands were applied
-  returned: When I(supports_onbox_diff=True) in the platform's cliconf plugin
+  description:
+  - The diff generated on the device when the commands were applied.
+  - When neither I(supports_onbox_diff) nor I(supports_generate_diff) is set in the
+    platform's cliconf plugin, this is a dictionary with C(before) and C(after) keys
+    containing the running configuration snapshots taken before and after the
+    configuration was pushed.
+  returned: When I(supports_onbox_diff=True) in the platform's cliconf plugin, or when
+    neither I(supports_onbox_diff) nor I(supports_generate_diff) is set and the C(--diff)
+    option is used
   type: str
   sample: |-
     --- system:/running-config
@@ -260,7 +271,7 @@ def validate_args(module, device_operations):
                 module.fail_json(msg="Option %s is not supported on this platform" % feature)
 
 
-def run(module, device_operations, connection, candidate, running, rollback_id):
+def run(module, device_operations, connection, candidate, running, rollback_id, flags=None):
     result = {}
     resp = {}
     config_diff = []
@@ -356,10 +367,47 @@ def run(module, device_operations, connection, candidate, running, rollback_id):
                 connection.edit_banner(**kwargs)
             result["changed"] = True
 
+    else:
+        # Platform supports neither onbox diff nor generate diff. Push the
+        # candidate configuration unconditionally and detect changes by
+        # comparing a running-config snapshot taken before and after the
+        # change, similar to how netconf_config behaves when a device does
+        # not support the candidate datastore.
+        if module.check_mode:
+            module.warn(
+                "Check mode is not supported for this platform, as it does not"
+                " support onbox diff or generate diff. No changes have been made"
+                " to the device."
+            )
+        else:
+            if candidate and not isinstance(candidate, list):
+                candidate = candidate.strip("\n").splitlines()
+
+            kwargs = {
+                "candidate": candidate,
+                "commit": commit,
+                "replace": replace,
+                "comment": commit_comment,
+            }
+            connection.edit_config(**kwargs)
+
+            running_after = connection.get_config(flags=flags or [])
+
+            if running != running_after:
+                result["changed"] = True
+                if module._diff:
+                    result["diff"] = {"before": running, "after": running_after}
+
+            module.warn(
+                "This platform does not support onbox diff or generate diff."
+                " The configuration was pushed unconditionally, so idempotency"
+                " and check mode cannot be guaranteed."
+            )
+
     if module._diff:
         if "diff" in resp:
             result["diff"] = {"prepared": resp["diff"]}
-        else:
+        elif "diff" not in result:
             diff = ""
             if config_diff:
                 if isinstance(config_diff, list):
@@ -448,6 +496,7 @@ def main():
                     candidate,
                     running,
                     rollback_id,
+                    flags,
                 )
             )
         except Exception as exc:

--- a/tests/unit/modules/network/cli/test_cli_config.py
+++ b/tests/unit/modules/network/cli/test_cli_config.py
@@ -155,3 +155,50 @@ class TestCliConfigModule(TestCliModule):
         self.conn.rollback.return_value = {}
         set_module_args(args)
         self.execute_module(changed=False)
+
+    def test_cli_config_no_diff_support_changed(self):
+        self.conn.get_capabilities.return_value = "{}"
+        self.conn.get_config.side_effect = ["running before", "running after"]
+
+        set_module_args({"config": "hostname foo"})
+        self.execute_module(changed=True)
+        self.conn.edit_config.assert_called_once_with(
+            candidate=["hostname foo"],
+            commit=True,
+            replace=None,
+            comment=None,
+        )
+
+    def test_cli_config_no_diff_support_unchanged(self):
+        self.conn.get_capabilities.return_value = "{}"
+        self.conn.get_config.side_effect = ["same config", "same config"]
+
+        set_module_args({"config": "hostname foo"})
+        self.execute_module(changed=False)
+        self.conn.edit_config.assert_called_once_with(
+            candidate=["hostname foo"],
+            commit=True,
+            replace=None,
+            comment=None,
+        )
+
+    def test_cli_config_no_diff_support_check_mode(self):
+        self.conn.get_capabilities.return_value = "{}"
+        self.conn.get_config.return_value = "running config"
+
+        args = {"config": "hostname foo", "_ansible_check_mode": True}
+        set_module_args(args)
+        self.execute_module(changed=False)
+        self.conn.edit_config.assert_not_called()
+
+    def test_cli_config_no_diff_support_returns_diff(self):
+        self.conn.get_capabilities.return_value = "{}"
+        self.conn.get_config.side_effect = ["running before", "running after"]
+
+        args = {"config": "hostname foo", "_ansible_diff": True}
+        set_module_args(args)
+        result = self.execute_module(changed=True)
+        self.assertEqual(
+            result["diff"],
+            {"before": "running before", "after": "running after"},
+        )

--- a/tests/unit/modules/network/cli/test_cli_config.py
+++ b/tests/unit/modules/network/cli/test_cli_config.py
@@ -10,10 +10,21 @@ __metaclass__ = type
 
 from unittest.mock import MagicMock, patch
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
+    config as network_common_config,
+)
 from ansible_collections.ansible.netcommon.plugins.modules import cli_config
 from ansible_collections.ansible.netcommon.tests.unit.modules.utils import set_module_args
 
 from .cli_module import TestCliModule
+
+
+# NetworkConfig(ignore_lines=[...]) permanently adds the supplied patterns to
+# the module-level DEFAULT_IGNORE_LINES_RE set (see module_utils/network/common
+# /config.py). Snapshot/restore it around each test the same way
+# tests/unit/module_utils/network/common/test_config.py does, so a custom
+# diff_ignore_lines pattern used in one test can't leak into another.
+ORIGINAL_DEFAULT_IGNORE_LINES_RE = network_common_config.DEFAULT_IGNORE_LINES_RE.copy()
 
 
 class TestCliConfigModule(TestCliModule):
@@ -28,12 +39,20 @@ class TestCliConfigModule(TestCliModule):
         self.get_connection = self.mock_connection.start()
 
         self.conn = self.get_connection()
-        self.conn.get_capabilities.return_value = "{}"
+        # A well-formed capabilities payload where the platform explicitly
+        # declares support for neither onbox diff nor generate diff (mirroring
+        # what ansible.netcommon's own "default" cliconf plugin returns). Tests
+        # that need other capabilities override this in-test.
+        self.conn.get_capabilities.return_value = (
+            '{"rpc": [], "device_operations":'
+            ' {"supports_onbox_diff": false, "supports_generate_diff": false}}'
+        )
 
     def tearDown(self):
         super(TestCliConfigModule, self).tearDown()
 
         self.mock_connection.stop()
+        network_common_config.DEFAULT_IGNORE_LINES_RE = ORIGINAL_DEFAULT_IGNORE_LINES_RE.copy()
 
     @patch("ansible_collections.ansible.netcommon.plugins.modules.cli_config.run")
     def test_cli_config_backup_returns__backup__(self, run_mock):
@@ -146,6 +165,11 @@ class TestCliConfigModule(TestCliModule):
         )
 
     def test_cli_config_rollback(self):
+        self.conn.get_capabilities.return_value = """{
+            "device_operations": {
+                "supports_rollback": true
+            }
+        }"""
         self.conn.rollback.return_value = {"diff": "set interface eth0 ip address dhcp"}
 
         args = {"rollback": 123456}
@@ -157,7 +181,6 @@ class TestCliConfigModule(TestCliModule):
         self.execute_module(changed=False)
 
     def test_cli_config_no_diff_support_changed(self):
-        self.conn.get_capabilities.return_value = "{}"
         self.conn.get_config.side_effect = ["running before", "running after"]
 
         set_module_args({"config": "hostname foo"})
@@ -170,7 +193,6 @@ class TestCliConfigModule(TestCliModule):
         )
 
     def test_cli_config_no_diff_support_unchanged(self):
-        self.conn.get_capabilities.return_value = "{}"
         self.conn.get_config.side_effect = ["same config", "same config"]
 
         set_module_args({"config": "hostname foo"})
@@ -183,7 +205,6 @@ class TestCliConfigModule(TestCliModule):
         )
 
     def test_cli_config_no_diff_support_check_mode(self):
-        self.conn.get_capabilities.return_value = "{}"
         self.conn.get_config.return_value = "running config"
 
         args = {"config": "hostname foo", "_ansible_check_mode": True}
@@ -192,7 +213,6 @@ class TestCliConfigModule(TestCliModule):
         self.conn.edit_config.assert_not_called()
 
     def test_cli_config_no_diff_support_returns_diff(self):
-        self.conn.get_capabilities.return_value = "{}"
         self.conn.get_config.side_effect = ["running before", "running after"]
 
         args = {"config": "hostname foo", "_ansible_diff": True}
@@ -201,4 +221,136 @@ class TestCliConfigModule(TestCliModule):
         self.assertEqual(
             result["diff"],
             {"before": "running before", "after": "running after"},
+        )
+
+    # --- Hardening: capabilities that couldn't be retrieved/parsed must not
+    # be treated the same as a platform explicitly declaring no diff support.
+
+    def test_cli_config_capabilities_empty_fails(self):
+        self.conn.get_capabilities.return_value = "{}"
+
+        set_module_args({"config": "hostname foo"})
+        result = self.execute_module(failed=True)
+        self.assertIn("Unable to retrieve device capabilities", result["msg"])
+        self.conn.edit_config.assert_not_called()
+
+    def test_cli_config_capabilities_null_fails(self):
+        self.conn.get_capabilities.return_value = "null"
+
+        set_module_args({"config": "hostname foo"})
+        result = self.execute_module(failed=True)
+        self.assertIn("Unable to retrieve device capabilities", result["msg"])
+        self.conn.edit_config.assert_not_called()
+
+    def test_cli_config_capabilities_not_a_dict_fails(self):
+        self.conn.get_capabilities.return_value = "[]"
+
+        set_module_args({"config": "hostname foo"})
+        result = self.execute_module(failed=True)
+        self.assertIn("Unable to retrieve device capabilities", result["msg"])
+        self.conn.edit_config.assert_not_called()
+
+    def test_cli_config_capabilities_missing_device_operations_fails(self):
+        # A non-empty, well-formed dict that is nonetheless missing
+        # device_operations entirely is just as malformed as an empty "{}"
+        # response and must not be treated as a "no diff support" declaration.
+        self.conn.get_capabilities.return_value = '{"rpc": [], "network_api": "cliconf"}'
+
+        set_module_args({"config": "hostname foo"})
+        result = self.execute_module(failed=True)
+        self.assertIn("Unable to retrieve device capabilities", result["msg"])
+        self.conn.edit_config.assert_not_called()
+
+    # --- Regression: diff_ignore_lines validation must still be enforced
+    # for code paths that don't actually reach the local-filtering fallback
+    # branch, even when the platform supports neither onbox nor generate diff.
+
+    def test_cli_config_rollback_with_unsupported_diff_ignore_lines_fails(self):
+        # rollback takes priority over device_operations in run(), so
+        # diff_ignore_lines is neither delegated nor applied locally here;
+        # the platform's (non-)declaration must still be enforced.
+        self.conn.get_capabilities.return_value = """{
+            "device_operations": {
+                "supports_rollback": true
+            }
+        }"""
+
+        args = {"rollback": 123456, "diff_ignore_lines": ["foo"]}
+        set_module_args(args)
+        result = self.execute_module(failed=True)
+        self.assertEqual(
+            result["msg"],
+            "This platform does not specify whether diff_ignore_lines is supported or not. "
+            "Please report an issue against this platform's cliconf plugin.",
+        )
+        self.conn.rollback.assert_not_called()
+
+    def test_cli_config_onbox_diff_with_unsupported_diff_ignore_lines_fails(self):
+        self.conn.get_capabilities.return_value = """{
+            "device_operations": {
+                "supports_onbox_diff": true
+            }
+        }"""
+
+        args = {
+            "config": "hostname foo",
+            "diff_ignore_lines": ["foo"],
+        }
+        set_module_args(args)
+        result = self.execute_module(failed=True)
+        self.assertEqual(
+            result["msg"],
+            "This platform does not specify whether diff_ignore_lines is supported or not. "
+            "Please report an issue against this platform's cliconf plugin.",
+        )
+        self.conn.edit_config.assert_not_called()
+
+    # --- Hardening: the before/after snapshot comparison must apply
+    # diff_ignore_lines (and the built-in default ignore patterns), the same
+    # way the supports_generate_diff branch already does, instead of a raw
+    # string comparison that would flag volatile lines as a real change.
+
+    def test_cli_config_no_diff_support_ignores_default_volatile_lines(self):
+        # "Current configuration : N bytes" is one of the built-in ignore
+        # patterns applied by NetworkConfig even without diff_ignore_lines set.
+        self.conn.get_config.side_effect = [
+            "hostname foo\nCurrent configuration : 100 bytes",
+            "hostname foo\nCurrent configuration : 104 bytes",
+        ]
+
+        set_module_args({"config": "hostname foo"})
+        self.execute_module(changed=False)
+
+    def test_cli_config_no_diff_support_diff_ignore_lines_filters_custom_pattern(self):
+        self.conn.get_config.side_effect = [
+            "hostname foo\nLast configuration change at 10:00:00",
+            "hostname foo\nLast configuration change at 10:00:05",
+        ]
+
+        args = {
+            "config": "hostname foo",
+            "diff_ignore_lines": ["Last configuration change"],
+        }
+        set_module_args(args)
+        self.execute_module(changed=False)
+
+    def test_cli_config_no_diff_support_detects_real_change_with_diff_ignore_lines(self):
+        self.conn.get_config.side_effect = [
+            "hostname foo\nLast configuration change at 10:00:00",
+            "hostname bar\nLast configuration change at 10:00:05",
+        ]
+
+        args = {
+            "config": "hostname bar",
+            "diff_ignore_lines": ["Last configuration change"],
+            "_ansible_diff": True,
+        }
+        set_module_args(args)
+        result = self.execute_module(changed=True)
+        self.assertEqual(
+            result["diff"],
+            {
+                "before": "hostname foo\nLast configuration change at 10:00:00",
+                "after": "hostname bar\nLast configuration change at 10:00:05",
+            },
         )


### PR DESCRIPTION
Fixes #156 

> **Note:** This contribution was developed with AI assistance (Cursor IDE). 
 - Note added as per -> https://docs.ansible.com/projects/ansible/latest/community/ai_policy.html

##### SUMMARY
<details>
  <summary>Platforms whose cliconf plugin . . .  (click to expand) </summary>
 
- Platforms whose cliconf plugin declares neither supports_onbox_diff nor supports_generate_diff fell through the run() branch chain with no else clause, so edit_config() was never called and the configuration was silently never applied to the device.

- Add a fallback branch that pushes the candidate configuration unconditionally and determines changed/diff by comparing a running-config snapshot taken before and after the change, mirroring how netconf_config behaves for devices without candidate datastore support. Check mode is not supported in this path and a warning is emitted to make that limitation clear to playbook authors.
</details>


Fixes https://github.com/ansible-collections/ansible.netcommon/issues/156

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- cli_config

##### ADDITIONAL INFORMATION

**Reproduction (before this change):**

Calling `run()` for a device whose cliconf plugin reports neither `supports_onbox_diff` nor `supports_generate_diff` silently does nothing — `edit_config()` is never invoked and the module reports `changed: False` even though the user asked to push configuration:

```paste below
>>> device_operations = {}  # neither capability declared
>>> result = run(module, device_operations, connection, candidate, running, rollback_id=None)
>>> result
{}
>>> connection.edit_config.called
False