### PR TITLE
Disable automatic release workflow on GitHub release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 ---
 name: "Release collection 🚀"
 on:  # yamllint disable-line rule:truthy
-  release:
-    types: [published]
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
Replace the `release: published` trigger with `workflow_dispatch` so the release workflow no longer fires automatically when a GitHub release is published. It can still be triggered manually from the Actions tab.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
