### PR TITLE
ci: split secret-free jobs to pull_request, Sonar label-gated on pull_request_target

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,29 @@
+---
+name: "SonarCloud 🔍"
+
+concurrency:
+  group: sonar-${{ github.head_ref || github.run_id }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: [main]
+  pull_request_target:
+    branches: [main]
+    types:
+      - labeled
+      - opened
+      - synchronize
+  workflow_dispatch:
+
+jobs:
+  sonar:
+    name: SonarCloud
+    uses: ansible/ansible-content-actions/.github/workflows/sonarcloud.yaml@main
+    with:
+      python_version: "3.12"
+      galaxy_dependencies: |
+        git+https://github.com/ansible-collections/ansible.utils.git
+      test_command: "pip install passlib && pytest tests/unit -v --cov-report xml --cov=./"
+    secrets:
+      SONAR_TOKEN: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,26 +8,16 @@ concurrency:
 on:  # yamllint disable-line rule:truthy
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
 
 jobs:
-  sonar:
-    name: SonarCloud
-    uses: ansible/ansible-content-actions/.github/workflows/sonarcloud.yaml@main
-    with:
-      python_version: "3.12"
-      galaxy_dependencies: |
-        git+https://github.com/ansible-collections/ansible.utils.git
-      test_command: "pip install passlib && pytest tests/unit -v --cov-report xml --cov=./"
-    secrets:
-      SONAR_TOKEN: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}
   changelog:
     uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@main
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
   build-import:
     uses: ansible/ansible-content-actions/.github/workflows/build_import.yaml@main
   ansible-lint:
@@ -69,7 +59,6 @@ jobs:
       - unit-galaxy
       - unit-source
       - ansible-lint
-      - sonar
       - report-status
     runs-on: ubuntu-latest
     steps:
@@ -81,6 +70,5 @@ jobs:
           '${{ needs.unit-galaxy.result }}',
           '${{ needs.ansible-lint.result }}',
           '${{ needs.unit-source.result }}',
-          '${{ needs.sonar.result }}',
           '${{ needs.report-status.result }}'
           ])"

--- a/changelogs/fragments/ci_pull_request_trigger.yaml
+++ b/changelogs/fragments/ci_pull_request_trigger.yaml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - ci - Run secret-free test jobs on pull_request and move SonarCloud to a
+    label-gated pull_request_target workflow.


### PR DESCRIPTION
## Summary

- `tests.yml`: switch secret-free jobs (lint, changelog, sanity, unit, build-import) to `pull_request`
- `sonarcloud.yml`: new workflow on `pull_request_target` with `safe to test` label gating (via reusable workflow)
- Matches ansible-collections/cisco.ios#1357

## Test plan

- [ ] `pull_request` jobs run on this PR without duplicate checkout issues on fork PRs
- [ ] Sonar runs on push to main after merge
- [ ] Sonar on PRs requires `safe to test` label