### PR TITLE
Bind 'safe to test' approval to a commit in integration-cml workflow

### DIFF
--- a/.github/workflows/integration-cml.yml
+++ b/.github/workflows/integration-cml.yml
@@ -40,8 +40,68 @@ name: "Integration tests 💻"
           - "libssh"
           - "paramiko"
         default: "libssh"
+permissions:
+  contents: read
+# One run per PR. A new push supersedes the previous run rather than letting two
+# runs contend for the same lab. cancel-in-progress is safe because lab-destroy
+# uses always(), so a cancelled run still tears its own lab down.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
+  # Runs first and gates everything below it. Approval is granted to one
+  # commit: only a "labeled" event approves, and the netcommon checkout below
+  # pins github.event.pull_request.head.sha from that same payload, so the code
+  # under test is exactly the code that was present when the label was applied.
+  # Every other event -- synchronize, opened, reopened -- is unapproved, even
+  # when the PR still carries the label, so a push can never re-run against an
+  # approval nobody granted for it. This job checks out nothing and runs no PR
+  # code; it needs no write scopes.
+  gate:
+    name: "Check approval"
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    outputs:
+      approved: ${{ steps.check.outputs.approved }}
+    steps:
+      - name: Revoke "safe to test" on new commits
+        # Runs before any other job, so the label is gone by the time anything
+        # touching the CML secrets could start. Re-approving the new head SHA
+        # means a maintainer applies the label again.
+        if: ${{ github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'safe to test') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          gh api --method DELETE --silent \
+            "repos/${REPO}/issues/${PR_NUMBER}/labels/safe%20to%20test"
+          echo "Revoked 'safe to test' on #${PR_NUMBER}: head is now ${HEAD_SHA}"
+
+      - name: Determine approval
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            approved=true
+          elif [ "$ACTION" = "labeled" ] && [ "$LABEL_NAME" = "safe to test" ]; then
+            approved=true
+          else
+            approved=false
+          fi
+          echo "approved=$approved" >> "$GITHUB_OUTPUT"
+          echo "event=${EVENT_NAME} action=${ACTION:-n/a} label=${LABEL_NAME:-n/a} -> approved=${approved}"
+
   lab-create:
+    needs: gate
+    if: ${{ needs.gate.outputs.approved == 'true' }}
     uses: ansible/ansible-content-actions/.github/workflows/cml_lab_create.yaml@main
     with:
       topology_path: tests/integration/labs/multi.yaml
@@ -52,10 +112,13 @@ jobs:
       virl_password: ${{ secrets.VIRL_PASSWORD }}
 
   integration-tests:
-    needs: lab-create
+    needs: [gate, lab-create]
     name: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ssh_type || 'libssh' }} & ansible-core ${{ matrix.ansible_version }}"
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'safe to test') }}
+    # Read the gate, not github.event.pull_request.labels: the payload is a
+    # snapshot taken when the event fired, so on a synchronize it still shows a
+    # label the gate has since revoked.
+    if: ${{ needs.gate.outputs.approved == 'true' }}
     env:
       PY_COLORS: "1"
       ANSIBLE_COLLECTIONS_PATHS: "/home/runner/.ansible/collections"
@@ -258,8 +321,11 @@ jobs:
           LAB_NODES: ${{ needs.lab-create.outputs.lab_nodes_json }}
 
   lab-destroy:
-    if: ${{ always() }}
-    needs: integration-tests
+    # always() ignores skipped upstreams, so this has to check lab-create
+    # explicitly -- otherwise every unapproved run (where the whole chain skips)
+    # would still call lab destroy with no lab of its own to tear down.
+    if: ${{ always() && needs.lab-create.result == 'success' }}
+    needs: [lab-create, integration-tests]
     uses: ansible/ansible-content-actions/.github/workflows/cml_lab_destroy.yaml@main
     secrets:
       virl_host: ${{ secrets.VIRL_HOST }}


### PR DESCRIPTION
## Summary

`integration-cml.yml` runs on `pull_request_target` and executes PR-authored code against a CML lab, so the runner holds `VIRL_HOST` / `VIRL_USERNAME` / `VIRL_PASSWORD` while running code from the pull request. Approval was granted by the `safe to test` label, but **the label was not bound to a commit**: once applied it persisted across pushes, and `synchronize` re-ran the whole suite against whatever the contributor pushed next.

A contributor could open a benign PR, wait for a maintainer to label it, then push a commit that runs arbitrary code with the lab credentials in scope — no second review required.

## What changed

**A `gate` job now runs before every other job.**

- Only a `labeled` event (or `workflow_dispatch`) sets `approved=true`. `synchronize`, `opened` and `reopened` are unapproved *even when the label is still on the PR*.
- The netcommon checkout already pins `github.event.pull_request.head.sha` from the same payload, so the code under test is exactly the code present when the label was applied.
- The gate's first step revokes `safe to test` on any non-`labeled` event, so re-approving a new head SHA means a maintainer applies the label again. It runs ahead of everything else, so the label is gone before anything that can reach the secrets starts.

**`integration-tests` now reads `needs.gate.outputs.approved`** instead of `contains(github.event.pull_request.labels.*.name, 'safe to test')`. The event payload is a snapshot taken when the event fired, so on a `synchronize` it still lists a label the gate has since revoked — checking it there fails open.

**`lab-create` is gated.** It previously had no condition at all and spun up a CML lab on every matching PR event, labelled or not.

## Related fixes

- **`lab-destroy` fired on runs that never created a lab.** It used `always()` with `needs: integration-tests`, and `always()` ignores *skipped* upstreams — so an unapproved run, where the whole chain skips, still invoked lab destroy. With per-PR lab titles that tear-down could hit a lab an approved run was still using. It now requires `needs.lab-create.result == 'success'`.
- **Added a per-PR `concurrency` group** so a new push supersedes the previous run rather than two runs contending for one lab. `cancel-in-progress` is safe because `lab-destroy` keeps `always()`, so a cancelled run still tears its own lab down.
- **Set top-level `permissions: contents: read`** so `GITHUB_TOKEN` cannot obtain repository write scopes while PR code is executing. The `gate` job overrides this with `pull-requests: write`, which is safe because it checks out nothing and runs no PR code.

## Behaviour change for maintainers

Labelling is now a per-commit approval rather than a one-time switch. After any push the label is stripped and must be re-applied to run the suite against the new head. That extra click is the security property.

## Notes for reviewers

- **`paths:` bounds the revoke.** A push touching only e.g. `requirements.txt` or `galaxy.yml` doesn't trigger the workflow, so the label survives that push. Not exploitable — nothing but a `labeled` event approves — but GitHub won't re-fire `labeled` for a label already present, so re-approval there needs a manual remove-then-add. Happy to drop the `paths:` filter if you'd rather every push reach the gate; unapproved runs skip in about ten seconds.
- **`pull-requests: write` on the gate.** If the org restricts what scopes workflows may request, the revoke step returns 403 and fails the run — which blocks it rather than letting it through, so it fails closed. Worth confirming against org settings.
- No changelog fragment: this touches `.github/` only, no shipped plugin or module code.

## Testing

`.github/workflows/integration-cml.yml` parses and the resulting job graph is:

| job | needs | if |
|---|---|---|
| `gate` | — | — |
| `lab-create` | `gate` | `approved == 'true'` |
| `integration-tests` | `gate`, `lab-create` | `approved == 'true'` |
| `lab-destroy` | `lab-create`, `integration-tests` | `always() && lab-create succeeded` |

This PR touches neither `plugins/**` nor `tests/integration/**`, so it does not trigger the workflow it modifies. Verifying the gate end-to-end needs a follow-up PR that touches those paths, or a `workflow_dispatch` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)