### PR TITLE
Fix libssh connection plugin to respect persistent_connect_timeout

### DIFF
--- a/changelogs/fragments/798-libssh-connect-timeout.yaml
+++ b/changelogs/fragments/798-libssh-connect-timeout.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "libssh - Use ``persistent_connect_timeout`` option for the SSH connect timeout instead of the generic play context timeout,
+    ensuring that ``ansible_connect_timeout`` / ``ANSIBLE_PERSISTENT_CONNECT_TIMEOUT`` is respected
+    (https://github.com/ansible-collections/ansible.netcommon/issues/798)."

--- a/docs/ansible.netcommon.libssh_connection.rst
+++ b/docs/ansible.netcommon.libssh_connection.rst
@@ -134,6 +134,29 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>import_modules</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"yes"</div>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[ansible_network]<br>import_modules = yes</p>
+                            </div>
+                                <div>env:ANSIBLE_NETWORK_IMPORT_MODULES</div>
+                                <div>var: ansible_network_import_modules</div>
+                    </td>
+                <td>
+                        <div>Reduce CPU usage and network module execution time by enabling direct execution. Instead of the module being packaged and executed by the shell, it will be directly executed by the Ansible control node using the same python interpreter as the Ansible process. Note- Incompatible with <code>asynchronous mode</code>. Note- Python 3 and Ansible 2.9.16 or greater required. Note- With Ansible 2.9.x fully qualified modules names are required in tasks.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>key_exchange_algorithms</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -217,6 +240,76 @@ Parameters
                 <td>
                         <div>Text to match when using keyboard-interactive authentication to determine if the prompt is for the password.</div>
                         <div>Requires ansible-pylibssh version &gt;= 1.0.0</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>persistent_command_timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">30</div>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[persistent_connection]<br>command_timeout = 30</p>
+                            </div>
+                                <div>env:ANSIBLE_PERSISTENT_COMMAND_TIMEOUT</div>
+                                <div>var: ansible_command_timeout</div>
+                    </td>
+                <td>
+                        <div>Configures, in seconds, the amount of time to wait for a command to return from the remote device.  If this timer is exceeded before the command returns, the connection plugin will raise an exception and close.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>persistent_connect_timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">30</div>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[persistent_connection]<br>connect_timeout = 30</p>
+                            </div>
+                                <div>env:ANSIBLE_PERSISTENT_CONNECT_TIMEOUT</div>
+                                <div>var: ansible_connect_timeout</div>
+                    </td>
+                <td>
+                        <div>Configures, in seconds, the amount of time to wait when trying to initially establish a persistent connection.  If this value expires before the connection to the remote device is completed, the connection will fail.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>persistent_log_messages</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"no"</div>
+                </td>
+                    <td>
+                            <div> ini entries:
+                                    <p>[persistent_connection]<br>log_messages = no</p>
+                            </div>
+                                <div>env:ANSIBLE_PERSISTENT_LOG_MESSAGES</div>
+                                <div>var: ansible_persistent_log_messages</div>
+                    </td>
+                <td>
+                        <div>This flag will enable logging the command executed and response received from target device in the ansible log file. For this option to work &#x27;log_path&#x27; ansible configuration option is required to be set to a file path with write access.</div>
+                        <div>Be sure to fully understand the security implications of enabling this option as it could create a security vulnerability by logging sensitive information in log file.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/connection/libssh.py
+++ b/plugins/connection/libssh.py
@@ -17,6 +17,8 @@ DOCUMENTATION = """
         - The python bindings use libssh C library (https://www.libssh.org/) to connect to targets
         - This plugin borrows a lot of settings from the ssh plugin as they both cover the same protocol.
     version_added: 1.1.0
+    extends_documentation_fragment:
+    - ansible.netcommon.connection_persistent
     options:
       remote_addr:
         description:
@@ -230,8 +232,6 @@ DOCUMENTATION = """
             key: config_file
         vars:
           - name: ansible_libssh_config_file
-# TODO:
-#timeout=self._play_context.timeout,
 """
 import logging
 import os
@@ -542,7 +542,7 @@ class Connection(ConnectionBase):
                 password_prompt=self.get_option("password_prompt"),
                 private_key=private_key,
                 private_key_password=self.get_option("private_key_passphrase"),
-                timeout=self._play_context.timeout,
+                timeout=self.get_option("persistent_connect_timeout"),
                 port=port,
                 **ssh_connect_kwargs,
             )

--- a/tests/unit/plugins/connection/test_libssh.py
+++ b/tests/unit/plugins/connection/test_libssh.py
@@ -28,6 +28,9 @@ pylibsshext = pytest.importorskip("pylibsshext")
 
 @pytest.fixture(name="conn")
 def plugin_fixture():
+    libssh.SSH_CONNECTION_CACHE.clear()
+    libssh.SFTP_CONNECTION_CACHE.clear()
+
     pc = PlayContext()
     pc.port = 8080
     pc.timeout = 60

--- a/tests/unit/plugins/connection/test_libssh.py
+++ b/tests/unit/plugins/connection/test_libssh.py
@@ -63,7 +63,7 @@ def test_libssh_connect(conn, monkeypatch):
         password_prompt=None,
         private_key_password=None,
         port=8080,
-        timeout=60,
+        timeout=30,
         user="user1",
         private_key=None,
     )
@@ -409,3 +409,56 @@ def test_libssh_invalidate_ssh_close_exception_swallowed(conn):
     )
     conn._invalidate_ssh_session_after_scp_get_failure()
     assert conn.ssh is None
+
+
+def test_libssh_connect_uses_persistent_connect_timeout(conn, monkeypatch):
+    """Verify that _connect passes persistent_connect_timeout to Session.connect()."""
+    conn.set_options(
+        direct={
+            "remote_addr": "localhost",
+            "remote_user": "user1",
+            "password": "test",
+            "host_key_checking": False,
+            "persistent_connect_timeout": 15,
+        }
+    )
+
+    mock_session = MagicMock()
+    monkeypatch.setattr(libssh, "Session", mock_session)
+    mock_ssh = MagicMock()
+    mock_session.return_value = mock_ssh
+    conn._connect()
+    mock_ssh.connect.assert_called_with(
+        host="localhost",
+        host_key_checking=False,
+        look_for_keys=True,
+        password="test",
+        password_prompt=None,
+        private_key_password=None,
+        port=8080,
+        timeout=15,
+        user="user1",
+        private_key=None,
+    )
+
+
+def test_libssh_connect_ignores_play_context_timeout(conn, monkeypatch):
+    """Verify that play_context.timeout does NOT leak into Session.connect()."""
+    conn._play_context.timeout = 999
+    conn.set_options(
+        direct={
+            "remote_addr": "localhost",
+            "remote_user": "user1",
+            "password": "test",
+            "host_key_checking": False,
+            "persistent_connect_timeout": 10,
+        }
+    )
+
+    mock_session = MagicMock()
+    monkeypatch.setattr(libssh, "Session", mock_session)
+    mock_ssh = MagicMock()
+    mock_session.return_value = mock_ssh
+    conn._connect()
+    call_kwargs = mock_ssh.connect.call_args
+    assert call_kwargs[1]["timeout"] == 10


### PR DESCRIPTION
The libssh plugin was using play_context.timeout instead of the persistent_connect_timeout option for SSH connect, causing ansible_connect_timeout / ANSIBLE_PERSISTENT_CONNECT_TIMEOUT to be ignored. This led to connections hanging for the full command_timeout duration when targeting unreachable hosts.

Fixes #798

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
